### PR TITLE
Fix Vibe 20 Windows energy package uploads

### DIFF
--- a/vibe_code_apps_20/tests/test_energy_use_windows_zip.py
+++ b/vibe_code_apps_20/tests/test_energy_use_windows_zip.py
@@ -6,7 +6,10 @@ import json
 import zipfile
 from pathlib import Path
 
+import pytest
+
 from wattlab.energy_use import load_energy_use_package
+from wattlab.energy_use.package import _extract_zip
 
 
 def test_windows_zip_separators_discover_wrapped_campus_package(tmp_path: Path):
@@ -39,3 +42,22 @@ def test_windows_zip_separators_discover_wrapped_campus_package(tmp_path: Path):
 
     assert loaded.campus is not None
     assert loaded.campus.campus_id == "demo"
+
+
+@pytest.mark.parametrize(
+    "arcname",
+    [
+        "../escape.txt",
+        "/tmp/escape.txt",
+        "C:/Windows/escape.txt",
+        "C:\\Windows\\escape.txt",
+        "//server/share/escape.txt",
+    ],
+)
+def test_extract_zip_rejects_unsafe_member_paths(tmp_path: Path, arcname: str):
+    archive = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr(arcname, b"nope")
+
+    with pytest.raises(ValueError, match="Unsafe path"):
+        _extract_zip(archive)

--- a/vibe_code_apps_20/tests/test_energy_use_windows_zip.py
+++ b/vibe_code_apps_20/tests/test_energy_use_windows_zip.py
@@ -1,0 +1,41 @@
+"""Regression coverage for Windows-created energy-use archives."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from wattlab.energy_use import load_energy_use_package
+
+
+def test_windows_zip_separators_discover_wrapped_campus_package(tmp_path: Path):
+    package = tmp_path / "campus_liberty_practice"
+    package.mkdir()
+    (package / "campus.json").write_text(
+        json.dumps(
+            {
+                "campus_id": "demo",
+                "label": "Demo",
+                "lat": 42.0,
+                "lon": -83.0,
+                "buildings": [],
+                "meters": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (package / "bill_column_map.json").write_text(
+        json.dumps({"version": 1, "siteRef": "demo"}),
+        encoding="utf-8",
+    )
+
+    archive = tmp_path / "campus.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        for path in package.iterdir():
+            zf.write(path, arcname=f"campus_liberty_practice\\{path.name}")
+
+    loaded = load_energy_use_package(archive)
+
+    assert loaded.campus is not None
+    assert loaded.campus.campus_id == "demo"

--- a/vibe_code_apps_20/tests/test_studio_app.py
+++ b/vibe_code_apps_20/tests/test_studio_app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import socket
 import subprocess
 import time
@@ -119,7 +120,7 @@ def test_turnkey_live_html_smoke():
     port = _free_port()
     proc = subprocess.Popen(
         [
-            "python",
+            sys.executable,
             "-m",
             "streamlit",
             "run",

--- a/vibe_code_apps_20/wattlab/energy_use/package.py
+++ b/vibe_code_apps_20/wattlab/energy_use/package.py
@@ -48,25 +48,48 @@ def _unwrap_root(path: Path) -> Path:
     return path
 
 
-def _extract_zip(zip_path: Path) -> Path:
-    dest = Path(tempfile.mkdtemp(prefix="energy_use_"))
-    with zipfile.ZipFile(zip_path, "r") as zf:
-        # Windows-created archives may store directory separators as ``\\``.
-        # On Linux that backslash is a literal character, so a valid
-        # ``folder\\campus.json`` entry otherwise looks like a missing campus
-        # file after extraction. Normalize separators and retain explicit
-        # zip-slip protection while extracting.
-        for member in zf.infolist():
-            normalized_name = member.filename.replace("\\", "/")
-            member_path = PurePosixPath(normalized_name)
-            if member_path.is_absolute() or ".." in member_path.parts:
-                raise ValueError(f"Unsafe path in energy-use zip: {member.filename!r}")
+def _zip_member_parts(filename: str) -> tuple[str, ...]:
+    """Normalize archive member paths and reject zip-slip / absolute entries.
 
-            parts = tuple(part for part in member_path.parts if part not in ("", "."))
+    Windows-created archives may store separators as ``\\``. On Linux that
+    backslash is a literal character, so ``folder\\\\campus.json`` otherwise
+    looks missing after extract. Also reject drive-letter and UNC forms —
+    ``PurePosixPath('C:/foo').is_absolute()`` is False, which would otherwise
+    allow escape on a Windows host.
+    """
+    normalized = filename.replace("\\", "/")
+    member_path = PurePosixPath(normalized)
+    parts = tuple(part for part in member_path.parts if part not in ("", "."))
+    if not parts:
+        return ()
+    if (
+        member_path.is_absolute()
+        or ".." in parts
+        or any(part.endswith(":") for part in parts)
+        or (len(parts) >= 2 and parts[0] in ("/", "//"))
+        or normalized.startswith("//")
+    ):
+        raise ValueError(f"Unsafe path in energy-use zip: {filename!r}")
+    return parts
+
+
+def _extract_zip(zip_path: Path) -> Path:
+    dest = Path(tempfile.mkdtemp(prefix="energy_use_")).resolve()
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        for member in zf.infolist():
+            parts = _zip_member_parts(member.filename)
             if not parts:
                 continue
 
-            target = dest.joinpath(*parts)
+            target = dest.joinpath(*parts).resolve()
+            try:
+                target.relative_to(dest)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Unsafe path in energy-use zip: {member.filename!r}"
+                ) from exc
+
+            normalized_name = member.filename.replace("\\", "/")
             if member.is_dir() or normalized_name.endswith("/"):
                 target.mkdir(parents=True, exist_ok=True)
                 continue

--- a/vibe_code_apps_20/wattlab/energy_use/package.py
+++ b/vibe_code_apps_20/wattlab/energy_use/package.py
@@ -11,6 +11,7 @@ import tempfile
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any
 
 import pandas as pd
@@ -50,7 +51,29 @@ def _unwrap_root(path: Path) -> Path:
 def _extract_zip(zip_path: Path) -> Path:
     dest = Path(tempfile.mkdtemp(prefix="energy_use_"))
     with zipfile.ZipFile(zip_path, "r") as zf:
-        zf.extractall(dest)
+        # Windows-created archives may store directory separators as ``\\``.
+        # On Linux that backslash is a literal character, so a valid
+        # ``folder\\campus.json`` entry otherwise looks like a missing campus
+        # file after extraction. Normalize separators and retain explicit
+        # zip-slip protection while extracting.
+        for member in zf.infolist():
+            normalized_name = member.filename.replace("\\", "/")
+            member_path = PurePosixPath(normalized_name)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise ValueError(f"Unsafe path in energy-use zip: {member.filename!r}")
+
+            parts = tuple(part for part in member_path.parts if part not in ("", "."))
+            if not parts:
+                continue
+
+            target = dest.joinpath(*parts)
+            if member.is_dir() or normalized_name.endswith("/"):
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(member, "r") as source, target.open("wb") as sink:
+                shutil.copyfileobj(source, sink)
     return _unwrap_root(dest)
 
 


### PR DESCRIPTION
## What changed\n- Normalize Windows backslash paths in uploaded energy-use ZIPs so campus.json and column maps load on Linux.\n- Reject unsafe absolute and parent-traversal archive paths.\n- Add a regression test for the real wrapped Windows archive layout.\n- Use the active pytest interpreter for the live Streamlit smoke test.\n\n## Validation\n- 14 focused Vibe 20 tests pass.\n- Streamlit health check and AppTest pass with BUILDING_100 dump plus campus_liberty_practice.zip.\n- scripts/smoke_studio.py passes.\n\nA follow-up commit will add the calendar-window calibration alignment and practice Open-Meteo/EnergyPlus evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of energy-use ZIP packages created on Windows.
  * ZIP contents with Windows-style paths are now discovered and loaded correctly.
  * Added safeguards to reject unsafe archive paths during extraction.

* **Tests**
  * Added regression coverage for Windows ZIP compatibility.
  * Improved app smoke tests to use the active Python interpreter reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->