### PR TITLE
feat(vibe20): Fuel Weather dashboard (data-model driven)

### DIFF
--- a/vibe_code_apps_20/AGENTS.md
+++ b/vibe_code_apps_20/AGENTS.md
@@ -15,7 +15,11 @@ Optimize for engineering defensibility, reproducibility, and honest limits (unca
 ## Tomorrow demo — vibe19 dump → EnergyPlus twin (generalized)
 
 Works for **any** building zip processed through vibe19 Export → **Build WattLab dump (zip)**.
-Do **not** hardcode BUILDING_100 (or any site) IDs, paths, or characteristics.
+Do **not** hardcode BUILDING_100, Liberty, Detroit, or any site IDs, paths,
+lat/lon, or bill filenames. Sites are **data-model driven**: vibe19 Haystack
+`column_map` / dump contracts, and vibe20 `campus.json` (+ optional
+`bill_columns`). `examples/liberty/` is practice data for both apps — production
+buildings ship their own JSON + CSVs.
 
 ### Human prep (vibe19)
 
@@ -78,8 +82,9 @@ python -m pytest tests/test_studio_app.py -q
 python scripts/browser_smoke_vibe20.py --url http://localhost:8520 --screenshots .artifacts/browser/native
 ```
 
-AppTest must cover all pages (including **Data Explorer** + **Assumption Ledger**)
-with 0 exceptions. Playwright is a local gate — not part of `vibe20-ghcr.yml`.
+AppTest must cover all pages (including **Data Explorer**, **Assumption Ledger**,
+**Fuel Weather**) with 0 exceptions. Playwright is a local gate — not part of
+`vibe20-ghcr.yml`.
 
 ### Conceptual disclaimer (required on anonymized / uncalibrated exports)
 

--- a/vibe_code_apps_20/README.md
+++ b/vibe_code_apps_20/README.md
@@ -35,15 +35,16 @@ wattlab studio
 2. **Data Explorer** — browse dump analytic tables + shared `telemetry/` CSVs (measured evidence)
 3. **Assumption Ledger** — read-only provenance (`MEASURED` / `INFERRED` / `DEFAULTED` / `HUMAN` / `MISSING`)
 4. **Model** — profile editor, provenance, calibration badge
-5. **Benchmark** — bills vs peer bands, shared-meter scenarios, monthly signatures
-6. **Existing Building Hypothesis Lab** — sparse-input scenario ladder + artifact downloads
-7. **ECM Easy Buttons** — catalog cards/packages (proxy + conceptual EnergyPlus)
-8. **Measures** — catalog + FDD-suggested measures, proxy savings, editable costs
-9. **Twin loop** — dry-run plan or Docker EnergyPlus runs, crosscheck verdicts
-10. **EP Results** — post-sim charts / scorecards
-11. **Capital plan** — payback / ROI / NPV gated by benchmark guardrails (`PUBLISH` / `INVESTIGATE`)
+5. **Benchmark** — bills vs peer bands, shared-meter scenarios, monthly signatures (`campus.json` — any site)
+6. **Fuel Weather** — campus bills × Open-Meteo/synthetic HDD/CDD, intensity/demand heatmaps, gas×HDD & elec×CDD R²
+7. **Existing Building Hypothesis Lab** — sparse-input scenario ladder + artifact downloads
+8. **ECM Easy Buttons** — catalog cards/packages (proxy + conceptual EnergyPlus)
+9. **Measures** — catalog + FDD-suggested measures, proxy savings, editable costs
+10. **Twin loop** — dry-run plan or Docker EnergyPlus runs, crosscheck verdicts
+11. **EP Results** — post-sim charts / scorecards
+12. **Capital plan** — payback / ROI / NPV gated by benchmark guardrails (`PUBLISH` / `INVESTIGATE`)
 
-Most pages work dry-run without EnergyPlus. Start on **Ingest** with a dump zip.
+Most pages work dry-run without EnergyPlus. Start on **Ingest** with a dump zip, or **Benchmark / Fuel Weather** with any `campus.json` + bill CSVs (`examples/liberty/` is a practice example only; CI uses the shared-meter fixture).
 
 ## Pre-ship smoke (local)
 

--- a/vibe_code_apps_20/README.md
+++ b/vibe_code_apps_20/README.md
@@ -1,392 +1,65 @@
-﻿# OpenFDD WattLab
+﻿# OpenFDD WattLab Studio
 
-**OpenFDD WattLab** is the EnergyPlus companion to [Open-FDD](https://bbartling.github.io/open-fdd/) / [Vibe App 19](../vibe_code_apps_19/): an AI-helper stack that turns fault evidence into auditable **ECM energy screens** (prototype IDF + weather + progressive patches) and **ESCO-grade capital plans** (bin-method calculators, payback/ROI/NPV, EnergyPlus-vs-proxy crosscheck).
+**WattLab Studio** is the Streamlit cockpit for [OpenFDD WattLab](AGENTS.md) (Vibe App 20): turn a [Vibe 19](../vibe_code_apps_19/) WattLab dump into model, benchmark, ECM, twin, and capital-plan workflows.
 
-Folder: `vibe_code_apps_20` — now an installable Python package (`pip install -e .` → `import wattlab`, CLI `wattlab`).
+Vibe 19 = measured FDD. Vibe 20 = model / ECM / capital. They stay separate apps.
 
-## Install + CLI
+Agent / CLI / package detail lives in [`AGENTS.md`](AGENTS.md) — this README is for running the UI.
 
-```powershell
-cd vibe_code_apps_20
-pip install -e .          # or: pip install -e ".[studio,excel,dev]"
+## Run (Docker / GHCR)
 
-wattlab --help            # defaults / easy-button / calibrate / bridge / epw /
-                          # bench / crosscheck / benchmark / seed / studio
-wattlab twin path\to\wattlab_dump.zip          # start here: gaps -> profile -> FDD bridge
-wattlab twin path\to\wattlab_dump.zip --inputs answers.json --measure-set better
-wattlab seed path\to\wattlab_dump.zip          # inspect a vibe19 dump
-wattlab seed path\to\wattlab_dump.zip --gaps --strict   # exit 1 if required gaps missing
-wattlab explore-existing --config examples\poorly_documented_existing_building\config.yaml --dry-run
-wattlab ecm list                               # canonical ECM catalog
-wattlab ecm package partial-g36
-wattlab benchmark examples\liberty\campus.json # annualize bills + peer-band compare
-wattlab studio                                  # launch WattLab Studio (Streamlit)
-```
-
-Old flat-script entry points (`python easy_button.py …`) keep working via thin shims.
-
-## The `wattlab` package
-
-| Module | Role |
-| --- | --- |
-| `wattlab.twin` | **Start here** — dump zip → gaps → resolved profile → FDD bridge |
-| `wattlab.seed` | Load vibe19 WattLab dumps (zip/folder) + gap report |
-| `wattlab.benchmarks` | Benchmark governance: EUI peer bands (EPA/CBECS), retrofit-cost bands (LBNL/RMI, with unit basis + vintage + confidence), shared-meter allocation scenarios, and the ROI guardrail gate |
-| `wattlab.weather.bins` | Weather-Man OAT bin tables (5°F × 3 shifts + MCWB), psychrometrics, built-in NOAA Washington DC table, `from_hourly` for `weather_observed.csv` |
-| `wattlab.weather.epw` | AMY EPW builder |
-| `wattlab.bench` | Proxy calculators + open, independently implemented **HVAC bin-method screening calculators** (`wattlab.bench.esco`) with synthetic golden tests |
-| `wattlab.finance` | Payback / ROI / NPV / escalated cash flows / capital-plan rollup + CSV/JSON export |
-| `wattlab.crosscheck` | EnergyPlus-vs-proxy referee: agreement ratios, ASHRAE G14 gates, `in_line` / `investigate` / `keep_iterating` verdicts |
-| `wattlab.energyplus` | Docker runner, MCP client, results parsing, run manifests, IDF patches |
-| `wattlab.measures` | Good/Better/Best measure sets |
-| `wattlab.bridge` / `wattlab.calibrate` / `wattlab.easy_button` | vibe19 bridge, calibration, progressive ECM runs |
-
-### Bin-method calculators (`wattlab.bench.esco`)
-
-Open, independently implemented HVAC bin-method screening calculators with
-synthetic golden tests (see `tests/test_esco_golden.py`):
-
-`scheduling_fan_bins` · `scheduling_cooling_bins` · `scheduling_heating_bins` ·
-`oad_unoccupied_closed` · `dcv_bins` · `static_pressure_reset` ·
-`dat_reset_bins` · `hydronic_reset_bins` · `dewpoint_economizer` ·
-`chw_reset` · `condenser_water_reset` · `pneumatic_compressor`
-
-All are driven by a `WeatherBins` table (NOAA-style rows, hourly OAT series, or
-the built-in Washington DC table) plus shift schedules and equipment inventory.
-Privacy/provenance: [`docs/PRIVACY_AND_PROVENANCE.md`](docs/PRIVACY_AND_PROVENANCE.md).
-
-### Existing Building Hypothesis Lab
-
-`wattlab explore-existing` investigates sparse existing buildings (autosizing,
-capacity, weather-responsive schedules, ventilation hypotheses, proxy
-crosschecks). Badge stays `CONCEPTUAL_HYPOTHESIS` without held-out bills.
-Examples:
-[`examples/poorly_documented_existing_building/`](examples/poorly_documented_existing_building/),
-[`examples/synthetic_controls_school/`](examples/synthetic_controls_school/)
-(IP + SI configs). Docs: [ECM Easy Buttons](docs/ECM_EASY_BUTTONS.md),
-[units](docs/UNITS_AND_CONVERSIONS.md),
-[privacy](docs/PRIVACY_AND_PROVENANCE.md),
-[benchmarks](docs/CONTROLS_RETROFIT_BENCHMARKS.md),
-[interactions](docs/ECM_INTERACTIONS.md).
-
-### WattLab Studio
-
-`wattlab studio` (or `streamlit run studio.py`) — the ESCO / capital-planning
-cockpit, fully functional in dry-run without Docker:
-
-1. **Ingest** — upload the vibe19 WattLab dump zip → summary, gap checklist, fault highlights, next-step framing
-2. **Data Explorer** — browse dump analytic tables + shared `telemetry/` CSVs (measured evidence)
-3. **Assumption Ledger** — read-only provenance (MEASURED / INFERRED / DEFAULTED / HUMAN / MISSING)
-4. **Model** — profile editor seeded by defaults + dump, provenance table, calibration badge
-5. **Benchmark** — bills before models: annualized EUIs vs EPA/CBECS peer bands (Plotly), shared-meter allocation scenarios side-by-side, monthly gas/electric+demand signatures (fixture campus pre-filled)
-6. **Existing Building Hypothesis Lab** — sparse-input scenario ladder + artifact downloads
-7. **ECM Easy Buttons** — catalog-driven cards/packages with proxy and conceptual E+ actions
-8. **Measures** — catalog + FDD-suggested measures with proxy savings and editable costs
-9. **Twin loop** — dry-run plan or Docker EnergyPlus runs, iteration history, crosscheck verdicts
-10. **EP Results** — post-sim charts / scorecards
-11. **Capital plan** — payback/ROI/NPV rollup gated by the benchmark guardrails (`PUBLISH` / `INVESTIGATE`), CSV/JSON export
-
-**Pre-ship / pre-GHCR Studio gate** (local agent checklist; GHCR CI builds the image only):
-
-```powershell
-python scripts/smoke_studio.py
-python -m pytest tests/test_studio_app.py -q
-# with Studio running on :8520 (host or Docker):
-python scripts/browser_smoke_vibe20.py --url http://localhost:8520 --screenshots .artifacts/browser/native
-```
-
-Vibe 19 and Vibe 20 stay separate apps: 19 = measured FDD; 20 = model/ECM/capital. No in-app chat, Mapping Studio, or full calibration workbench in this Phase 1 cockpit slice.
-
-### Benchmark governance (`wattlab.benchmarks`)
-
-Three-layer screening stack: benchmark plausibility → ESCO bin-method proxies →
-calibrated EnergyPlus. The benchmarks layer keeps the other two honest:
-
-- `benchmarks_public.json` — EPA Portfolio Manager national median site EUIs by
-  property type + CBECS all-commercial fallback (70.6 kBtu/ft²).
-- `retrofit_costs_public.json` — cost bands by scope (RCx $0.26/ft² … deep
-  retrofit $25–150/ft²) with explicit `unit_basis`, `currency_year`, and
-  `confidence`, so windows priced per glazing-ft² never silently compare
-  against chillers per building-ft², and 2009 LBNL medians are never quoted as
-  2026 bids.
-- `meters.py` — shared meters are first-class: `campus.json` declares who
-  serves whom; splits (`area_weighted` / `equal` / `gas_share` / `manual`) are
-  visible scenarios, not buried assumptions. See
-  [examples/liberty](examples/liberty/README.md) for the real two-building
-  practice campus.
-- `guardrails.py` — the gate before ROI publication: baseline EUI band,
-  claimed-savings fraction by scope, implied post-retrofit EUI, per-measure
-  cost bands, payback plausibility. Any failure marks the plan `INVESTIGATE`
-  instead of quietly rendering a glossy ROI chart.
-
-**Quick link (vibe19 upload zips):** [`../vibe_code_apps_19/docs/PACKAGE_SPEC.md`](../vibe_code_apps_19/docs/PACKAGE_SPEC.md) — `openfdd_package_v1` layout for historian packages that feed WattLab via the Energy Model tab / Model Seed Bundle.
-
-## School 30-year rehearsal
-
-`examples/school_30yr/` is a fictional 100,000 ft² Detroit K-12 school. Its
-twelve 2025 electricity and gas bills are repository-authored
-`synthetic_rehearsal` data, not measured or transformed property, district, or
-utility data. The example exists only to exercise the end-to-end workflow.
-
-Inputs fail closed through strict Pydantic v2 contracts:
-`WeatherRequest` / `WeatherDatasetMeta` require valid coordinates, ordered
-dates, UTC archive data, all EPW variables, bounded values, SHA-256 provenance,
-and complete annual coverage; `UtilityBillRecord` / `UtilityDataset` require
-valid fuel-unit pairs and exactly 12 consecutive single-fuel months; and
-`RetrofitScenario` requires unique measures plus an explicit
-`conceptual_surrogate` declaration.
-
-Open-Meteo archive responses use request-keyed, atomically written cache
-envelopes, preserve download time and source hash, validate units/coordinates/
-array shapes/physical bounds, and retry only timeouts, HTTP 429, and HTTP 5xx
-with bounded backoff. Annual EPWs reject gaps, duplicates, and anything other
-than 8,760 rows (8,784 in leap years). Archive timestamps are UTC, but EPW rows
-**must be converted to local standard time** and the LOCATION header must use
-the same fixed offset; UTC-stamped EPW rows misalign solar and weather data.
-
-Measure sets:
-
-- `school_30yr_hydronic`: schedule alignment, premium fan/VFD, high-efficiency
-  chiller, condensing boiler, and high-performance glazing.
-- `school_30yr_electrify`: schedule alignment, premium fan/VFD, high-efficiency
-  chiller, conceptual air-to-water heat pump, and high-performance glazing.
-
-These are screening models. The AWHP is represented as an electric-boiler
-surrogate, glazing as a simple-glazing envelope proxy, and fan/chiller/boiler
-replacements as direct parameter or efficiency edits—not equipment selection,
-plant redesign, controls design, or construction-ready analysis.
-
-```powershell
-cd vibe_code_apps_20
-
-# Focused unit verification (no network or Docker)
-python -m pytest tests/test_input_contracts.py tests/test_open_meteo_weather.py tests/test_deep_retrofit_patches.py tests/test_school_30yr_rehearsal.py -q
-
-# Full suite
-python -m pytest -q
-
-# Live Open-Meteo + Docker rehearsal
-$env:RUN_SCHOOL_30YR_LIVE="1"
-python -m pytest tests/test_school_30yr_rehearsal.py::test_live_school_30yr_rehearsal -q -s
-Remove-Item Env:RUN_SCHOOL_30YR_LIVE
-
-# Equivalent report-producing run
-python scripts/school_30yr_rehearsal.py
-```
-
-The script exits nonzero only for simulation/runtime failure. `INVESTIGATE` is
-a review status recorded in the report, so a completed conceptual rehearsal
-does not fail CI. Baseline G14 calibration is dual-fuel: monthly electricity
-and natural gas must each pass NMBE/CV(RMSE). The fan, chiller, and heating
-plant are explicit shares of one major-HVAC p50 package; glazing and controls
-retain separate cost bases.
-
-The live evidence recorded on 2026-07-18 completed 12/12 simulations. Both
-baseline fuels fail ASHRAE G14: electricity NMBE/CV(RMSE) are 52.21%/52.61%,
-and natural gas is 78.03%/93.74%. The fail-closed release verdict is therefore
-`INVESTIGATE` even though execution completed and the separate capital-plan
-guardrails pass. Report: `.artifacts/school_30yr_rehearsal.json`.
-Its `comparison` rollup reports hydronic renewal at 90,261.2 kWh and 4,864.5
-therms saved/year, $17,986.53/year cost savings, $716,806.94 implementation
-cost, and -$346,521.59 NPV; electrification at 61,148.4 kWh and 8,085.7
-therms saved/year, $17,133.43/year cost savings, $716,806.94 implementation
-cost, and -$364,084.16 NPV. Both remain `INVESTIGATE`.
-
-## Design principles
-
-1. **Evidence before modeling.** An OpenFDD finding is not automatically an ECM.
-2. **Measure briefs are authoritative.** Easy button + IDF patches execute approved briefs.
-3. **One change at a time.** Preserve progressive ECM accounting.
-4. **Never hide assumptions.** Provenance, confidence, `NEEDS_INPUT`.
-5. **Dockerized EnergyPlus** via [LBNL EnergyPlus-MCP](https://github.com/LBNL-ETA/EnergyPlus-MCP) (`energyplus-mcp-dev`, EP 26.1) — no host EnergyPlus install.
-6. **Honest G36 limit.** Full ASHRAE Guideline 36 is **not** an MCP button; WattLab ships labeled IDF proxies (`conceptual_gl36_proxy`).
-
-**Start here:** [`AGENTS.md`](AGENTS.md) → [`.agents/routing.md`](.agents/routing.md).
-
-Cursor skill: [`.cursor/skills/openfdd-wattlab/SKILL.md`](.cursor/skills/openfdd-wattlab/SKILL.md).
-
-## Requirements
-
-- Docker Desktop / Engine running
-- Python 3.10+ (stdlib + `pytest` for tests)
-- One-time build of image `energyplus-mcp-dev` (see below)
-
-## Quick start
-
-```powershell
-cd vibe_code_apps_20
-
-# One-time: clone + build (pin in third_party/VERSION.txt)
-git clone https://github.com/LBNL-ETA/EnergyPlus-MCP.git third_party/EnergyPlus-MCP
-cd third_party/EnergyPlus-MCP
-git checkout 5a7d3bb1d2e537ba329d3412c8b79d22cedd7c70
-# TARGETPLATFORM is required (plain docker build often fails with "parameter not set")
-docker build --build-arg TARGETPLATFORM=linux/amd64 \
-  -t energyplus-mcp-dev -f .devcontainer/Dockerfile .devcontainer
-cd ../..
-# or: bash scripts/build_energyplus_mcp.sh
-
-# Plan only (no Docker sim)
-python madison_office.py --dry-run
-
-# Live screen: baseline → schedule ECM → GL36-proxy ECM
-python madison_office.py
-
-# Or any building profile
-python easy_button.py --building examples/buildings/chicago_office.json --dry-run
-python easy_button.py --building examples/buildings/chicago_office.json
-```
-
-Artifacts land under `.artifacts/wattlab_<UTC>/` (`result_record_*.json`, IDF copies, `eplustbl.*`, `wattlab_report.json`).
-
-## Docker / GHCR (WattLab Studio image)
-
-Multi-arch (`linux/amd64` + `linux/arm64`) images publish automatically from
-`.github/workflows/vibe20-ghcr.yml` on every `develop`/`main` push that touches
-`vibe_code_apps_20/`:
+Multi-arch images publish from `develop` via `.github/workflows/vibe20-ghcr.yml`:
 
 ```powershell
 docker pull ghcr.io/bbartling/vibe20:latest
 docker rm -f vibe20 2>$null
 # Use 8520 when vibe19 already owns 8501/8502/8503 on the same host
 docker run -d --restart unless-stopped -p 8520:8501 --name vibe20 ghcr.io/bbartling/vibe20:latest
-# open http://localhost:8520  →  WattLab Studio → Ingest → upload wattlab_dump_*.zip
+# open http://localhost:8520
 ```
 
-Tags: `:latest` (tip of default branch), `:develop`, `:sha-<commit>`,
-`vibe20-v*` releases. The container serves Studio; **Ingest accepts a vibe19
-WattLab dump zip**, then dry-run / benchmark / measures / capital-plan work
-inside the container. Real EnergyPlus simulations need a Docker daemon on the
-**host** (`energyplus-mcp-dev` + `wattlab twin --live` / easy-button) — not
-inside the vibe20 container. Verify a published tip:
+Tags: `:latest`, `:develop`, `:sha-<commit>`. Real EnergyPlus sims need a host Docker image `energyplus-mcp-dev` (see [`AGENTS.md`](AGENTS.md)) — not inside this container.
 
-```powershell
-docker buildx imagetools inspect ghcr.io/bbartling/vibe20:latest   # must list amd64 + arm64
-```
-
-## Legacy script shims
-
-The pre-package flat scripts still work and forward to the package:
-
-| Script | Forwards to |
-| --- | --- |
-| `wattlab_defaults.py` | `wattlab.defaults` (`defaults/` data → `wattlab/data/defaults/`) |
-| `easy_button.py` | `wattlab.easy_button` (supports `--measure-set` / `--minimal`) |
-| `calibrate.py` | `wattlab.calibrate` |
-| `weather_epw.py` | `wattlab.weather.epw` |
-| `run_manifest.py` | `wattlab.energyplus.manifest` |
-| `vibe19_bridge.py` | `wattlab.bridge` |
-| `ep_docker.py` / `ep_mcp_client.py` | `wattlab.energyplus.docker` / `.mcp` |
-| `idf_patches/` | `wattlab.energyplus.patches` |
-| `ecm_library/` | `wattlab.measures` |
-| `results_parse.py` | `wattlab.energyplus.results` |
-| `config.py` | `wattlab.config` |
-| `madison_office.py` | Madison conceptual playbook wrapper (unchanged) |
-
-## Easy-button defaults
-
-Minimal inputs only (building type, city, code vintage, area, floors, HVAC family). EnergyPlus **autosizes** capacities — fan sizes / plant tons are not required. Defaults are tagged `user` | `default` | `vibe19` in `field_sources` (black/blue-text analog).
-
-```powershell
-# Resolve defaults only
-python wattlab_defaults.py --type office --city madison --code 90.1-2013 --area 150000 --floors 6
-
-# Dry-run Best measure set from minimal JSON
-python easy_button.py --minimal "{\"building_type\":\"office\",\"city\":\"madison\",\"measure_set\":\"best\"}" --dry-run
-
-# Live Best set
-python easy_button.py --minimal "{\"building_type\":\"office\",\"city\":\"madison\",\"measure_set\":\"best\"}" --measure-set best
-
-# Bridge a vibe19 agent-export directory into measures
-python vibe19_bridge.py path/to/vibe19_export -o .artifacts/bridge.json
-
-# Calibrate against a vibe19 Model Seed Bundle (needs weather_observed.csv + Docker)
-python calibrate.py --bundle path/to/vibe19_export --dry-run
-python calibrate.py --bundle path/to/vibe19_export --lat 42.33 --lon -83.05
-
-# Build AMY EPW alone
-python weather_epw.py path/to/weather_observed.csv -o .artifacts/amy.epw --lat 42.33 --lon -83.05
-```
-
-Measure sets: **Good** (schedules) · **Better** (+ chiller lockout) · **Best** (+ SAT reset + GL36 airside proxy).
-
-## Calibration (partial-year OK)
-
-vibe19 exports a **Model Seed Bundle** (`model_seed.json`, inferred schedules, OAT-binned operating signatures, observed weather). WattLab:
-
-1. Builds an **AMY EPW** from `weather_observed.csv` (Open-Meteo fields) — weather mode `ACTUAL_YEAR_CALIBRATION`.
-2. Patches **RunPeriod** to the data window (no full year of HVAC runtime required).
-3. Simulates and writes `calibration_scorecard.json` with NMBE/CVRMSE vs signatures and optional monthly utility bills (ASHRAE Guideline 14 monthly thresholds ±5% / 15%).
-4. Optional holdout: `--validation-months N` (needs ≥6 bill months) splits bills into calibration vs validation; scorecard `status` is one of `VALIDATED` / `CALIBRATED_NOT_VALIDATED` / `FAILED_VALIDATION` / `CONCEPTUAL_ONLY`.
-5. Hour-shift warning via lag-scan correlation (does not auto-correct). Signature shape match stays whole-window (OAT-binned).
-
-Without bills the scorecard still reports **shape match** on fan/cooling on-fractions and flags `bills_recommended` → status `CONCEPTUAL_ONLY`.
-
-```powershell
-python calibrate.py --bundle path/to/vibe19_export --validation-months 3
-```
-
-Every run writes `run_manifest.json` (IDF/EPW sha256, EnergyPlus pin, Docker image).
-
-### Weather suitability (stamped on every report)
-
-| Mode | When |
-| --- | --- |
-| `TYPICAL_YEAR_SCREENING` | City-matched TMY (e.g. Chicago EPW for Chicago) |
-| `ACTUAL_YEAR_CALIBRATION` | AMY EPW from observed weather (`calibrate.py`) |
-| `SUBSTITUTE_CLIMATE_CONCEPTUAL_ONLY` | Wrong-city / approximated EPW (e.g. Chicago TMY for Madison) |
-
-Never silently substitute weather — every `wattlab_report.json` / scorecard includes `weather_suitability.mode` + reason.
-
-## vibe19 Streamlit integration
-
-The vibe19 **Energy Model** tab shells out to this pack (no Python cross-imports):
-
-1. Sibling folder auto-detect, or set `VIBE19_WATTLAB_DIR` to this directory.
-2. Build `energyplus-mcp-dev` once (see Quick start / [`third_party/README.md`](third_party/README.md)).
-3. Open Streamlit → **Energy Model** → preview defaults / dry-run / live Sims / **Calibrate against my data**.
-4. Optional: **Fetch Open-Meteo weather** + enter monthly utility bills for ASHRAE-14 magnitude calibration.
-
-Copy [`.env.example`](.env.example) → `.env` for image name and utility-rate overrides only — never put credentials in `.env`.
-
-## Examples
-
-| Path | Role |
-| --- | --- |
-| `examples/buildings/madison_office.json` | Conceptual Madison screen (Chicago TMY3 climate proxy) |
-| `examples/evidence/madison_office_evidence.json` | SCHED-247 + GL36-style evidence pack |
-| `examples/prototypes/5ZoneAirCooled.idf` | Default MediumOffice-class sample IDF |
-| `examples/weather/*.epw` | Bundled TMY3 weather |
-
-## Tests
+## Run (local)
 
 ```powershell
 cd vibe_code_apps_20
-python -m pytest tests -q
+pip install -e ".[studio]"
+wattlab studio
+# or: streamlit run studio.py --server.port 8520
 ```
 
-Unit tests scrub proprietary terms and exercise dry-run / IDF patches. Docker tests (`test_ep_docker_smoke.py`) skip if the image is missing. Golden tests (`test_esco_golden.py`) pin calculators to synthetic engineering fixtures; `test_studio_app.py` drives WattLab Studio via Streamlit AppTest (dry-run path); `test_package_shims.py` guards the legacy script entry points.
+## Studio pages
 
-## Cursor MCP (full toolkit)
+1. **Ingest** — upload `wattlab_dump_*.zip` from vibe19 Export → summary, gaps, FDD highlights, next-step framing
+2. **Data Explorer** — browse dump analytic tables + shared `telemetry/` CSVs (measured evidence)
+3. **Assumption Ledger** — read-only provenance (`MEASURED` / `INFERRED` / `DEFAULTED` / `HUMAN` / `MISSING`)
+4. **Model** — profile editor, provenance, calibration badge
+5. **Benchmark** — bills vs peer bands, shared-meter scenarios, monthly signatures
+6. **Existing Building Hypothesis Lab** — sparse-input scenario ladder + artifact downloads
+7. **ECM Easy Buttons** — catalog cards/packages (proxy + conceptual EnergyPlus)
+8. **Measures** — catalog + FDD-suggested measures, proxy savings, editable costs
+9. **Twin loop** — dry-run plan or Docker EnergyPlus runs, crosscheck verdicts
+10. **EP Results** — post-sim charts / scorecards
+11. **Capital plan** — payback / ROI / NPV gated by benchmark guardrails (`PUBLISH` / `INVESTIGATE`)
 
-For HVAC inspect / validate / plot beyond the easy button, mount the cloned EnergyPlus-MCP tree and run the MCP server inside `energyplus-mcp-dev` — snippet in [`third_party/README.md`](third_party/README.md).
+Most pages work dry-run without EnergyPlus. Start on **Ingest** with a dump zip.
 
-| Mode | When | How |
-| --- | --- | --- |
-| **Easy button** | Default ECM screen | `python easy_button.py` / `madison_office.py` |
-| **Full EnergyPlus-MCP** | Loops, plots, custom run periods | Cursor MCP → Docker image |
+## Pre-ship smoke (local)
 
-## Package layout
+GHCR CI builds/pushes the image only. Before merge, run:
 
-| Path | Role |
+```powershell
+python scripts/smoke_studio.py
+python -m pytest tests/test_studio_app.py -q
+# with Studio on :8520 (host or Docker):
+python scripts/browser_smoke_vibe20.py --url http://localhost:8520 --screenshots .artifacts/browser/native
+```
+
+## Related docs
+
+| Doc | For |
 | --- | --- |
-| `AGENTS.md` | Agent handbook (source of truth) |
-| `.agents/skills/*/SKILL.md` | Domain + EP skills |
-| `schemas/` | `building_profile` / `measure_brief` / `result_record` |
-| `examples/` | Profiles, evidence, prototypes, weather |
-| `third_party/` | EnergyPlus-MCP pin + Cursor MCP notes |
-| `docs/` | Stub → AGENTS.md |
-
-## Primary workflow
-
-`OpenFDD / Vibe 19 → evidence → MeasureBrief → WattLab easy button → progressive ECMs → QA`
+| [`AGENTS.md`](AGENTS.md) | Agent handbook, CLI (`wattlab twin` / `seed` / …), hard rules |
+| [`../vibe_code_apps_19/docs/PACKAGE_SPEC.md`](../vibe_code_apps_19/docs/PACKAGE_SPEC.md) | Historian package layout that feeds dumps |
+| [`docs/`](docs/) | ECM briefs, units, privacy, benchmarks |

--- a/vibe_code_apps_20/SESSION_LOG.md
+++ b/vibe_code_apps_20/SESSION_LOG.md
@@ -2,6 +2,15 @@
 
 Newest first. One entry per shipped work session.
 
+## 2026-07-20 — Fuel Weather dashboard (data-model driven)
+
+- Studio **Fuel Weather**: campus.json bills × Open-Meteo/synthetic HDD/CDD
+  (base 65°F), intensity/demand heatmaps, gas×HDD & elec×CDD R².
+- `bill_columns` maps on campus/meters; lat/lon/siteRef from JSON — no city
+  hardcodes. Liberty = practice example only; CI fixture for AppTest.
+- Haystack interval maps documented as shared vibe19 contract (Phase 2 UI).
+- Agent spec: `vibe20_agent_spec` DATA_CONTRACT + AGENTS + studio skill updated.
+
 ## 2026-07-20 — ESCO cockpit Phase 1 + Studio UI smoke gate
 
 - Studio pages: **Data Explorer** (dump tables/telemetry) + **Assumption Ledger**

--- a/vibe_code_apps_20/docs/superpowers/plans/2026-07-20-fuel-weather-dashboard.md
+++ b/vibe_code_apps_20/docs/superpowers/plans/2026-07-20-fuel-weather-dashboard.md
@@ -1,0 +1,39 @@
+# Fuel Weather Dashboard Implementation Plan
+
+> **For agentic workers:** Implement task-by-task. Steps use checkbox syntax.
+
+**Goal:** Add Studio **Fuel Weather** page: campus monthly bills → Open-Meteo → HDD/CDD → fuel timelines, kBtu/demand heatmaps, gas×HDD & elec×CDD R²; ship with AppTest smoke + GHCR.
+
+**Architecture:** Pure library modules (`degree_days`, `fuel_weather`) + Streamlit page; reuse `Campus` / `load_bill_csv`; mock Open-Meteo in tests.
+
+**Tech Stack:** pandas, numpy, plotly, streamlit, existing `wattlab.weather.open_meteo`
+
+## Global Constraints
+
+- Interval Haystack maps = Phase 2 caption only
+- No private Liberty CSVs in git; fixture campus for CI
+- AppTest offline (synthetic hourly OAT)
+- Do not merge Vibe 19 into Studio
+
+---
+
+### Task 1: Degree days + regression library
+
+- [ ] `wattlab/weather/degree_days.py` — HDD/CDD base 65°F from hourly dry_bulb_f
+- [ ] `wattlab/benchmarks/fuel_weather.py` — align meters + DD, OLS fit, monthly kBtu helpers
+- [ ] Tests with synthetic series
+- [ ] Commit
+
+### Task 2: Studio Fuel Weather page
+
+- [ ] `wattlab/studio/pages/fuel_weather.py`
+- [ ] Register in `studio.py` PAGES after Benchmark
+- [ ] Wire smoke + browser_smoke + test_studio_app page lists
+- [ ] README / AGENTS one-liners
+- [ ] Commit
+
+### Task 3: Verify + ship
+
+- [ ] Full pytest + smoke_studio
+- [ ] PR → merge develop → watch vibe20-ghcr → verify tags
+- [ ] Confirm no open PRs / stale remote branches

--- a/vibe_code_apps_20/docs/superpowers/specs/2026-07-20-fuel-weather-dashboard-design.md
+++ b/vibe_code_apps_20/docs/superpowers/specs/2026-07-20-fuel-weather-dashboard-design.md
@@ -1,0 +1,118 @@
+# Fuel Weather Dashboard (Studio) — Design
+
+**Date:** 2026-07-20  
+**Status:** draft for review  
+**App:** `vibe_code_apps_20` WattLab Studio  
+**Approach:** A — new **Fuel Weather** page (Benchmark stays EUI / peers / allocation)
+
+## Goal
+
+Give operators a turnkey Studio page that:
+
+1. Loads **Liberty-style campus monthly bill CSVs** (first example) via a fuel-file picker.
+2. Pulls **Open-Meteo** hourly dry-bulb for the bill window + lat/lon.
+3. Computes **HDD / CDD** (base 65°F) and fits **gas×HDD** and **electric×CDD** with **R²**, slope, intercept, baseload.
+4. Renders a strong fuel dashboard: time charts, kBtu intensity, demand heatmap, gas heatmap — without merging Vibe 19/20 codebases.
+
+Interval historian meters + Haystack `column_map` JSON are **Phase 2** (stub caption only in v1).
+
+## Non-goals (v1)
+
+- No merge of Vibe 19 analytics into Studio.
+- No full Haystack interval map UI / `history_wide.csv` integration.
+- No replacement of Benchmark peer-band / capital guardrails.
+- No Playwright inside `vibe20-ghcr.yml` (keep local AppTest + existing browser smoke walk).
+- No committing private Liberty CSVs (remain gitignored); fixture campus stays CI default.
+
+## Data model (align with vibe19 handoff)
+
+### Monthly bills (v1 primary)
+
+Reuse existing WattLab campus contract:
+
+- Sidecar: `campus.json` (`buildings[]`, `meters[]` with `fuel`, `unit`, `file`, `serves`, optional `allocation`).
+- Loader: `wattlab.benchmarks.meters.load_bill_csv` → tidy `month`, `usage`, optional `cost_usd`, `demand_kw`.
+- Column discovery stays fuzzy (Bill Month / kWh / Usage Mcf / Billed Demand) so Liberty CSVs and fixture CSVs both work.
+- Twin handoff stays via existing `wattlab seed import-bills` → wide `utility_bills.csv` (`month,kwh,therms`) — dashboard can offer a one-click “export for twin” later; not required for v1 charts.
+
+Optional **column alias JSON** (vibe19-compatible spirit, monthly-only in v1):
+
+```json
+{
+  "version": 1,
+  "generated_by": "manual",
+  "notes": "Monthly utility summary map (not interval Haystack points).",
+  "bill_columns": {
+    "month": "Bill Month",
+    "usage": "kWh Total",
+    "demand_kw": "Billed Demand (kW)",
+    "cost_usd": "Total Current Charges ($)"
+  }
+}
+```
+
+If present beside a meter CSV (or uploaded), overrides header heuristics. Document that interval maps use vibe19 `equip.points` / `column_roles` shape and are out of scope until Phase 2.
+
+### Weather
+
+- Source: existing `wattlab.weather.open_meteo` archive API (cached envelopes).
+- Inputs: lat/lon (form; Liberty default Detroit ~42.33, -83.05) + date range from min/max bill months.
+- Output: hourly `dry_bulb_f` → monthly **HDD** / **CDD** with base **65°F** (match vibe19 metering convention).
+
+### Degree-day regression
+
+For each fuel series aligned to months with complete DD:
+
+| Series | X | Y |
+| --- | --- | --- |
+| Gas | monthly HDD | gas usage (therms or Mcf → display both; regression in native meter unit) |
+| Electric | monthly CDD | kWh (and optional demand_kw secondary chart) |
+
+Report: **R²**, slope, intercept (baseload), n months, base °F, weather provenance (Open-Meteo request hash / cache key). Fail closed if &lt; 6 overlapping months.
+
+## Studio UX
+
+**New page:** `Fuel Weather` registered in `PAGES` (after **Benchmark**).
+
+Sections (one job each):
+
+1. **Campus / files** — pick `campus.json` or “Use Liberty fixture / local examples/liberty if CSVs exist”; show meter table + file status; optional per-meter column-map JSON upload.
+2. **Site + weather** — lat/lon, Fetch Open-Meteo (or use cached); caption weather suitability.
+3. **Fuel timeline** — Plotly multi-trace monthly kWh / gas / demand; toggle building vs shared meter + allocation scenario (reuse Benchmark allocation helpers).
+4. **Intensity & heatmaps** — monthly site / building kBtu/ft²; heatmaps for electric intensity, demand_kw, gas intensity.
+5. **Weather response** — scatter + fit lines for gas×HDD and elec×CDD with R² badges; residual time series.
+
+Empty states: clear “load campus / CSVs” messaging; never invent bills or weather.
+
+## Library layout
+
+| Path | Role |
+| --- | --- |
+| `wattlab/weather/degree_days.py` | Hourly OAT → daily mean → monthly HDD/CDD |
+| `wattlab/benchmarks/fuel_weather.py` | Align bills + DD, OLS fit, dashboard tables |
+| `wattlab/studio/pages/fuel_weather.py` | Streamlit page |
+| `studio.py` | Register page in `PAGES` + dispatch |
+| `tests/test_degree_days.py` | Synthetic OAT → known HDD/CDD |
+| `tests/test_fuel_weather.py` | Fixture campus + synthetic weather → R² path |
+| `tests/test_studio_app.py` + `scripts/smoke_studio.py` | Visit Fuel Weather; fixture path 0 exceptions |
+
+## Defaults
+
+- Prefer `examples/liberty/campus.json` when referenced CSVs exist on disk.
+- Else `tests/fixtures/shared_meter_campus/campus.json` (CI + GHCR).
+- Open-Meteo calls in AppTest: **mock / offline fixture** hourly series so CI needs no network; live fetch is UI-only with cache.
+
+## Verification + ship
+
+1. Unit tests for degree days + regression.
+2. `python scripts/smoke_studio.py` and `pytest tests/test_studio_app.py -q` — all pages including Fuel Weather, 0 `at.exception`.
+3. Optional: `browser_smoke_vibe20.py` walks new page (extend page list).
+4. PR → merge `develop` → `vibe20-ghcr` → verify `:latest` / `:sha-*`.
+5. README Studio page list + one-liner for Fuel Weather; detail in `AGENTS.md`.
+
+## Success criteria
+
+- Operator can open Studio → Fuel Weather → Liberty (or fixture) → see fuel timelines, kBtu heatmaps, Open-Meteo-backed HDD/CDD R² without CLI.
+- No UI exceptions on AppTest walk.
+- GHCR `ghcr.io/bbartling/vibe20` refreshed to merge tip.
+- Interval / Haystack map UI explicitly deferred with a visible Phase-2 caption.

--- a/vibe_code_apps_20/examples/liberty/campus.json
+++ b/vibe_code_apps_20/examples/liberty/campus.json
@@ -1,7 +1,10 @@
 {
   "campus_id": "liberty",
   "label": "Liberty Buildings 50 + 100 (Detroit)",
-  "notes": "Two ~140k ft2 buildings sharing one electric meter; gas is metered per building. Practice campus for the WattLab benchmark + twin loop workflow using vibe19 dumps.",
+  "notes": "PRACTICE EXAMPLE ONLY — not a production template. Two ~140k ft2 buildings sharing one electric meter; gas is metered per building. Copy campus.json shape for real sites; never hardcode this campus_id in WattLab logic.",
+  "siteRef": "liberty_practice",
+  "lat": 42.33,
+  "lon": -83.05,
   "buildings": [
     {
       "building_id": "liberty_50",

--- a/vibe_code_apps_20/scripts/browser_smoke_vibe20.py
+++ b/vibe_code_apps_20/scripts/browser_smoke_vibe20.py
@@ -44,6 +44,7 @@ PAGES = [
     "Assumption Ledger",
     "Model",
     "Benchmark",
+    "Fuel Weather",
     "Measures",
     "Twin loop",
     "EP Results",

--- a/vibe_code_apps_20/scripts/smoke_studio.py
+++ b/vibe_code_apps_20/scripts/smoke_studio.py
@@ -28,6 +28,7 @@ PAGES = [
     "Assumption Ledger",
     "Model",
     "Benchmark",
+    "Fuel Weather",
     "Measures",
     "Twin loop",
     "EP Results",
@@ -94,6 +95,15 @@ def main() -> int:
     at.selectbox(key="studio_allocation").set_value("gas_share").run()
     if at.exception:
         return _fail(at, "Benchmark(gas_share)")
+
+    at.radio(key="studio_page").set_value("Fuel Weather").run()
+    at.button(key="fuel_weather_load_campus").click().run()
+    if at.exception:
+        return _fail(at, "Fuel Weather(load)")
+    at.button(key="fuel_weather_synth").click().run()
+    if at.exception:
+        return _fail(at, "Fuel Weather(synth)")
+    print("OK: Fuel Weather loaded + synthetic OAT")
 
     at.radio(key="studio_page").set_value("Model").run()
     at.text_input(key="studio_btype").set_value("office")

--- a/vibe_code_apps_20/studio.py
+++ b/vibe_code_apps_20/studio.py
@@ -31,6 +31,7 @@ PAGES = [
     "Assumption Ledger",
     "Model",
     "Benchmark",
+    "Fuel Weather",
     "Measures",
     "Twin loop",
     "EP Results",
@@ -1169,6 +1170,10 @@ def main() -> None:
         page_model()
     elif page == "Benchmark":
         page_benchmark()
+    elif page == "Fuel Weather":
+        from wattlab.studio.pages.fuel_weather import render
+
+        render(campus=_state("fuel_weather_campus") or _state("studio_campus"))
     elif page == "Measures":
         page_measures()
     elif page == "Twin loop":

--- a/vibe_code_apps_20/tests/fixtures/shared_meter_campus/campus.json
+++ b/vibe_code_apps_20/tests/fixtures/shared_meter_campus/campus.json
@@ -1,7 +1,10 @@
 {
-  "campus_id": "liberty",
+  "campus_id": "shared_meter_fixture",
   "label": "Synthetic shared-electric + per-building-gas campus (CI fixture)",
-  "notes": "Privacy-safe fixture with stable golden anchors (same math as the published Liberty demo). Local customer CSVs under examples/liberty remain gitignored.",
+  "notes": "Privacy-safe fixture with stable golden anchors. building_ids mirror the published practice example for test continuity only — production sites use their own ids. Local customer CSVs under examples/liberty remain gitignored.",
+  "siteRef": "ci_shared_meter_fixture",
+  "lat": 42.33,
+  "lon": -83.05,
   "buildings": [
     {
       "building_id": "liberty_50",
@@ -22,31 +25,22 @@
       "fuel": "electricity",
       "unit": "kwh",
       "file": "shared_electric_summary.csv",
-      "serves": [
-        "liberty_50",
-        "liberty_100"
-      ],
-      "allocation": {
-        "method": "area_weighted"
-      }
+      "serves": ["liberty_50", "liberty_100"],
+      "allocation": { "method": "area_weighted" }
     },
     {
       "meter_id": "gas_50",
       "fuel": "gas",
       "unit": "mcf",
       "file": "building_a_gas_summary.csv",
-      "serves": [
-        "liberty_50"
-      ]
+      "serves": ["liberty_50"]
     },
     {
       "meter_id": "gas_100",
       "fuel": "gas",
       "unit": "mcf",
       "file": "building_b_gas_summary.csv",
-      "serves": [
-        "liberty_100"
-      ]
+      "serves": ["liberty_100"]
     }
   ]
 }

--- a/vibe_code_apps_20/tests/test_degree_days_fuel_weather.py
+++ b/vibe_code_apps_20/tests/test_degree_days_fuel_weather.py
@@ -1,0 +1,121 @@
+"""Unit tests for HDD/CDD and fuel×weather regression."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from wattlab.benchmarks.fuel_weather import (
+    align_fuel_and_degree_days,
+    build_fuel_weather_report,
+    fit_weather_responses,
+    ols_fit,
+)
+from wattlab.benchmarks.meters import Campus
+from wattlab.weather.degree_days import DD_BASE_F, monthly_degree_days
+
+FIXTURE_CAMPUS = (
+    Path(__file__).resolve().parents[1]
+    / "tests"
+    / "fixtures"
+    / "shared_meter_campus"
+    / "campus.json"
+)
+
+
+def _hourly_oat(start: str, hours: int, temps_f: list[float] | None = None) -> pd.Series:
+    t0 = pd.Timestamp(start)
+    idx = pd.date_range(t0, periods=hours, freq="h")
+    if temps_f is None:
+        # Alternate cold / hot days roughly
+        temps_f = [40.0 + 30.0 * ((i // 24) % 2) for i in range(hours)]
+    return pd.Series(temps_f, index=idx, name="dry_bulb_f")
+
+
+def test_monthly_degree_days_known_day():
+    # One day at 55°F → HDD=10, CDD=0; one day at 75°F → HDD=0, CDD=10
+    idx = pd.date_range("2024-01-01", periods=48, freq="h")
+    temps = [55.0] * 24 + [75.0] * 24
+    s = pd.Series(temps, index=idx)
+    dd = monthly_degree_days(s)
+    assert list(dd["month"]) == ["2024-01"]
+    assert dd.loc[0, "hdd"] == pytest.approx(10.0)
+    assert dd.loc[0, "cdd"] == pytest.approx(10.0)
+    assert dd.loc[0, "n_days"] == 2
+    assert DD_BASE_F == 65.0
+
+
+def test_ols_on_constructed_hdd_gas():
+    """Guaranteed R² path without relying on fixture bill noise."""
+    months = [f"2024-{m:02d}" for m in range(1, 13)]
+    hdd = np.linspace(800, 50, 12)
+    usage = 100.0 + 0.5 * hdd
+    aligned = pd.DataFrame({
+        "month": months * 2,
+        "fuel": ["gas"] * 12 + ["electricity"] * 12,
+        "unit": ["mcf"] * 12 + ["kwh"] * 12,
+        "usage": list(usage) + list(200.0 + 0.3 * np.linspace(0, 400, 12)),
+        "hdd": list(hdd) + list(hdd),
+        "cdd": list(np.linspace(0, 300, 12)) * 2,
+        "kbtu": [0.0] * 24,
+    })
+    fits = fit_weather_responses(aligned, min_months=6)
+    by_fuel = {f.fuel: f for f in fits}
+    assert by_fuel["gas"].r2 == pytest.approx(1.0, abs=1e-6)
+
+
+def test_bill_columns_map_overrides_headers(tmp_path: Path):
+    csv = tmp_path / "weird.csv"
+    csv.write_text(
+        "Period,Qty,Demand\n2024-01,100,10\n2024-02,110,11\n",
+        encoding="utf-8",
+    )
+    from wattlab.benchmarks.meters import load_bill_csv
+
+    df = load_bill_csv(
+        csv,
+        column_map={"month": "Period", "usage": "Qty", "demand_kw": "Demand"},
+    )
+    assert list(df["month"]) == ["2024-01", "2024-02"]
+    assert df.loc[0, "usage"] == 100
+    assert df.loc[0, "demand_kw"] == 10
+
+
+
+def test_fuel_weather_on_fixture_campus():
+    assert FIXTURE_CAMPUS.is_file()
+    campus = Campus.from_json(FIXTURE_CAMPUS)
+    months = sorted(set.intersection(*(m.months() for m in campus.meters)))
+    assert len(months) >= 12
+    # Build hourly OAT with strong seasonal signal spanning the bill window.
+    start = f"{months[0]}-01"
+    y, m = map(int, months[-1].split("-"))
+    end = datetime(y + (1 if m == 12 else 0), 1 if m == 12 else m + 1, 1)
+    t0 = datetime.fromisoformat(start)
+    hours = int((end - t0).total_seconds() // 3600)
+    temps = []
+    for i in range(hours):
+        ts = t0 + timedelta(hours=i)
+        # Clear winter/summer swing so HDD/CDD vary across months
+        seasonal = 30.0 + 40.0 * np.sin(2 * np.pi * (ts.timetuple().tm_yday - 80) / 365)
+        temps.append(float(seasonal))
+    hourly = _hourly_oat(start, hours, temps)
+
+    aligned, window = align_fuel_and_degree_days(campus, hourly)
+    assert len(window) >= 12
+    assert not aligned.empty
+    # Force a clean OLS path: gas usage vs HDD must be finite and varying
+    gas = aligned[aligned["fuel"] == "gas"]
+    assert len(gas) >= 6
+    assert float(gas["hdd"].std()) > 0
+    fits = fit_weather_responses(aligned, min_months=6)
+    assert any(f.fuel == "gas" for f in fits) or any(f.fuel == "electricity" for f in fits)
+    report = build_fuel_weather_report(campus, hourly, weather_source="synthetic_test")
+    assert report["aligned_rows"] > 0
+    assert report["degree_days"]["base_f"] == 65.0
+    # Even if polyfit fails on noisy bills, report still builds
+    assert "fits" in report

--- a/vibe_code_apps_20/tests/test_studio_app.py
+++ b/vibe_code_apps_20/tests/test_studio_app.py
@@ -28,6 +28,7 @@ ALL_PAGES = [
     "Assumption Ledger",
     "Model",
     "Benchmark",
+    "Fuel Weather",
     "Measures",
     "Twin loop",
     "EP Results",
@@ -94,7 +95,7 @@ def test_studio_ep_results_page_loads_without_dump():
 
 @pytest.mark.parametrize(
     "page",
-    ["Hypothesis Lab", "ECM Easy Buttons", "Data Explorer", "Assumption Ledger"],
+    ["Hypothesis Lab", "ECM Easy Buttons", "Data Explorer", "Assumption Ledger", "Fuel Weather"],
 )
 def test_studio_new_pages_load_without_inputs(page):
     at = _boot(page)
@@ -203,7 +204,7 @@ def test_studio_benchmark_page_loads_liberty_campus():
     at.button(key="studio_load_campus").click().run()
     assert not at.exception
     campus = at.session_state["studio_campus"]
-    assert campus.campus_id == "liberty"
+    assert campus.campus_id == "shared_meter_fixture"
     summary = at.session_state["studio_benchmark_summary"]
     assert summary["campus"]["site_eui_kbtu_ft2"] == 71.6
     assert summary["window"]["start"] == "2024-12"

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -18,14 +18,16 @@ Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
 4. **Crosscheck referees every E+ measure** — `wattlab.crosscheck`: agreement ratio E+/proxy in 0.5–2.0× → `in_line`; outside → `investigate`; wrong sign / missing → `keep_iterating` with hints. `easy_button` report gains a `crosscheck` block when the profile carries `proxy_savings`. **Always area-normalize**: the 5ZoneAirCooled prototype is ~10k ft², so raw E+ savings for a real building are meaningless — `prototype_area_scale` (target ft² / model ft² from `building_area_m2`) is applied automatically and stamped on each verdict as `area_scale` + `ep_savings_kwh_scaled`. Verified live in the Liberty rehearsal (`scripts/agent_twin_demo.py`).
 5. **ASHRAE G14 gates calibration** — monthly NMBE ±5%, CV(RMSE) ≤15% where bills exist. No calibrated-savings claims before the baseline passes. The gate needs a monthly series: `easy_button` patches monthly facility meters into every prototype (`apply_monthly_energy_tables`) and results parsing falls back to `eplusout.mtr` (`parse_monthly_from_mtr`) because E+ 26.1 emits no monthly tabular section for the bundled prototype. Empty `monthly` = fix outputs, never skip the gate.
 6. **Benchmark gate before ROI publication** — `wattlab.benchmarks.guardrails.gate_capital_plan` must run on every capital plan: baseline EUI vs peer band, savings fraction vs scope ceiling, implied post-retrofit EUI, per-measure cost bands, payback floors. Any hit → verdict `INVESTIGATE`; show the deltas, make the human override. Never quietly publish. See [`docs/BENCHMARK_GOVERNANCE.md`](docs/BENCHMARK_GOVERNANCE.md).
-7. **Shared meters are schema, not spreadsheet hacks** — `campus.json` declares meter → building relationships. Allocation modes (`area_weighted` / `equal` / `gas_share` / `manual`) are side-by-side **scenarios**, none is "truth" until submetered evidence exists. Liberty (`examples/liberty/`) is the canonical practice campus.
+7. **Shared meters are schema, not spreadsheet hacks** — `campus.json` declares meter → building relationships. Allocation modes (`area_weighted` / `equal` / `gas_share` / `manual`) are side-by-side **scenarios**, none is "truth" until submetered evidence exists. `examples/liberty/` is a **practice example** for both vibe19 and vibe20 — never hardcode Liberty ids, Detroit coords, or bill filenames in package logic; real sites ship their own `campus.json` + CSVs.
+7b. **Data-model driven sites** — Haystack-style maps (vibe19 `column_map` / `points` → CSV headers) and campus `bill_columns` are the portable contract. Heuristics are fallbacks only. Never invent office/Madison/Chicago/Detroit defaults for a production dump or campus.
+7c. **Fuel Weather** — Studio page for campus bills × Open-Meteo HDD/CDD (base 65°F) + R². Coords from `campus.json` or the form. Interval meter UI is Phase 2 using the vibe19 Haystack map shape.
 8. **Costs are range + basis + vintage + confidence** — `retrofit_costs_public.json` rows carry `unit_basis` (building_ft2 vs glazing_ft2 …), `currency_year`, `confidence`. Historical LBNL medians are reference bands, **never** current-year bids. Windows math on glazing area, chillers on building area — never mix.
 9. **EUI units are kBtu/ft²-year (site)** — conversions: 1 kWh = 3,412 Btu; 1 Mcf gas = 1.037 MMBtu; 1 therm = 100 kBtu. Peer bands from `benchmarks_public.json` (EPA PM medians, CBECS 70.6 fallback).
 10. **Docker-only EnergyPlus** — pinned image via `wattlab.energyplus.docker`; run manifests (`run_manifest.json`) record model/weather SHA + image on every run. Docker tests skip when the image is missing — that's fine.
 11. **Dry-run first** — `run_easy_button(profile, dry_run=True)` and the Studio "Dry-run plan" path must always work without Docker. Never make a feature Docker-mandatory when a plan/preview is possible.
 12. **Weather** — AMY EPW from `weather_observed.csv` / Open-Meteo (`wattlab.weather.epw`); Weather-Man OAT bin tables (5°F × 3 shifts + MCWB) in `wattlab.weather.bins` (built-in NOAA Washington DC table + `from_hourly`). Calibration weather and degree-day benchmarking are separate use cases — don't conflate.
 13. **The vibe19 dump is the seed** — start with `wattlab twin <dump.zip>` (or `wattlab.seed.load_bundle` + `gap_report`). Read `MANIFEST.json` first. Required human fields: `building_type`, `city`, `floor_area_ft2` (plus `lat`/`lon` for AMY calibrate). **Never invent office/Madison/Chicago** for a real dump. Prefer `fdd_findings.csv` over `fdd_summary.csv`. See [`DATA_CONTRACT.md`](DATA_CONTRACT.md) and the **Tomorrow demo** section in [`../AGENTS.md`](../AGENTS.md).
-14. **No client data in git** — the Liberty CSVs are approved for the repo; any other building's bills/BAS exports need explicit user sign-off before committing.
+14. **No client data in git** — example/practice CSVs under `examples/liberty/` are **gitignored**; CI uses `tests/fixtures/shared_meter_campus/`. Any other building's bills/BAS exports need explicit user sign-off before committing.
 15. **Studio smoke before claiming done / before GHCR merge** —
     ```text
     python scripts/smoke_studio.py
@@ -34,8 +36,8 @@ Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
     python scripts/browser_smoke_vibe20.py --url http://localhost:8520 \
         --screenshots .artifacts/browser/native
     ```
-    AppTest walk must cover all pages (including Data Explorer + Assumption
-    Ledger) with 0 exceptions; live check: `/_stcore/health` → `ok`. Playwright
+    AppTest walk must cover all pages (including Data Explorer, Assumption
+    Ledger, **Fuel Weather**) with 0 exceptions; live check: `/_stcore/health` → `ok`. Playwright
     is a local/agent gate (not inside vibe20-ghcr.yml).
 16. **Streamlit conventions** — `width='stretch'` (never deprecated `use_container_width`), unique `key=` on every widget/chart, Plotly for charts (look-and-feel follows vibe19).
 17. **Session log discipline** — append `../SESSION_LOG.md` (newest first) after every shipped session; update skills/docs here when behavior changes.
@@ -96,7 +98,8 @@ Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
 | `wattlab/privacy/` | Hash-only proprietary-content scanner |
 | `wattlab/studio/pages/` | Streamlit page modules (Hypothesis Lab, Easy Buttons, …) |
 | `wattlab/seed/` | vibe19 dump loader + gap report |
-| `wattlab/benchmarks/` | EUI peer bands, cost bands, campus/meters/allocation, ROI guardrail gate |
+| `wattlab/benchmarks/` | EUI peer bands, cost bands, campus/meters/allocation, fuel_weather, ROI guardrail gate |
+| `wattlab/weather/degree_days.py` | HDD/CDD (base 65°F) from hourly OAT |
 | `wattlab/weather/bins.py` | Weather-Man OAT bins (5°F × 3 shifts, MCWB, psychrometrics) |
 | `wattlab/weather/epw.py` | AMY EPW builder |
 | `wattlab/bench/` | Proxy calculators + ESCO bin-method calculators (`esco.py`) |
@@ -108,12 +111,13 @@ Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
 | `wattlab/energyplus/` | Docker, MCP, results parse, manifests, IDF patches |
 | `wattlab/measures/` | Good / Better / Best measure sets |
 | `wattlab/cli.py` | `wattlab` CLI (defaults / easy-button / calibrate / bridge / epw / bench / crosscheck / benchmark / seed / studio) |
-| `studio.py` | WattLab Studio (Ingest / Model / Benchmark / Measures / Twin loop / Capital plan) |
-| `scripts/smoke_studio.py` | AppTest smoke walk (all pages + loaded Liberty walk) |
-| `scripts/agent_twin_demo.py` | Full twin-loop rehearsal on Liberty (real Docker E+ baseline + ECMs) |
+| `studio.py` | WattLab Studio (Ingest / … / Benchmark / Fuel Weather / … / Capital plan) |
+| `scripts/smoke_studio.py` | AppTest smoke walk (all pages + fixture campus + Fuel Weather) |
+| `scripts/agent_twin_demo.py` | Full twin-loop rehearsal on practice campus (real Docker E+ baseline + ECMs) |
 | `scripts/school_30yr_rehearsal.py` | Synthetic K-12 30-year hydronic/electrification rehearsal |
 | `examples/school_30yr/` | Fictional school profile and synthetic 2025 bills |
-| `examples/liberty/` | Real shared-meter practice campus (bills + campus.json) |
+| `examples/liberty/` | **Practice** shared-meter campus schema (bill CSVs gitignored) |
+| `tests/fixtures/shared_meter_campus/` | Privacy-safe CI campus + bill CSVs |
 | `wattlab/data/benchmarks/` | `benchmarks_public.json` + `retrofit_costs_public.json` |
 | `wattlab/data/defaults/` | Archetypes / climate / code vintages |
 | `tests/` | Pytest incl. golden ESCO + golden Liberty suites |

--- a/vibe_code_apps_20/vibe20_agent_spec/DATA_CONTRACT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/DATA_CONTRACT.md
@@ -42,30 +42,68 @@ required fields are supplied — never invent office/Chicago defaults.
 
 ## 2. campus.json (utility-meter relationships)
 
-Loaded by `wattlab.benchmarks.Campus.from_json`. Canonical example:
-[`../examples/liberty/campus.json`](../examples/liberty/campus.json).
-Tests: `tests/test_benchmarks_liberty.py`.
+Loaded by `wattlab.benchmarks.Campus.from_json`. **Any site** uses this schema —
+`examples/liberty/` and `tests/fixtures/shared_meter_campus/` are **practice /
+CI examples only**. Never hardcode `campus_id`, building ids, city, or lat/lon
+in Python; put them in the JSON. Tests: `tests/test_benchmarks_liberty.py`.
 
 ```json
 {
-  "campus_id": "liberty",
+  "campus_id": "my_site",
+  "label": "Human label",
+  "siteRef": "optional_haystack_site",
+  "lat": 42.33,
+  "lon": -83.05,
+  "bill_columns": {
+    "month": "Bill Month",
+    "usage": "kWh Total",
+    "demand_kw": "Billed Demand (kW)",
+    "cost_usd": "Total Current Charges ($)"
+  },
   "buildings": [
-    {"building_id": "liberty_50", "floor_area_ft2": 140000, "property_type": "office"}
+    {"building_id": "b1", "floor_area_ft2": 140000, "property_type": "office"}
   ],
   "meters": [
     {"meter_id": "elec_shared", "fuel": "electricity", "unit": "kwh",
-     "file": "Liberty_50_100_Electric_Summary.csv",
-     "serves": ["liberty_50", "liberty_100"],
-     "allocation": {"method": "area_weighted"}}
+     "file": "electric.csv",
+     "serves": ["b1", "b2"],
+     "allocation": {"method": "area_weighted"},
+     "bill_columns": {"month": "Bill Month", "usage": "kWh Total"}}
   ]
 }
 ```
 
 - `serves` length > 1 ⇒ shared meter ⇒ allocation is a **scenario** (`area_weighted` / `equal` / `gas_share` / `manual`).
-- Bill CSVs: month column + usage column (kWh or Mcf) autodetected; thousands
-  separators OK; duplicate bill months summed; demand kW → month max.
+- Optional campus- or meter-level `bill_columns`: logical keys → **exact CSV
+  headers** (same spirit as vibe19 Haystack point→column maps). Heuristics
+  remain as fallback when the map is omitted.
+- Optional `lat`/`lon` (aliases `latitude`/`longitude`) and `siteRef` feed
+  Open-Meteo / Fuel Weather — never invent Detroit/Madison in code.
+- Bill CSVs: month + usage (kWh or Mcf); thousands separators OK; duplicate
+  bill months summed; demand kW → month max.
 - `annual_summary` picks the **latest common complete 12-month window** across
   all meters unless given one.
+
+### 2b. Haystack column maps (vibe19 interval meters — shared contract)
+
+Interval historian CSVs stay **unrewritten**. Mapping is Haystack-style JSON
+(`siteRef`, `equip`/`equipment`, `points`/`column_roles`: point → CSV header).
+Canonical docs live in vibe19:
+
+- [`../../vibe_code_apps_19/docs/COLUMN_MAP_JSON.md`](../../vibe_code_apps_19/docs/COLUMN_MAP_JSON.md)
+- Meter points: `elec-power`, `gas-flow` (rates) → monthly integrate in vibe19
+
+WattLab Studio **Fuel Weather** v1 is monthly campus bills; interval + Haystack
+UI is Phase 2 but **must reuse this map shape** when added — do not invent a
+parallel mapping dialect.
+
+## 2c. Fuel Weather analytics
+
+Modules: `wattlab.weather.degree_days` (HDD/CDD base **65°F**, vibe19 metering
+convention), `wattlab.benchmarks.fuel_weather` (align bills×DD, OLS R²).
+Studio page: **Fuel Weather**. Offline path uses synthetic seasonal OAT for
+AppTest; live path uses `wattlab.weather.open_meteo` with campus/form coords.
+Tests: `tests/test_degree_days_fuel_weather.py`.
 
 ## 3. Building profile (resolve_profile output)
 

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
@@ -2,11 +2,11 @@
 name: wattlab-studio
 description: >-
   Use when working on the WattLab Studio Streamlit app: studio.py pages
-  (Ingest, Model, Benchmark, Hypothesis Lab, ECM Easy Buttons, Measures,
-  Twin loop, EP Results, Capital plan), session state keys, Plotly charts,
+  (Ingest, Model, Benchmark, Fuel Weather, Hypothesis Lab, ECM Easy Buttons,
+  Measures, Twin loop, EP Results, Capital plan), session state keys, Plotly,
   AppTest smoke, guardrail verdict rendering. Triggers on: Studio, Streamlit,
   studio.py, page, AppTest, plotly chart, capital plan UI, benchmark page,
-  Hypothesis Lab, Easy Buttons.
+  Fuel Weather, Hypothesis Lab, Easy Buttons.
 ---
 
 # WattLab Studio — the ESCO cockpit (Streamlit)
@@ -15,30 +15,45 @@ Human-facing side of the twin loop. Launch: `wattlab studio` (or
 `streamlit run studio.py`). Look-and-feel follows vibe19: Plotly charts,
 lazy pages, wide layout. Page modules live under `wattlab/studio/pages/`.
 
+## Hard rule — data-model driven sites
+
+- **Never hardcode** Liberty / Detroit / Madison / building ids / bill filenames
+  into page logic. Sites are `campus.json` + CSVs (+ optional Haystack maps).
+- `examples/liberty/` and the shared-meter fixture are **examples / CI only**.
+- Lat/lon: from `campus.json` (`lat`/`lon`) or the form — required for live
+  Open-Meteo, never a baked-in city.
+- Column maps: monthly `bill_columns` on campus/meters; interval Phase 2 must
+  reuse vibe19 Haystack `points` → CSV header maps
+  (`../vibe_code_apps_19/docs/COLUMN_MAP_JSON.md`).
+
 ## Pages and state keys
 
 | Page | Does | Key session keys |
 | --- | --- | --- |
 | Ingest | vibe19 dump upload → summary, gap checklist, fault highlights | `studio_bundle` |
+| Data Explorer | dump tables + telemetry browse | (bundle) |
+| Assumption Ledger | read-only provenance | profile / bundle / hypothesis |
 | Model | resolve_profile form + provenance + calibration badge | `studio_profile` |
-| Benchmark | campus.json bills → EUIs vs peer bands, allocation scenarios, monthly signatures | `studio_campus`, `studio_benchmark_summary`, `studio_allocation` |
-| Existing Building Hypothesis Lab | sparse-input explore-existing ladder + downloads | `studio_hypothesis_*` |
-| ECM Easy Buttons | catalog-driven proxy / conceptual E+ cards + packages | `studio_ecm_*` |
+| Benchmark | campus.json bills → EUIs vs peer bands, allocation scenarios | `studio_campus`, `studio_benchmark_summary`, `studio_allocation` |
+| Fuel Weather | campus bills × Open-Meteo/synthetic HDD/CDD, heatmaps, R² | `fuel_weather_campus`, `fuel_weather_hourly`, `fuel_weather_meta` |
+| Existing Building Hypothesis Lab | sparse-input explore-existing ladder + downloads | `hypothesis_lab.*` |
+| ECM Easy Buttons | catalog-driven proxy / conceptual E+ cards + packages | `ecm_easy.*` |
 | Measures | measure set + bridge suggestions, ESCO proxy savings, editable costs | `studio_measures`, `studio_proxies`, `studio_costs` |
 | Twin loop | dry-run plan / Docker E+ runs, crosscheck verdicts, manifest history | `studio_plan`, `studio_report` |
 | EP Results | post-sim charts / scorecards | `studio_ep_results` |
 | Capital plan | finance rollup + **guardrail gate** + downloads | `studio_capital_plan`, `studio_guardrail_gate` |
 
-Navigation: `st.sidebar.radio(key="studio_page")`. Liberty campus path is
-pre-filled on Benchmark when `examples/liberty/campus.json` exists.
-Profile/bundle changes must invalidate stale hypothesis/report state.
+Navigation: `st.sidebar.radio(key="studio_page")`. Campus path fields default
+to the **fixture** (or a local example campus when its CSVs exist) — operators
+point at any production `campus.json`. Profile/bundle changes must invalidate
+stale hypothesis/report state.
 
 ## Conventions (do not regress)
 
 1. `width='stretch'` — never the deprecated `use_container_width`.
 2. Unique `key=` on every widget and `st.plotly_chart` (prevents stale reuse).
 3. Dry-run path must work with zero Docker/network. Docker failures show
-   `st.error`, never a traceback.
+   `st.error`, never a traceback. Fuel Weather offline path = synthetic OAT.
 4. Guardrail gate always renders on Capital plan: green `PUBLISH` banner or
    red `INVESTIGATE` with the check table expanded. Never hide failed checks.
 5. Proxy pricing goes through `estimate_proxy_savings` →
@@ -50,7 +65,7 @@ Profile/bundle changes must invalidate stale hypothesis/report state.
 ## Smoke (before claiming done)
 
 ```powershell
-python scripts/smoke_studio.py     # AppTest: bare page walk (9 pages) + Liberty walk
+python scripts/smoke_studio.py     # AppTest: all pages + fixture campus + Fuel Weather
 python -m pytest tests/test_studio_app.py -q
 # live: wattlab studio → http://localhost:8501/_stcore/health → "ok"
 ```
@@ -61,8 +76,8 @@ console output ASCII (Windows cp1252).
 
 ## Adding a page
 
-1. `page_x()` function + entry in `PAGES` + branch in `main()`.
-2. Namespaced state keys (`studio_*`), unique widget keys.
+1. Prefer `wattlab/studio/pages/<name>.py` + entry in `PAGES` + branch in `main()`.
+2. Namespaced state keys (`studio_*` / page prefix), unique widget keys.
 3. Extend `scripts/smoke_studio.py` walk + an AppTest in
    `tests/test_studio_app.py`.
-4. Update this skill + `vibe20_agent_spec/AGENTS.md` map + README page list.
+4. Update this skill + `vibe20_agent_spec/AGENTS.md` + `DATA_CONTRACT.md` + README.

--- a/vibe_code_apps_20/wattlab/benchmarks/fuel_weather.py
+++ b/vibe_code_apps_20/wattlab/benchmarks/fuel_weather.py
@@ -1,0 +1,281 @@
+"""Fuel × weather analytics for the Studio Fuel Weather dashboard.
+
+Aligns campus monthly bills with HDD/CDD, fits simple OLS (gas×HDD,
+electric×CDD), and builds tidy frames for timelines / intensity heatmaps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from wattlab.benchmarks.meters import (
+    KBTU_PER_KWH,
+    KBTU_PER_MCF,
+    THERMS_PER_MCF,
+    Campus,
+    latest_complete_window,
+)
+from wattlab.weather.degree_days import DD_BASE_F, degree_day_meta, monthly_degree_days
+
+MIN_OVERLAP_MONTHS = 6
+
+
+@dataclass(frozen=True)
+class FuelFit:
+    fuel: str
+    x_name: str
+    y_name: str
+    unit: str
+    n: int
+    slope: float
+    intercept: float
+    r2: float
+    base_f: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "fuel": self.fuel,
+            "x": self.x_name,
+            "y": self.y_name,
+            "unit": self.unit,
+            "n_months": self.n,
+            "slope": round(self.slope, 6),
+            "intercept": round(self.intercept, 4),
+            "r2": round(self.r2, 4),
+            "base_f": self.base_f,
+        }
+
+
+def ols_fit(x: np.ndarray, y: np.ndarray) -> tuple[float, float, float]:
+    """Return slope, intercept, R² for y ≈ slope*x + intercept."""
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    mask = np.isfinite(x) & np.isfinite(y)
+    x, y = x[mask], y[mask]
+    n = int(x.size)
+    if n < 2:
+        return float("nan"), float("nan"), float("nan")
+    if float(np.std(x)) < 1e-12:
+        return float("nan"), float("nan"), float("nan")
+    try:
+        slope, intercept = np.polyfit(x, y, 1)
+    except np.linalg.LinAlgError:
+        return float("nan"), float("nan"), float("nan")
+    y_hat = slope * x + intercept
+    ss_res = float(np.sum((y - y_hat) ** 2))
+    ss_tot = float(np.sum((y - y.mean()) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    return float(slope), float(intercept), float(r2)
+
+
+def _usage_to_kbtu(usage: float, fuel: str, unit: str) -> float:
+    u = (unit or "").lower()
+    f = (fuel or "").lower()
+    if f.startswith("elec") or u == "kwh":
+        return float(usage) * KBTU_PER_KWH
+    if u in ("therm", "therms"):
+        return float(usage) * 100.0  # 1 therm = 100 kBtu
+    # default gas as Mcf
+    return float(usage) * KBTU_PER_MCF
+
+
+def meter_monthly_long(campus: Campus) -> pd.DataFrame:
+    """Long frame: month, meter_id, fuel, unit, usage, cost_usd?, demand_kw?, kbtu."""
+    rows: list[dict[str, Any]] = []
+    for m in campus.meters:
+        for _, r in m.bills.iterrows():
+            usage = float(r["usage"]) if pd.notna(r["usage"]) else float("nan")
+            row: dict[str, Any] = {
+                "month": str(r["month"]),
+                "meter_id": m.meter_id,
+                "fuel": m.fuel,
+                "unit": m.unit,
+                "usage": usage,
+                "kbtu": _usage_to_kbtu(usage, m.fuel, m.unit) if np.isfinite(usage) else float("nan"),
+                "serves": ",".join(m.serves),
+                "shared": bool(m.shared),
+            }
+            if "cost_usd" in r and pd.notna(r["cost_usd"]):
+                row["cost_usd"] = float(r["cost_usd"])
+            if "demand_kw" in r and pd.notna(r["demand_kw"]):
+                row["demand_kw"] = float(r["demand_kw"])
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def campus_fuel_totals(campus: Campus, window: list[str] | None = None) -> pd.DataFrame:
+    """Monthly campus totals by fuel (sum of meters; shared elec counted once)."""
+    long = meter_monthly_long(campus)
+    if window is not None:
+        long = long[long["month"].isin(window)]
+    if long.empty:
+        return pd.DataFrame(columns=["month", "fuel", "usage", "kbtu", "demand_kw", "unit"])
+
+    parts: list[pd.DataFrame] = []
+    for fuel, g in long.groupby("fuel"):
+        # One row per meter-month already; summing meters of same fuel is correct
+        # (shared electric appears once as one meter).
+        aggs: dict[str, Any] = {
+            "usage": ("usage", "sum"),
+            "kbtu": ("kbtu", "sum"),
+            "unit": ("unit", "first"),
+        }
+        if "demand_kw" in g.columns:
+            aggs["demand_kw"] = ("demand_kw", "max")
+        agg = g.groupby("month", as_index=False).agg(**aggs)
+        agg.insert(1, "fuel", fuel)
+        parts.append(agg)
+    out = pd.concat(parts, ignore_index=True).sort_values(["month", "fuel"])
+    return out.reset_index(drop=True)
+
+
+def intensity_heatmap_frame(
+    campus: Campus,
+    *,
+    fuel: str,
+    window: list[str] | None = None,
+) -> pd.DataFrame:
+    """Year × month matrix of site kBtu/ft² for one fuel (campus total / total area)."""
+    totals = campus_fuel_totals(campus, window)
+    fuel_key = "electricity" if fuel.startswith("elec") else "gas"
+    sub = totals[totals["fuel"] == fuel_key].copy()
+    if sub.empty:
+        return pd.DataFrame()
+    area = max(campus.total_area_ft2, 1.0)
+    sub["intensity_kbtu_ft2"] = sub["kbtu"] / area
+    sub["year"] = sub["month"].str[:4].astype(int)
+    sub["mon"] = sub["month"].str[5:7].astype(int)
+    mat = sub.pivot_table(
+        index="year", columns="mon", values="intensity_kbtu_ft2", aggfunc="sum"
+    )
+    return mat.reindex(columns=range(1, 13)).sort_index(ascending=False)
+
+
+def demand_heatmap_frame(campus: Campus, window: list[str] | None = None) -> pd.DataFrame:
+    """Year × month matrix of billed demand (kW) from electric meters."""
+    long = meter_monthly_long(campus)
+    if "demand_kw" not in long.columns:
+        return pd.DataFrame()
+    elec = long[long["fuel"] == "electricity"].copy()
+    if window is not None:
+        elec = elec[elec["month"].isin(window)]
+    if elec.empty:
+        return pd.DataFrame()
+    elec["year"] = elec["month"].str[:4].astype(int)
+    elec["mon"] = elec["month"].str[5:7].astype(int)
+    mat = elec.pivot_table(index="year", columns="mon", values="demand_kw", aggfunc="max")
+    return mat.reindex(columns=range(1, 13)).sort_index(ascending=False)
+
+
+def align_fuel_and_degree_days(
+    campus: Campus,
+    hourly_oat: pd.Series | pd.DataFrame,
+    *,
+    base_f: float = DD_BASE_F,
+    months: int = 12,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Join campus fuel totals to monthly HDD/CDD; return frame + analysis window."""
+    dd = monthly_degree_days(hourly_oat, base_f=base_f)
+    totals = campus_fuel_totals(campus)
+    month_sets = [set(m.bills["month"]) for m in campus.meters] + [set(dd["month"])]
+    window = latest_complete_window(month_sets, months=months)
+    if window is None:
+        # Fall back to intersection sorted
+        common = set.intersection(*month_sets) if month_sets else set()
+        window = sorted(common)
+    fuel_w = totals[totals["month"].isin(window)].copy() if window else totals.copy()
+    merged = fuel_w.merge(dd, on="month", how="inner")
+    return merged.sort_values(["month", "fuel"]).reset_index(drop=True), list(window or [])
+
+
+def fit_weather_responses(
+    aligned: pd.DataFrame,
+    *,
+    base_f: float = DD_BASE_F,
+    min_months: int = MIN_OVERLAP_MONTHS,
+) -> list[FuelFit]:
+    """OLS: gas vs HDD, electricity vs CDD (native meter units)."""
+    fits: list[FuelFit] = []
+    specs = (
+        ("gas", "hdd", "Gas vs HDD"),
+        ("electricity", "cdd", "Electric vs CDD"),
+    )
+    for fuel, x_col, _label in specs:
+        sub = aligned[aligned["fuel"] == fuel]
+        if len(sub) < min_months:
+            continue
+        unit = str(sub["unit"].iloc[0])
+        slope, intercept, r2 = ols_fit(sub[x_col].to_numpy(), sub["usage"].to_numpy())
+        if not np.isfinite(r2):
+            continue
+        fits.append(
+            FuelFit(
+                fuel=fuel,
+                x_name=x_col,
+                y_name="usage",
+                unit=unit,
+                n=int(len(sub)),
+                slope=slope,
+                intercept=intercept,
+                r2=r2,
+                base_f=base_f,
+            )
+        )
+    return fits
+
+
+def residual_frame(aligned: pd.DataFrame, fit: FuelFit) -> pd.DataFrame:
+    sub = aligned[aligned["fuel"] == fit.fuel].copy()
+    x = sub[fit.x_name].astype(float)
+    y = sub["usage"].astype(float)
+    sub["predicted"] = fit.slope * x + fit.intercept
+    sub["residual"] = y - sub["predicted"]
+    return sub[["month", "usage", "predicted", "residual", fit.x_name]].reset_index(drop=True)
+
+
+def gas_usage_therms(usage: float, unit: str) -> float:
+    u = (unit or "").lower()
+    if u in ("therm", "therms"):
+        return float(usage)
+    return float(usage) * THERMS_PER_MCF
+
+
+def build_fuel_weather_report(
+    campus: Campus,
+    hourly_oat: pd.Series | pd.DataFrame,
+    *,
+    base_f: float = DD_BASE_F,
+    weather_source: str = "synthetic_or_open_meteo",
+) -> dict[str, Any]:
+    """Bundle aligned series, fits, and provenance for Studio / tests."""
+    aligned, window = align_fuel_and_degree_days(campus, hourly_oat, base_f=base_f)
+    fits = fit_weather_responses(aligned, base_f=base_f)
+    return {
+        "campus_id": campus.campus_id,
+        "label": campus.label,
+        "window": {"start": window[0] if window else None, "end": window[-1] if window else None, "months": window},
+        "degree_days": degree_day_meta(base_f=base_f, source=weather_source),
+        "fits": [f.as_dict() for f in fits],
+        "aligned_rows": int(len(aligned)),
+        "n_fits": len(fits),
+    }
+
+
+__all__ = [
+    "FuelFit",
+    "MIN_OVERLAP_MONTHS",
+    "align_fuel_and_degree_days",
+    "build_fuel_weather_report",
+    "campus_fuel_totals",
+    "demand_heatmap_frame",
+    "fit_weather_responses",
+    "gas_usage_therms",
+    "intensity_heatmap_frame",
+    "meter_monthly_long",
+    "ols_fit",
+    "residual_frame",
+]

--- a/vibe_code_apps_20/wattlab/benchmarks/meters.py
+++ b/vibe_code_apps_20/wattlab/benchmarks/meters.py
@@ -45,19 +45,42 @@ def _find_col(cols: list[str], *needles: str) -> str | None:
     return None
 
 
-def load_bill_csv(path: str | Path) -> pd.DataFrame:
+def load_bill_csv(
+    path: str | Path,
+    column_map: dict[str, str] | None = None,
+) -> pd.DataFrame:
     """Load a monthly utility bill summary CSV into a tidy frame.
 
     Returns columns: ``month`` (YYYY-MM str), ``usage`` (kWh or Mcf),
     ``cost_usd`` and, when present, ``demand_kw``. Duplicate bill months
     (split billing periods) are summed; demand takes the month max.
+
+    Optional ``column_map`` (data-model driven, same spirit as vibe19 Haystack
+    maps) remaps logical keys → exact CSV headers::
+
+        {"month": "Bill Month", "usage": "kWh Total",
+         "demand_kw": "Billed Demand (kW)", "cost_usd": "Total Current Charges ($)"}
+
+    When omitted, header heuristics still apply so example campuses keep working.
     """
     df = pd.read_csv(path, thousands=",")
     cols = list(df.columns)
-    month_col = _find_col(cols, "month") or cols[0]
-    usage_col = _find_col(cols, "kwh") or _find_col(cols, "usage") or cols[1]
-    cost_col = _find_col(cols, "charges") or _find_col(cols, "cost")
-    demand_col = _find_col(cols, "billed", "demand")
+    cmap = {str(k): str(v) for k, v in (column_map or {}).items()}
+
+    def _mapped(logical: str, *needles: str, fallback: str | None = None) -> str | None:
+        if logical in cmap and cmap[logical] in df.columns:
+            return cmap[logical]
+        found = _find_col(cols, *needles) if needles else None
+        return found or fallback
+
+    month_col = _mapped("month", "month", fallback=cols[0])
+    usage_col = (
+        _mapped("usage", "kwh")
+        or _mapped("usage", "usage")
+        or (cols[1] if len(cols) > 1 else cols[0])
+    )
+    cost_col = _mapped("cost_usd", "charges") or _mapped("cost_usd", "cost")
+    demand_col = _mapped("demand_kw", "billed", "demand") or _mapped("demand_kw", "demand")
 
     out = pd.DataFrame({
         "month": df[month_col].astype(str).str.strip().str[:7],
@@ -119,6 +142,10 @@ class Campus:
     meters: list[Meter]
     notes: str = ""
     source: str = ""
+    # Optional site coords for Open-Meteo / Fuel Weather — from campus.json, never code defaults.
+    lat: float | None = None
+    lon: float | None = None
+    site_ref: str | None = None
 
     @classmethod
     def from_json(cls, path: str | Path) -> "Campus":
@@ -127,8 +154,8 @@ class Campus:
             raise FileNotFoundError(
                 f"Campus config not found: {p}. "
                 "Checked-in demo: tests/fixtures/shared_meter_campus/campus.json. "
-                "Local Liberty CSVs under examples/liberty/ are gitignored — "
-                "copy them beside campus.json or point Studio at the fixture."
+                "Any campus.json + sibling bill CSVs work — examples/liberty/ is practice "
+                "data only (gitignored CSVs), not a production building id."
             )
         doc = json.loads(p.read_text(encoding="utf-8"))
         buildings = [
@@ -149,8 +176,8 @@ class Campus:
             raise FileNotFoundError(
                 f"Campus {p} references missing bill CSV(s): {', '.join(missing)}. "
                 "Use tests/fixtures/shared_meter_campus/ for the privacy-safe demo, "
-                "or place local meter CSVs next to campus.json (examples/liberty CSVs "
-                "are gitignored on purpose)."
+                "or place meter CSVs next to campus.json (example CSVs under "
+                "examples/liberty/ are gitignored on purpose)."
             )
         meters = [
             Meter(
@@ -158,11 +185,16 @@ class Campus:
                 fuel=str(m["fuel"]),
                 unit=str(m.get("unit") or ("kwh" if m["fuel"] == "electricity" else "mcf")),
                 serves=[str(s) for s in m.get("serves", [])],
-                bills=load_bill_csv(p.parent / m["file"]),
+                bills=load_bill_csv(
+                    p.parent / m["file"],
+                    column_map=m.get("bill_columns") or doc.get("bill_columns"),
+                ),
                 allocation=dict(m.get("allocation") or {}),
             )
             for m in doc.get("meters", [])
         ]
+        lat = doc.get("lat", doc.get("latitude"))
+        lon = doc.get("lon", doc.get("longitude"))
         return cls(
             campus_id=str(doc.get("campus_id") or p.stem),
             label=str(doc.get("label") or doc.get("campus_id") or p.stem),
@@ -170,6 +202,11 @@ class Campus:
             meters=meters,
             notes=str(doc.get("notes") or ""),
             source=str(p),
+            lat=float(lat) if lat is not None else None,
+            lon=float(lon) if lon is not None else None,
+            site_ref=str(doc["siteRef"]) if doc.get("siteRef") else (
+                str(doc["site_ref"]) if doc.get("site_ref") else None
+            ),
         )
 
     def building(self, building_id: str) -> BuildingRef:

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_weather.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_weather.py
@@ -1,0 +1,375 @@
+"""Fuel Weather — campus bills × Open-Meteo HDD/CDD dashboard.
+
+Data-model driven: any ``campus.json`` + meter CSVs. Example campuses
+(``examples/liberty``, CI fixture) are practice data only — lat/lon and
+ids come from the JSON, never from hardcoded production building logic.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+from wattlab.benchmarks.fuel_weather import (
+    align_fuel_and_degree_days,
+    build_fuel_weather_report,
+    campus_fuel_totals,
+    demand_heatmap_frame,
+    fit_weather_responses,
+    intensity_heatmap_frame,
+    meter_monthly_long,
+    residual_frame,
+)
+from wattlab.benchmarks.meters import Campus
+from wattlab.config import ARTIFACTS
+from wattlab.contracts import WeatherRequest
+from wattlab.weather.degree_days import DD_BASE_F
+from wattlab.weather.open_meteo import download_archive_weather
+
+ROOT = Path(__file__).resolve().parents[3]
+# CI / AppTest default — privacy-safe fixture, not a named customer site.
+DEFAULT_CAMPUS = ROOT / "tests" / "fixtures" / "shared_meter_campus" / "campus.json"
+# Optional practice example path (gitignored CSVs); only used when loadable.
+EXAMPLE_CAMPUS = ROOT / "examples" / "liberty" / "campus.json"
+
+
+def resolve_default_campus_path() -> Path:
+    """Default to the checked-in fixture; use a local example campus only if complete."""
+    if EXAMPLE_CAMPUS.is_file():
+        try:
+            Campus.from_json(EXAMPLE_CAMPUS)
+            return EXAMPLE_CAMPUS
+        except FileNotFoundError:
+            pass
+    return DEFAULT_CAMPUS
+
+
+def _coords_from_campus(campus: Campus) -> tuple[float | None, float | None]:
+    return campus.lat, campus.lon
+
+
+def _synthetic_hourly_for_campus(campus: Campus) -> pd.Series:
+    """Offline seasonal OAT for AppTest / no-network demos (not site-specific climate)."""
+    months = sorted(set.intersection(*(m.months() for m in campus.meters)))
+    if not months:
+        months = sorted({m for meter in campus.meters for m in meter.months()})
+    start = datetime.fromisoformat(f"{months[0]}-01")
+    y, mo = map(int, months[-1].split("-"))
+    end = datetime(y + (1 if mo == 12 else 0), 1 if mo == 12 else mo + 1, 1)
+    hours = max(int((end - start).total_seconds() // 3600), 24)
+    idx = pd.date_range(start, periods=hours, freq="h")
+    temps = [
+        float(35.0 + 30.0 * np.sin(2 * np.pi * (ts.timetuple().tm_yday - 80) / 365.0))
+        for ts in idx
+    ]
+    return pd.Series(temps, index=idx, name="dry_bulb_f")
+
+
+def _fetch_open_meteo(campus: Campus, lat: float, lon: float) -> tuple[pd.DataFrame, dict[str, Any]]:
+    months = sorted(set.intersection(*(m.months() for m in campus.meters)))
+    if not months:
+        raise ValueError("Campus has no overlapping bill months")
+    start = date.fromisoformat(f"{months[0]}-01")
+    y, mo = map(int, months[-1].split("-"))
+    if mo == 12:
+        end = date(y, 12, 31)
+    else:
+        end = date(y, mo + 1, 1) - timedelta(days=1)
+    today = date.today()
+    if end >= today:
+        end = today - timedelta(days=2)
+    if end < start:
+        raise ValueError(f"Bill window {start}→{end} is not fetchable yet from Open-Meteo")
+    req = WeatherRequest(
+        latitude=lat,
+        longitude=lon,
+        start_date=start,
+        end_date=end,
+        allow_partial=True,
+    )
+    cache = ARTIFACTS / "open_meteo_cache"
+    df, meta = download_archive_weather(req, cache_dir=cache)
+    return df, meta.model_dump(mode="json")
+
+
+def render(*, campus: Campus | None = None) -> None:
+    import plotly.express as px
+    import plotly.graph_objects as go
+
+    st.header("Fuel Weather — bills × degree days")
+    st.caption(
+        "Monthly utility summaries via **campus.json** (any site) with Open-Meteo "
+        f"HDD/CDD (base {DD_BASE_F:g}°F). Lat/lon come from the campus file or the "
+        "form — never from hard-coded project cities. Interval meters use vibe19 "
+        "Haystack ``column_map`` (Phase 2); monthly ``bill_columns`` maps are supported now."
+    )
+
+    default = resolve_default_campus_path()
+    path = st.text_input(
+        "campus.json path (buildings + meter bill CSVs)",
+        value=str(st.session_state.get("fuel_weather_campus_path", default)),
+        key="fuel_weather_campus_path_input",
+        help=(
+            "Schema-driven: any campus.json + sibling CSVs. "
+            "CI default is tests/fixtures/shared_meter_campus/. "
+            "examples/liberty/ is a practice example when local CSVs exist."
+        ),
+    )
+
+    campus_preview_lat = None
+    campus_preview_lon = None
+    existing = campus or st.session_state.get("fuel_weather_campus")
+    if existing is not None:
+        campus_preview_lat, campus_preview_lon = _coords_from_campus(existing)
+
+    c_load, c_lat, c_lon = st.columns([2, 1, 1])
+    with c_load:
+        load = st.button("Load campus bills", key="fuel_weather_load_campus")
+    with c_lat:
+        lat_str = st.text_input(
+            "Latitude",
+            value="" if campus_preview_lat is None else str(campus_preview_lat),
+            key="fuel_weather_lat",
+            help="From campus.json lat/latitude, or type a value. No city hardcodes.",
+        )
+    with c_lon:
+        lon_str = st.text_input(
+            "Longitude",
+            value="" if campus_preview_lon is None else str(campus_preview_lon),
+            key="fuel_weather_lon",
+            help="From campus.json lon/longitude, or type a value. No city hardcodes.",
+        )
+
+    if load:
+        try:
+            loaded = Campus.from_json(path.strip())
+            st.session_state["fuel_weather_campus"] = loaded
+            st.session_state["fuel_weather_campus_path"] = path.strip()
+            st.session_state.pop("fuel_weather_hourly", None)
+            st.session_state.pop("fuel_weather_meta", None)
+            st.success(
+                f"Loaded {loaded.label} (id={loaded.campus_id}"
+                + (f", siteRef={loaded.site_ref}" if loaded.site_ref else "")
+                + f"): {len(loaded.buildings)} buildings, {len(loaded.meters)} meters."
+            )
+            if loaded.lat is None or loaded.lon is None:
+                st.warning(
+                    "campus.json has no lat/lon — enter coordinates before Fetch Open-Meteo, "
+                    "or add \"lat\"/\"lon\" (or latitude/longitude) to the campus file."
+                )
+        except Exception as exc:
+            st.error(f"Could not load campus: {exc}")
+
+    campus = campus or st.session_state.get("fuel_weather_campus")
+    if campus is None:
+        st.info(
+            "Load any campus.json to start. Practice examples: "
+            "`examples/liberty/campus.json` (local CSVs) or the checked-in fixture. "
+            "Production sites: ship your own campus.json + bill CSVs + coords."
+        )
+        return
+
+    st.subheader("Meters")
+    meter_rows = [
+        {
+            "meter_id": m.meter_id,
+            "fuel": m.fuel,
+            "unit": m.unit,
+            "shared": m.shared,
+            "serves": ", ".join(m.serves),
+            "months": len(m.bills),
+            "first": m.bills["month"].iloc[0] if len(m.bills) else "—",
+            "last": m.bills["month"].iloc[-1] if len(m.bills) else "—",
+        }
+        for m in campus.meters
+    ]
+    st.dataframe(pd.DataFrame(meter_rows), width="stretch", hide_index=True)
+
+    wx_col1, wx_col2 = st.columns(2)
+    with wx_col1:
+        fetch = st.button("Fetch Open-Meteo (live)", key="fuel_weather_fetch")
+    with wx_col2:
+        synth = st.button("Use synthetic seasonal OAT (offline)", key="fuel_weather_synth")
+
+    if fetch:
+        lat_use = lon_use = None
+        try:
+            if str(lat_str).strip():
+                lat_use = float(lat_str)
+            elif campus.lat is not None:
+                lat_use = float(campus.lat)
+            if str(lon_str).strip():
+                lon_use = float(lon_str)
+            elif campus.lon is not None:
+                lon_use = float(campus.lon)
+        except ValueError:
+            st.error("lat/lon must be numeric.")
+            lat_use = lon_use = None
+        if lat_use is None or lon_use is None:
+            st.error(
+                "lat/lon required — put them on campus.json (`lat`/`lon`) or the form. "
+                "Never rely on a hard-coded city."
+            )
+        else:
+            try:
+                with st.spinner("Downloading Open-Meteo archive…"):
+                    df, meta = _fetch_open_meteo(campus, float(lat_use), float(lon_use))
+                st.session_state["fuel_weather_hourly"] = df
+                st.session_state["fuel_weather_meta"] = meta
+                st.success(
+                    f"Open-Meteo OK — {meta.get('rows')} hourly rows, "
+                    f"sha {str(meta.get('sha256', ''))[:12]}…"
+                )
+            except Exception as exc:
+                st.error(f"Open-Meteo fetch failed: {exc}")
+
+    if synth:
+        s = _synthetic_hourly_for_campus(campus)
+        st.session_state["fuel_weather_hourly"] = s.to_frame(name="dry_bulb_f")
+        st.session_state["fuel_weather_meta"] = {
+            "source": "synthetic_seasonal",
+            "rows": int(len(s)),
+            "note": "Offline demo OAT — not measured weather",
+        }
+        st.warning("Using synthetic seasonal OAT (offline). Prefer Open-Meteo for real R².")
+
+    hourly = st.session_state.get("fuel_weather_hourly")
+    meta = st.session_state.get("fuel_weather_meta") or {}
+
+    st.subheader("Fuel timeline")
+    totals = campus_fuel_totals(campus)
+    if totals.empty:
+        st.warning("No bill rows to plot.")
+        return
+    for fuel, g in totals.groupby("fuel"):
+        unit = str(g["unit"].iloc[0])
+        fig = px.line(
+            g, x="month", y="usage", markers=True,
+            title=f"{fuel.title()} usage ({unit})",
+            labels={"usage": unit, "month": "Bill month"},
+        )
+        fig.update_layout(height=320, margin=dict(l=10, r=10, t=40, b=10))
+        st.plotly_chart(fig, width="stretch")
+
+    long = meter_monthly_long(campus)
+    if "demand_kw" in long.columns and long["demand_kw"].notna().any():
+        elec_d = long[long["fuel"] == "electricity"].dropna(subset=["demand_kw"])
+        if not elec_d.empty:
+            fig_d = px.line(
+                elec_d, x="month", y="demand_kw", color="meter_id", markers=True,
+                title="Billed demand (kW)",
+            )
+            fig_d.update_layout(height=300, margin=dict(l=10, r=10, t=40, b=10))
+            st.plotly_chart(fig_d, width="stretch")
+
+    st.subheader("Intensity & demand heatmaps")
+    h1, h2, h3 = st.columns(3)
+    with h1:
+        mat_e = intensity_heatmap_frame(campus, fuel="electricity")
+        if not mat_e.empty:
+            fig = px.imshow(
+                mat_e, aspect="auto", color_continuous_scale="YlOrRd",
+                labels=dict(color="kBtu/ft²", x="Month", y="Year"),
+                title="Electric intensity",
+            )
+            st.plotly_chart(fig, width="stretch")
+        else:
+            st.caption("No electric intensity matrix.")
+    with h2:
+        mat_g = intensity_heatmap_frame(campus, fuel="gas")
+        if not mat_g.empty:
+            fig = px.imshow(
+                mat_g, aspect="auto", color_continuous_scale="Blues",
+                labels=dict(color="kBtu/ft²", x="Month", y="Year"),
+                title="Gas intensity",
+            )
+            st.plotly_chart(fig, width="stretch")
+        else:
+            st.caption("No gas intensity matrix.")
+    with h3:
+        mat_d = demand_heatmap_frame(campus)
+        if not mat_d.empty:
+            fig = px.imshow(
+                mat_d, aspect="auto", color_continuous_scale="Viridis",
+                labels=dict(color="kW", x="Month", y="Year"),
+                title="Billed demand",
+            )
+            st.plotly_chart(fig, width="stretch")
+        else:
+            st.caption("No demand_kw in bill CSVs.")
+
+    st.subheader("Weather response (HDD / CDD)")
+    if hourly is None:
+        st.info("Fetch Open-Meteo or use synthetic OAT to compute HDD/CDD regressions.")
+        return
+
+    if meta:
+        st.caption(
+            f"Weather: {meta.get('source', '?')} · rows={meta.get('rows', '?')} · "
+            f"base {DD_BASE_F:g}°F"
+        )
+
+    aligned, window = align_fuel_and_degree_days(campus, hourly)
+    if not window:
+        st.warning("No overlapping months between bills and weather.")
+        return
+    st.caption(f"Analysis window: {window[0]} → {window[-1]} ({len(window)} months)")
+
+    fits = fit_weather_responses(aligned)
+    if not fits:
+        st.warning(f"Need ≥6 overlapping months for R² fits (have aligned rows={len(aligned)}).")
+        return
+
+    mcols = st.columns(len(fits))
+    for col, fit in zip(mcols, fits):
+        col.metric(
+            f"{fit.fuel} R² ({fit.x_name.upper()})",
+            f"{fit.r2:.3f}",
+            help=f"y = {fit.slope:.4g}·{fit.x_name} + {fit.intercept:.4g} ({fit.unit}), n={fit.n}",
+        )
+
+    for fit in fits:
+        sub = aligned[aligned["fuel"] == fit.fuel]
+        fig = go.Figure()
+        fig.add_scatter(
+            x=sub[fit.x_name], y=sub["usage"], mode="markers",
+            name="Bills", text=sub["month"],
+            hovertemplate="%{text}: %{y:.1f} @ %{x:.1f}<extra></extra>",
+        )
+        x_line = np.linspace(float(sub[fit.x_name].min()), float(sub[fit.x_name].max()), 50)
+        fig.add_scatter(
+            x=x_line, y=fit.slope * x_line + fit.intercept, mode="lines",
+            name=f"Fit R²={fit.r2:.3f}",
+        )
+        fig.update_layout(
+            title=f"{fit.fuel.title()} vs {fit.x_name.upper()} (base {fit.base_f:g}°F)",
+            xaxis_title=fit.x_name.upper(),
+            yaxis_title=fit.unit,
+            height=360,
+            margin=dict(l=10, r=10, t=40, b=10),
+        )
+        st.plotly_chart(fig, width="stretch")
+        res = residual_frame(aligned, fit)
+        fig_r = px.bar(res, x="month", y="residual", title=f"{fit.fuel.title()} residuals")
+        fig_r.update_layout(height=240, margin=dict(l=10, r=10, t=40, b=10))
+        st.plotly_chart(fig_r, width="stretch")
+
+    report = build_fuel_weather_report(
+        campus, hourly,
+        weather_source=str(meta.get("source") or "unknown"),
+    )
+    with st.expander("Fuel weather report JSON"):
+        st.json(report)
+
+    st.caption(
+        "Haystack (vibe19): interval meters use `equip`/`points` maps "
+        "(`elec-power`/`gas-flow` → CSV headers) — see "
+        "`vibe_code_apps_19/docs/COLUMN_MAP_JSON.md`. "
+        "Monthly bills use campus `bill_columns` or header heuristics. "
+        "Interval Fuel Weather UI is Phase 2."
+    )

--- a/vibe_code_apps_20/wattlab/weather/degree_days.py
+++ b/vibe_code_apps_20/wattlab/weather/degree_days.py
@@ -1,0 +1,76 @@
+"""Heating / cooling degree days from hourly dry-bulb (°F).
+
+Matches the vibe19 metering convention: base 65°F, daily mean OAT, then
+monthly sums. Used by the Studio Fuel Weather dashboard (not by AMY EPW).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+DD_BASE_F = 65.0
+
+
+def daily_mean_oat_f(hourly: pd.Series | pd.DataFrame, *, col: str = "dry_bulb_f") -> pd.Series:
+    """Daily mean outdoor air temperature (°F) from an hourly series/frame."""
+    if isinstance(hourly, pd.DataFrame):
+        if col not in hourly.columns:
+            raise KeyError(f"hourly frame missing {col!r}")
+        s = hourly[col]
+    else:
+        s = hourly
+    if not isinstance(s.index, pd.DatetimeIndex):
+        raise TypeError("hourly series/frame must have a DatetimeIndex")
+    return s.astype(float).groupby(s.index.floor("D")).mean()
+
+
+def degree_days_from_daily(
+    daily_mean_f: pd.Series,
+    *,
+    base_f: float = DD_BASE_F,
+) -> pd.DataFrame:
+    """Per-day HDD/CDD from daily mean OAT (°F)."""
+    mean = daily_mean_f.astype(float)
+    hdd = (base_f - mean).clip(lower=0.0)
+    cdd = (mean - base_f).clip(lower=0.0)
+    out = pd.DataFrame({"hdd": hdd, "cdd": cdd, "mean_oat_f": mean})
+    out.index = pd.DatetimeIndex(out.index)
+    return out
+
+
+def monthly_degree_days(
+    hourly: pd.Series | pd.DataFrame,
+    *,
+    col: str = "dry_bulb_f",
+    base_f: float = DD_BASE_F,
+) -> pd.DataFrame:
+    """Monthly HDD/CDD table: columns month (YYYY-MM), hdd, cdd, mean_oat_f, n_days."""
+    daily = degree_days_from_daily(daily_mean_oat_f(hourly, col=col), base_f=base_f)
+    g = daily.groupby(daily.index.strftime("%Y-%m"))
+    out = g.agg(
+        hdd=("hdd", "sum"),
+        cdd=("cdd", "sum"),
+        mean_oat_f=("mean_oat_f", "mean"),
+        n_days=("hdd", "count"),
+    ).reset_index(names="month")
+    return out.sort_values("month").reset_index(drop=True)
+
+
+def degree_day_meta(*, base_f: float = DD_BASE_F, source: str = "open-meteo-archive") -> dict[str, Any]:
+    return {
+        "base_f": float(base_f),
+        "source": source,
+        "method": "daily_mean_oat_then_monthly_sum",
+        "convention": "vibe19_metering_DD_BASE_F",
+    }
+
+
+__all__ = [
+    "DD_BASE_F",
+    "daily_mean_oat_f",
+    "degree_days_from_daily",
+    "monthly_degree_days",
+    "degree_day_meta",
+]


### PR DESCRIPTION
## Summary
- New Studio **Fuel Weather** page: any campus.json + bill CSVs → timelines, kBtu/demand heatmaps, Open-Meteo or synthetic HDD/CDD (base 65F), gas×HDD / elec×CDD R2
- Data-model driven: optional bill_columns, lat/lon/siteRef on campus JSON — no Liberty/Detroit hardcodes; Liberty remains a practice example for vibe19+20
- Agent spec updated (vibe20_agent_spec DATA_CONTRACT / AGENTS / studio skill) including Haystack column-map contract for interval Phase 2
- Also includes prior local docs commits: Studio-first README slim + design spec

## Test plan
- [x] python -m pytest -q (616 passed, 8 skipped)
- [x] python scripts/smoke_studio.py (12 pages + Fuel Weather synth path)
- [ ] Merge → watch vibe20-ghcr → verify :latest / :sha-* multi-arch
- [ ] Optional: pull GHCR on :8520 and browser smoke