### PR TITLE
feat(vibe20): Excel fuel intake + Twin 08 panes + agent E+ campaign

### DIFF
--- a/vibe_code_apps_20/README.md
+++ b/vibe_code_apps_20/README.md
@@ -4,35 +4,39 @@
 package into an ESCO fuel dashboard, EnergyPlus twin/calibrate viewer, and ECM
 capital plan.
 
-Chat with **Codex / agents outside Streamlit** on the shared workspace folder.
-Studio is the upload dropzone + results viewer.
+Chat with **any AI agent outside Streamlit** on the shared workspace folder.
+Studio is the upload dropzone + results viewer. Site ids, areas, and lat/lon
+come from dump / `campus.json` / `buildings.json` — never hardcoded in the app
+(practice zips on a test bench are examples only). Agents publish Twin iterations
+into `runs/` so the human sees APIHelper-08 panes in the browser.
 
 ## Run (Docker / GHCR)
 
-**Always pull, then recreate** (same easy-button as vibe19):
+**Always pull, then recreate** (same easy-button as vibe19). For Twin Docker
+EnergyPlus from inside Studio, also mount the Docker socket and ensure the
+`energyplus-mcp-dev` image exists on the host:
 
 ```bash
 docker pull ghcr.io/bbartling/vibe20:latest
 docker stop vibe20 2>/dev/null; docker rm vibe20 2>/dev/null
-docker run -d --restart unless-stopped -p 8520:8501 --name vibe20 \
-  ghcr.io/bbartling/vibe20:latest
+mkdir -p ~/wattlab_workspace/{uploads,runs,reports}
+docker run -d --restart unless-stopped -p 8520:8501 \
+  -v /home/ben/wattlab_workspace:/data \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e WATTLAB_STUDIO_WORKSPACE=/data \
+  --name vibe20 ghcr.io/bbartling/vibe20:latest
 ```
 
 Open **http://localhost:8520** (or `http://<host-ip>:8520`). Vibe19 typically uses **8502**.
+
+EnergyPlus sibling (host, once): build or load `energyplus-mcp-dev` per
+`wattlab.energyplus.docker` / vendored EnergyPlus-MCP notes. Studio does **not**
+bake EnergyPlus into the vibe20 image.
 
 ```bash
 docker ps
 docker logs -f vibe20
 docker stop vibe20
-```
-
-Optional shared workspace with Codex on the host:
-
-```bash
-docker run -d --restart unless-stopped -p 8520:8501 \
-  -v /home/ben/wattlab_workspace:/data \
-  -e WATTLAB_STUDIO_WORKSPACE=/data \
-  --name vibe20 ghcr.io/bbartling/vibe20:latest
 ```
 
 ## Run (local)
@@ -48,9 +52,13 @@ Workspace default: `.artifacts/studio_workspace/` (`uploads/dump`, `uploads/ener
 
 ## Studio pages (4 only)
 
-1. **Uploads** — `wattlab_dump_*.zip` (v3) + energy-use zip/folder (`campus.json` + bill CSVs + optional Haystack `column_map`)
+1. **Uploads** — `wattlab_dump_*.zip` (v3) + energy-use package:
+   - preferred: `campus.json` + bill CSVs (+ optional Haystack `column_map`)
+   - or monthly fuel **Excel** workbooks (auto-derived → `uploads/energy/derived/`)
+   - optional `buildings.json` / dump `model_seed` for ids, area, property type, lat/lon
 2. **Fuel dashboard** — ESCO monthly tables, peer EUI bands, Open-Meteo HDD/CDD, gap-aware charts
-3. **Twin / calibrate** — resolve profile, dry-run / Docker EnergyPlus, modeled vs bills, crosscheck vs ESCO proxies
+3. **Twin / calibrate** — profile resolve, dry-run / Docker EnergyPlus, APIHelper-08-style
+   progress + OA + classic 5Zone floor-plan panes, modeled vs bills, iteration history
 4. **ECMs** — catalog Easy Buttons + measure sets + capital plan guardrails
 
 ## Pre-ship smoke
@@ -67,5 +75,6 @@ python scripts/browser_smoke_vibe20.py --url http://localhost:8520 --screenshots
 | Doc | For |
 | --- | --- |
 | [`AGENTS.md`](AGENTS.md) | Agent handbook + twin CLI |
-| [`vibe20_agent_spec/`](vibe20_agent_spec/) | Data contract + Codex workspace rules |
+| [`vibe20_agent_spec/`](vibe20_agent_spec/) | Data contract + agent workspace rules |
+| [`vibe20_agent_spec/AGENT_TESTER_PROMPT.md`](vibe20_agent_spec/AGENT_TESTER_PROMPT.md) | QA + live E+ / EnergyPlus-MCP calibrate (any AI agent) |
 | [`../vibe_code_apps_19/docs/COLUMN_MAP_JSON.md`](../vibe_code_apps_19/docs/COLUMN_MAP_JSON.md) | Haystack point → CSV header maps |

--- a/vibe_code_apps_20/pyproject.toml
+++ b/vibe_code_apps_20/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-studio = ["streamlit>=1.37", "plotly>=5.20", "matplotlib>=3.8"]
+studio = ["streamlit>=1.37", "plotly>=5.20", "matplotlib>=3.8", "openpyxl>=3.1"]
 excel = ["openpyxl>=3.1"]
 dev = ["pytest>=8.0", "ruff>=0.5", "playwright>=1.40"]
 

--- a/vibe_code_apps_20/scripts/smoke_studio.py
+++ b/vibe_code_apps_20/scripts/smoke_studio.py
@@ -71,7 +71,7 @@ def main() -> int:
     at.text_input(key="twin_btype").set_value("office")
     at.text_input(key="twin_city").set_value("detroit")
     at.number_input(key="twin_area").set_value(75000.0)
-    at.button[0].set_value(True).run()
+    at.button(key="FormSubmitter:twin_profile_form-Resolve profile").click().run()
     if at.exception:
         return _fail(at, "Twin(resolve)")
     at.button(key="twin_dry_run").click().run()

--- a/vibe_code_apps_20/studio.py
+++ b/vibe_code_apps_20/studio.py
@@ -1,7 +1,7 @@
 """WattLab Studio — dump + energy upload → ESCO dashboard → twin → ECMs.
 
 Launch: ``wattlab studio`` or ``streamlit run studio.py``.
-AI agents (Codex) work on the shared workspace folder outside Streamlit.
+AI agents work on the shared workspace folder outside Streamlit; Studio is the browser viewer.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ def main() -> None:
     st.sidebar.title("WattLab Studio")
     st.sidebar.caption(
         "Uploads → Fuel dashboard → Twin / calibrate → ECMs. "
-        "Chat with Codex on the workspace folder; this UI is the viewer."
+        "AI agents work on the workspace folder; this UI is the viewer."
     )
     page = st.sidebar.radio("Workflow", PAGES, key="studio_page")
 

--- a/vibe_code_apps_20/tests/test_ep_viz.py
+++ b/vibe_code_apps_20/tests/test_ep_viz.py
@@ -1,0 +1,60 @@
+"""Unit tests for APIHelper-08-style Twin viz helpers."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from wattlab.energyplus.timeseries import parse_eplusout_timeseries
+from wattlab.studio.ep_viz import (
+    floor_plan_figure,
+    install_demo_replay,
+    map_zones_to_roles,
+    outdoor_figure,
+    publish_run_for_studio,
+    read_run_progress,
+    zone_mean_by_role,
+)
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "eplusout" / "eplusout.csv"
+
+
+def test_map_prototype_zones_to_compass_roles():
+    roles = map_zones_to_roles(["SPACE1-1", "SPACE2-1", "SPACE3-1", "SPACE4-1", "SPACE5-1"])
+    assert roles["SPACE1-1"] == "south"
+    assert roles["SPACE5-1"] == "center"
+
+
+def test_floor_plan_and_oa_from_fixture():
+    ts = parse_eplusout_timeseries(FIXTURE)
+    roles = zone_mean_by_role(ts)
+    assert roles
+    fig = floor_plan_figure(roles)
+    assert fig is not None
+    oa = outdoor_figure(ts.outdoor)
+    assert oa is not None
+
+
+def test_demo_replay_install(tmp_path: Path):
+    dest = tmp_path / "demo_replay"
+    install_demo_replay(dest, FIXTURE)
+    info = read_run_progress(dest)
+    assert info["replay"] is True
+    assert info["progress"] == 100
+    assert (dest / "eplusout.csv").is_file()
+    assert (dest.parent / "CURRENT_RUN.txt").is_file()
+
+
+def test_publish_run_for_studio_writes_current_pointer(tmp_path: Path):
+    src = tmp_path / "wattlab_sim"
+    (src / "sim_baseline").mkdir(parents=True)
+    shutil.copy2(FIXTURE, src / "sim_baseline" / "eplusout.csv")
+    (src / "run_manifest.json").write_text(
+        '{"run_id":"t1","status":"SUCCESS"}', encoding="utf-8"
+    )
+    dest = tmp_path / "runs" / "t1"
+    published = publish_run_for_studio(src, run_id="t1", dest_root=dest)
+    assert (published / "eplusout.csv").is_file()
+    pointer = published.parent / "CURRENT_RUN.txt"
+    assert pointer.is_file()
+    assert pointer.read_text(encoding="utf-8").strip() == str(published.resolve())

--- a/vibe_code_apps_20/tests/test_excel_campus.py
+++ b/vibe_code_apps_20/tests/test_excel_campus.py
@@ -1,0 +1,135 @@
+"""Regression: Excel-only energy zips derive campus for Fuel."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from wattlab.energy_use import load_energy_use_package
+from wattlab.energy_use.excel_campus import derive_campus_from_excel
+
+
+def _write_monthly_xlsx(path: Path, *, sheet: str, fuel: str) -> None:
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = sheet
+    if fuel == "electricity":
+        ws.append(["Bill Month", "kWh Total", "Billed Demand (kW)", "Total Current Charges ($)"])
+        for i, month in enumerate(
+            [
+                "2024-12",
+                "2025-01",
+                "2025-02",
+                "2025-03",
+                "2025-04",
+                "2025-05",
+                "2025-06",
+                "2025-07",
+                "2025-08",
+                "2025-09",
+                "2025-10",
+                "2025-11",
+            ]
+        ):
+            ws.append([month, 100000 + i * 1000, 500 + i, 1000.0])
+    else:
+        ws.append(["Bill Month", "Usage (Mcf)", "Total Current Charges ($)"])
+        for i, month in enumerate(
+            [
+                "2024-12",
+                "2025-01",
+                "2025-02",
+                "2025-03",
+                "2025-04",
+                "2025-05",
+                "2025-06",
+                "2025-07",
+                "2025-08",
+                "2025-09",
+                "2025-10",
+                "2025-11",
+            ]
+        ):
+            ws.append([month, 200 + i * 5, 800.0])
+    wb.save(path)
+
+
+def test_derive_campus_from_excel_monthly_workbook(tmp_path: Path):
+    pkg = tmp_path / "campus_fuel_package"
+    pkg.mkdir()
+    _write_monthly_xlsx(pkg / "Shared_Electric.xlsx", sheet="Electric Shared", fuel="electricity")
+    _write_monthly_xlsx(pkg / "Gas_A.xlsx", sheet="Gas Building A", fuel="gas")
+    _write_monthly_xlsx(pkg / "Gas_B.xlsx", sheet="Gas Building B", fuel="gas")
+    (pkg / "buildings.json").write_text(
+        json.dumps(
+            {
+                "buildings": [
+                    {
+                        "building_id": "site_a",
+                        "label": "Building A",
+                        "floor_area_ft2": 120000,
+                        "property_type": "office",
+                    },
+                    {
+                        "building_id": "site_b",
+                        "label": "Building B",
+                        "floor_area_ft2": 90000,
+                        "property_type": "office",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = derive_campus_from_excel(pkg, out_dir=tmp_path / "derived")
+    assert result.campus_path.is_file()
+    assert len(result.meters) >= 2
+    campus_doc = json.loads(result.campus_path.read_text(encoding="utf-8"))
+    assert {b["building_id"] for b in campus_doc["buildings"]} == {"site_a", "site_b"}
+    assert "liberty" not in json.dumps(campus_doc).lower()
+
+    loaded = load_energy_use_package(pkg, derive_dir=tmp_path / "derived2")
+    assert loaded.campus is not None
+    assert loaded.fuel_ready is True
+    assert loaded.derived_from_excel is True
+    assert not loaded.monthly_long.empty
+
+
+def test_excel_only_zip_windows_paths_fuel_ready(tmp_path: Path):
+    pkg = tmp_path / "fuel_use_package"
+    pkg.mkdir()
+    _write_monthly_xlsx(pkg / "Monthly_Electric.xlsx", sheet="Electric", fuel="electricity")
+    _write_monthly_xlsx(pkg / "Monthly_Gas.xlsx", sheet="Gas Building A", fuel="gas")
+
+    archive = tmp_path / "fuel.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        for path in pkg.iterdir():
+            zf.write(path, arcname=f"fuel_use_package\\{path.name}")
+
+    loaded = load_energy_use_package(
+        archive,
+        derive_dir=tmp_path / "derived_zip",
+    )
+    assert loaded.campus is not None
+    assert loaded.fuel_ready is True
+    assert loaded.derived_from_excel is True
+
+
+def test_excel_workbook_without_month_table_raises(tmp_path: Path):
+    from openpyxl import Workbook
+
+    pkg = tmp_path / "bad"
+    pkg.mkdir()
+    wb = Workbook()
+    wb.active.title = "Notes"
+    wb.active.append(["hello", "world"])
+    wb.save(pkg / "notes.xlsx")
+
+    with pytest.raises(ValueError, match="no monthly bill"):
+        derive_campus_from_excel(pkg, out_dir=tmp_path / "out")

--- a/vibe_code_apps_20/tests/test_studio_app.py
+++ b/vibe_code_apps_20/tests/test_studio_app.py
@@ -97,11 +97,11 @@ def test_studio_fuel_dashboard_with_fixture_campus():
 
 def test_studio_twin_and_ecms_dry_path():
     at = _boot("Twin / calibrate")
-    # form submit is button[0]
     at.text_input(key="twin_btype").set_value("office")
     at.text_input(key="twin_city").set_value("detroit")
     at.number_input(key="twin_area").set_value(75000.0)
-    at.button[0].set_value(True).run()
+    # Form submit (Refresh agent runs is a separate button above the form)
+    at.button(key="FormSubmitter:twin_profile_form-Resolve profile").click().run()
     assert not at.exception
     assert "studio_profile" in at.session_state
 

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -1,8 +1,10 @@
 # Vibe20 / WattLab agent workspace — orientation
 
-Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and similar agents. Product code lives in `vibe_code_apps_20/` (the `wattlab` package); orchestration lives in **`vibe20_agent_spec/`**.
+Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Codex CLI, Claude Code, etc.). Product code lives in `vibe_code_apps_20/` (the `wattlab` package); orchestration lives in **`vibe20_agent_spec/`**.
 
 **Primary agent prompt (paste into new sessions):** [`../AGENTS.md`](../AGENTS.md)
+
+**Turnkey QA + E+ calibrate loop (any AI agent):** [`AGENT_TESTER_PROMPT.md`](AGENT_TESTER_PROMPT.md)
 
 **App:** ESCO / energy-engineering toolkit — vibe19 FDD dumps in, calibrated EnergyPlus twins + benchmarked capital plans out. Where vibe19 is about **finding faults**, vibe20 is about **pricing the fixes credibly**: ESCO spreadsheet bin-method calculators, EnergyPlus crosschecks, public benchmarks, and ROI guardrails.
 
@@ -20,7 +22,9 @@ Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
 6. **Benchmark gate before ROI publication** — `wattlab.benchmarks.guardrails.gate_capital_plan` must run on every capital plan: baseline EUI vs peer band, savings fraction vs scope ceiling, implied post-retrofit EUI, per-measure cost bands, payback floors. Any hit → verdict `INVESTIGATE`; show the deltas, make the human override. Never quietly publish. See [`docs/BENCHMARK_GOVERNANCE.md`](docs/BENCHMARK_GOVERNANCE.md).
 7. **Shared meters are schema, not spreadsheet hacks** — `campus.json` declares meter → building relationships. Allocation modes (`area_weighted` / `equal` / `gas_share` / `manual`) are side-by-side **scenarios**, none is "truth" until submetered evidence exists. `examples/liberty/` is a **practice example** for both vibe19 and vibe20 — never hardcode Liberty ids, Detroit coords, or bill filenames in package logic; real sites ship their own `campus.json` + CSVs.
 7b. **Data-model driven sites** — Haystack-style maps (vibe19 `column_map` / `points` → CSV headers) and campus `bill_columns` are the portable contract. Heuristics are fallbacks only. Never invent office/Madison/Chicago/Detroit defaults for a production dump or campus.
-7c. **Fuel Weather** — Studio page for campus bills × Open-Meteo HDD/CDD (base 65°F) + R². Coords from `campus.json` or the form. Interval meter UI is Phase 2 using the vibe19 Haystack map shape.
+7c. **Fuel dashboard** — campus bills × Open-Meteo HDD/CDD (base 65°F) + R² + peers.
+    Coords from `campus.json` / dump / form — never a baked-in city. Interval meter UI
+    is Phase 2 using the vibe19 Haystack map shape.
 8. **Costs are range + basis + vintage + confidence** — `retrofit_costs_public.json` rows carry `unit_basis` (building_ft2 vs glazing_ft2 …), `currency_year`, `confidence`. Historical LBNL medians are reference bands, **never** current-year bids. Windows math on glazing area, chillers on building area — never mix.
 9. **EUI units are kBtu/ft²-year (site)** — conversions: 1 kWh = 3,412 Btu; 1 Mcf gas = 1.037 MMBtu; 1 therm = 100 kBtu. Peer bands from `benchmarks_public.json` (EPA PM medians, CBECS 70.6 fallback).
 10. **Docker-only EnergyPlus** — pinned image via `wattlab.energyplus.docker`; run manifests (`run_manifest.json`) record model/weather SHA + image on every run. Docker tests skip when the image is missing — that's fine.
@@ -36,8 +40,8 @@ Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
     python scripts/browser_smoke_vibe20.py --url http://localhost:8520 \
         --screenshots .artifacts/browser/native
     ```
-    AppTest walk must cover all pages (including Data Explorer, Assumption
-    Ledger, **Fuel Weather**) with 0 exceptions; live check: `/_stcore/health` → `ok`. Playwright
+    AppTest walk must cover all 4 Studio pages (Uploads, Fuel dashboard,
+    Twin/calibrate, ECMs) with 0 exceptions; live check: `/_stcore/health` → `ok`. Playwright
     is a local/agent gate (not inside vibe20-ghcr.yml).
 16. **Streamlit conventions** — `width='stretch'` (never deprecated `use_container_width`), unique `key=` on every widget/chart, Plotly for charts (look-and-feel follows vibe19).
 17. **Session log discipline** — append `../SESSION_LOG.md` (newest first) after every shipped session; update skills/docs here when behavior changes.
@@ -71,8 +75,11 @@ Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
 25. **Canonical ECM catalog** — sole source is `wattlab/measures/catalog.yaml`
     (`wattlab ecm`, Studio Easy Buttons, packages, coverage matrix).
 26. **Studio is 4 pages only** — Uploads / Fuel dashboard / Twin·calibrate / ECMs.
-    Codex chats **outside** Streamlit against `.artifacts/studio_workspace/`
+    AI agents chat **outside** Streamlit against `.artifacts/studio_workspace/`
     (or `WATTLAB_STUDIO_WORKSPACE`). No in-app chat panel. No Liberty/city hardcodes.
+    Excel energy zips may derive campus under `uploads/energy/derived/`; Twin shows
+    APIHelper-08 panes from `runs/<id>/` that agents **publish for the browser**.
+    Tester prompt: [`AGENT_TESTER_PROMPT.md`](AGENT_TESTER_PROMPT.md).
 
 ---
 
@@ -80,14 +87,15 @@ Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
 
 1. **`../AGENTS.md`** — mission, repo map, twin-loop + benchmark governance rules
 2. **AI quick rules above**
-3. **[`DATA_CONTRACT.md`](DATA_CONTRACT.md)** — vibe19 dump, campus.json, report/plan shapes
-4. **[`docs/TWIN_LOOP.md`](docs/TWIN_LOOP.md)** — the full agent + human iterate protocol
-5. **[`docs/ESCO_CALCULATORS.md`](docs/ESCO_CALCULATORS.md)** — when touching `wattlab/bench/esco.py` or weather bins
-6. **[`docs/BENCHMARK_GOVERNANCE.md`](docs/BENCHMARK_GOVERNANCE.md)** — when touching benchmarks/guardrails/meters
-7. **`skills/wattlab-esco-bins/SKILL.md`** — run/extend the bin-method calculators
-8. **`skills/wattlab-benchmarking/SKILL.md`** — bills → EUI → peer bands → gate
-9. **`skills/wattlab-studio/SKILL.md`** — Studio pages, state keys, smoke
-10. `.agents/` personas/workflows/checklists + `.agents/skills/*` (measure-specific domain skills) as needed
+3. **[`DATA_CONTRACT.md`](DATA_CONTRACT.md)** — dump, campus, Excel derive, workspace runs/
+4. **[`docs/TWIN_LOOP.md`](docs/TWIN_LOOP.md)** — human + agent iterate protocol
+5. **[`AGENT_TESTER_PROMPT.md`](AGENT_TESTER_PROMPT.md)** — QA / calibrate on a bench (any agent)
+6. **[`docs/ESCO_CALCULATORS.md`](docs/ESCO_CALCULATORS.md)** — when touching `wattlab/bench/esco.py` or weather bins
+7. **[`docs/BENCHMARK_GOVERNANCE.md`](docs/BENCHMARK_GOVERNANCE.md)** — when touching benchmarks/guardrails/meters
+8. **`skills/wattlab-esco-bins/SKILL.md`** — run/extend the bin-method calculators
+9. **`skills/wattlab-benchmarking/SKILL.md`** — bills → EUI → peer bands → gate
+10. **`skills/wattlab-studio/SKILL.md`** — 4 Studio pages, workspace, smoke
+11. `.agents/` personas/workflows/checklists + `.agents/skills/*` as needed
 
 ---
 
@@ -95,25 +103,24 @@ Plain Markdown on disk is the source of truth for **Cursor**, **Codex CLI**, and
 
 | Path | Role |
 | --- | --- |
-| `wattlab/existing_building/` | Hypothesis Lab orchestration (`explore-existing`) |
-| `wattlab/ecm/` + `wattlab/measures/catalog.yaml` | Canonical ECM registry / packages |
-| `wattlab/units/` | SI-first quantities and IP/SI display |
-| `wattlab/privacy/` | Hash-only proprietary-content scanner |
-| `wattlab/studio/pages/` | Streamlit page modules (Hypothesis Lab, Easy Buttons, …) |
+| `wattlab/studio/pages/` | Uploads, Fuel dashboard, Twin/calibrate, ECMs |
+| `wattlab/studio/ep_viz.py` | APIHelper-08 floor plan / OA / progress helpers |
+| `wattlab/studio/workspace.py` | Shared uploads/runs/reports tree |
+| `wattlab/energy_use/` | campus + Haystack maps + Excel→campus fallback |
 | `wattlab/seed/` | vibe19 dump loader + gap report |
-| `wattlab/benchmarks/` | EUI peer bands, cost bands, campus/meters/allocation, fuel_weather, ROI guardrail gate |
-| `wattlab/weather/degree_days.py` | HDD/CDD (base 65°F) from hourly OAT |
-| `wattlab/weather/bins.py` | Weather-Man OAT bins (5°F × 3 shifts, MCWB, psychrometrics) |
-| `wattlab/weather/epw.py` | AMY EPW builder |
-| `wattlab/bench/` | Proxy calculators + ESCO bin-method calculators (`esco.py`) |
-| `wattlab/finance.py` | Payback / ROI / NPV / capital-plan rollup |
-| `wattlab/crosscheck.py` | E+ vs proxy referee + G14 gates |
-| `wattlab/easy_button.py` | Baseline + progressive measure runs (`--dry-run` works Docker-less) |
-| `wattlab/calibrate.py` | Overlap-window calibration vs vibe19 model seed |
-| `wattlab/bridge.py` | vibe19 faults → suggested measures |
-| `wattlab/energyplus/` | Docker, MCP, results parse, manifests, IDF patches |
-| `wattlab/measures/` | Good / Better / Best measure sets |
-| `wattlab/cli.py` | `wattlab` CLI (defaults / easy-button / calibrate / bridge / epw / bench / crosscheck / benchmark / seed / studio) |
+| `wattlab/benchmarks/` | EUI peers, campus/meters, fuel_weather, guardrails |
+| `wattlab/weather/` | degree_days, Open-Meteo, EPW, bins |
+| `wattlab/bench/` | ESCO bin-method calculators |
+| `wattlab/finance.py` | Capital-plan rollup |
+| `wattlab/crosscheck.py` | E+ vs proxy + G14 |
+| `wattlab/easy_button.py` | Baseline + progressive measures (`--dry-run`) |
+| `wattlab/calibrate.py` | Overlap-window calibration |
+| `wattlab/bridge.py` | vibe19 faults → measures |
+| `wattlab/energyplus/` | Docker, results, timeseries, IDF patches |
+| `wattlab/measures/` + `wattlab/ecm/` | Catalog / packages |
+| `wattlab/existing_building/` | Hypothesis Lab orchestration (CLI; not a Studio page) |
+| `wattlab/cli.py` | `wattlab` CLI |
+| `vibe20_agent_spec/` | Agent handbook, contracts, tester prompt, skills |
 | `studio.py` | WattLab Studio (Ingest / … / Benchmark / Fuel Weather / … / Capital plan) |
 | `scripts/smoke_studio.py` | AppTest smoke walk (all pages + fixture campus + Fuel Weather) |
 | `scripts/agent_twin_demo.py` | Full twin-loop rehearsal on practice campus (real Docker E+ baseline + ECMs) |

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -1,0 +1,154 @@
+# AI agent tester prompt — WattLab Studio + live EnergyPlus campaign
+
+Paste into **any** AI coding agent (Cursor, Codex CLI, Claude Code, etc.) on the
+LAN box that shares `WATTLAB_STUDIO_WORKSPACE` with Studio.
+
+Studio is only the **browser viewer**. You are the energy-engineering helper.
+You must **actually run several live EnergyPlus simulations**, publish each one
+for the human to see in Twin (APIHelper-08 panes), and iterate with the human —
+not a single dry-run or fixture replay.
+
+Practice dumps/zips on a test bench are **examples only**. Data-model driven for
+*any* building. Never hardcode practice campus ids into code or invented answers.
+
+---
+
+## ROLE
+
+- Drive Docker **`energyplus-mcp-dev`** (EnergyPlus 26.1) and, when available,
+  **LBNL EnergyPlus-MCP** inspect/validate tools.
+- Build Fuel-ready campus + a **multi-run Twin campaign** under `runs/<id>/`.
+- Calibrate against **actual** monthly fuel + weather (Open-Meteo / dump EPW).
+- Chat with the human engineer between sims — do not invent building_type, city,
+  area, HVAC, or lat/lon.
+
+## HARD RULES
+
+1. Ask for NEEDS_INPUT — never invent.
+2. No calibrated-savings claims before G14 (NMBE ±5%, CV(RMSE) ≤15%) when bills exist.
+3. **Live sims only for Twin calibrate PASS.** Demo replay = UI smoke, not PASS.
+4. No host `pyenergyplus` Runtime API.
+5. Every sim → `publish_run_for_studio(...)` → human **Refresh agent runs** in Twin.
+6. Report bugs; do not patch unless asked.
+
+## MINIMUM LIVE SIM CAMPAIGN (required)
+
+You must complete **at least 3 successful live EnergyPlus runs** (Docker
+`energyplus-mcp-dev`), each published to a distinct `runs/<run_id>/` with
+`eplusout.csv`, and visible in the browser iteration history.
+
+Suggested campaign (adapt with the human; keep one hypothesis per run):
+
+| # | Run | What to try | Why |
+| --- | --- | --- | --- |
+| 1 | **Baseline** | `wattlab easy-button` / Studio Docker run, measure_set that yields a baseline (or dry-run plan first, then live baseline) | Establish modeled monthly fuel vs bills; first 08 panes from **live** eplusout |
+| 2 | **Schedule / occupancy hypothesis** | Patch or measure that changes fan/occupancy schedules (dump schedule hints / setpoints) | See if loads move toward bills; re-check G14 |
+| 3 | **Envelope or HVAC efficiency hypothesis** | One catalog measure (e.g. better set / LPD / cooling efficiency — whatever the resolved profile supports) | Incremental savings + crosscheck vs ESCO proxy if available |
+
+Optional 4th (encouraged if time): weather sensitivity (AMY vs TMY note) or a second measure — still one hypothesis per run.
+
+**Between every run:**
+
+1. Publish to workspace `runs/` (`publish_run_for_studio` or easy-button auto-publish).
+2. Tell the human to open Twin → Refresh → confirm 08 panes (OA + floor plan) updated.
+3. Compare monthly modeled vs `utility_bills` / campus; log NMBE/CV(RMSE).
+4. Ask the human what to try next if gates fail or crosscheck is `investigate`.
+
+If EnergyPlus-MCP is configured, use it at least once per campaign to
+**validate/inspect** the IDF (zones, meters, run period) before or after a sim —
+log the tool names.
+
+## SETUP — Studio (pull only)
+
+```bash
+docker pull ghcr.io/bbartling/vibe20:latest
+docker stop vibe20 2>/dev/null; docker rm vibe20 2>/dev/null
+mkdir -p ~/wattlab_workspace/{uploads,runs,reports}
+docker run -d --restart unless-stopped -p 8520:8501 \
+  -v "$HOME/wattlab_workspace:/data" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e WATTLAB_STUDIO_WORKSPACE=/data \
+  --name vibe20 ghcr.io/bbartling/vibe20:latest
+curl -sf http://127.0.0.1:8520/_stcore/health
+```
+
+## SETUP — EnergyPlus + EnergyPlus-MCP
+
+```bash
+docker images energyplus-mcp-dev
+# Build if missing: vibe_code_apps_20/third_party/README.md + scripts/build_energyplus_mcp.sh
+
+cd ~/py-bacnet-stacks-playground/vibe_code_apps_20   # if present
+python -c "from wattlab.energyplus.mcp import capability_status; import json; print(json.dumps(capability_status(), indent=2))"
+```
+
+Need `mode` = `simulate_only` or `full_mcp_available`.  
+MCP config: [`../third_party/README.md`](../third_party/README.md).
+
+How to run sims (host agent CLI preferred if Studio cannot reach Docker sock):
+
+```bash
+# After profile / answers.json resolved — example shape; use site data-model fields
+wattlab easy-button --minimal answers.json          # live; publishes when workspace set
+# or Studio Twin → "Run EnergyPlus (Docker)" then Refresh
+```
+
+Publish helper if artifacts landed under `.artifacts/wattlab_*`:
+
+```python
+from pathlib import Path
+from wattlab.studio.ep_viz import publish_run_for_studio
+publish_run_for_studio(Path("…/wattlab_<run_id>"), run_id="<run_id>")
+```
+
+## INPUTS
+
+| Artifact | Role |
+| --- | --- |
+| `uploads/dump/*.zip` | vibe19 dump v3 |
+| `uploads/energy/*` | campus / Excel fuel |
+| `reports/utility_bills.csv` | modeled vs actual |
+| `runs/<id>/` | each live E+ iteration for browser |
+| Weather | dump weather and/or Open-Meteo → EPW |
+
+## BROWSER — what the human must see
+
+After **each** of the ≥3 live runs: progress/log, OA chart, 5Zone floor plan,
+and a growing iteration history. Empty panes = you did not publish.
+
+## TURNKEY CHECKLIST
+
+1. Studio health ok; `energyplus-mcp-dev` present (`capability_status`).
+2. Dump + energy → Fuel charts green.
+3. Profile resolved with human.
+4. Dry-run plan once (optional warm-up).
+5. **Live campaign:** ≥3 Docker E+ sims, each published, each confirmed in Twin UI.
+6. MCP inspect at least once if `full_mcp_available`.
+7. G14 / crosscheck logged per run when bills exist.
+8. ECMs page exercised; capital gate noted.
+9. Write `reports/CALIBRATE_SESSION.md` + `BUG_REPORT.md`.
+
+## PASS / FAIL
+
+| Gate | PASS |
+| --- | --- |
+| Fuel | ≥1 real chart |
+| Twin UI smoke | 08 panes work (replay ok) |
+| **Twin calibrate** | **≥3 live** `energyplus-mcp-dev` sims in `runs/`, each with eplusout; human saw updates; G14 attempted when bills exist |
+| E+ MCP | ≥1 inspect/validate if MCP available; else document `simulate_only` |
+
+One live sim is **not** enough. Really try the loop — baseline + hypotheses —
+with the human engineer.
+
+## OUTPUT (`reports/CALIBRATE_SESSION.md`)
+
+For each live run:
+
+- `run_id`, hypothesis (one sentence), weather source
+- path to `runs/<id>/`, eplusout present yes/no
+- monthly vs bills delta / G14 if available
+- crosscheck verdict if proxies present
+- MCP tools used (if any)
+- human feedback / next hypothesis
+
+Plus overall PASS/FAIL and bugs. No glossy ROI without G14.

--- a/vibe_code_apps_20/vibe20_agent_spec/CODEX_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CODEX_TESTER_PROMPT.md
@@ -1,0 +1,5 @@
+# Moved
+
+Use **[`AGENT_TESTER_PROMPT.md`](AGENT_TESTER_PROMPT.md)** (any AI agent).
+
+Next QA pass must use live **`energyplus-mcp-dev`** / EnergyPlus-MCP — not replay-only.

--- a/vibe_code_apps_20/vibe20_agent_spec/DATA_CONTRACT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/DATA_CONTRACT.md
@@ -93,15 +93,42 @@ Canonical docs live in vibe19:
 - [`../../vibe_code_apps_19/docs/COLUMN_MAP_JSON.md`](../../vibe_code_apps_19/docs/COLUMN_MAP_JSON.md)
 - Meter points: `elec-power`, `gas-flow` (rates) → monthly integrate in vibe19
 
-WattLab Studio **Fuel Weather** v1 is monthly campus bills; interval + Haystack
+WattLab Studio **Fuel dashboard** uses monthly campus bills; interval + Haystack
 UI is Phase 2 but **must reuse this map shape** when added — do not invent a
 parallel mapping dialect.
 
-## 2c. Fuel Weather analytics
+## 2d. Excel → campus (fallback intake)
+
+When an energy zip/folder has **no** `campus.json` but has `.xlsx` monthly
+tables (Month + kWh/Mcf/therm/usage), `wattlab.energy_use.excel_campus` writes
+`uploads/energy/derived/campus.json` + bill CSVs. Building ids / areas / coords
+come from optional `buildings.json` / `campus_hint.json` or dump `model_seed`
+hints — **never** site-specific hardcodes. Tests: `tests/test_excel_campus.py`.
+
+## 2e. Studio workspace layout
+
+```
+uploads/dump/              # wattlab_dump_*.zip
+uploads/energy/            # energy zip or folder
+uploads/energy/derived/    # Excel-derived campus (if used)
+runs/<run_id>/             # Twin iterations: report.json, eplusout.csv,
+                           # run_manifest.json, progress.json, eplusout.err
+reports/                   # utility_bills.csv, dry-run plan, scorecards, BUG_REPORT.md
+```
+
+Twin 08-style panes read `runs/<id>/` post-sim artifacts (OA + zone floor plan).
+Agents publish with `wattlab.studio.ep_viz.publish_run_for_studio` so
+`runs/CURRENT_RUN.txt` points at the latest iteration for the browser Twin page.
+**Calibrate PASS** requires live Docker `energyplus-mcp-dev` (and EnergyPlus-MCP
+when vendor clone is present) — see [`AGENT_TESTER_PROMPT.md`](AGENT_TESTER_PROMPT.md).
+Demo replay uses `tests/fixtures/eplusout/eplusout.csv` labeled `REPLAY.txt` (UI smoke only).
+Tests: `tests/test_ep_viz.py`.
+
+## 2c. Fuel dashboard analytics (HDD/CDD)
 
 Modules: `wattlab.weather.degree_days` (HDD/CDD base **65°F**, vibe19 metering
 convention), `wattlab.benchmarks.fuel_weather` (align bills×DD, OLS R²).
-Studio page: **Fuel Weather**. Offline path uses synthetic seasonal OAT for
+Studio page: **Fuel dashboard**. Offline path uses synthetic seasonal OAT for
 AppTest; live path uses `wattlab.weather.open_meteo` with campus/form coords.
 Tests: `tests/test_degree_days_fuel_weather.py`.
 
@@ -185,7 +212,7 @@ Tests: `tests/test_benchmarks_guardrails.py`.
 
 ## 10. Studio workspace (agent + Streamlit)
 
-Shared tree for Uploads and external agents (Codex CLI). Default:
+Shared tree for Uploads and external AI agents. Default:
 `.artifacts/studio_workspace/` or env `WATTLAB_STUDIO_WORKSPACE` / `WATTLAB_WORKSPACE`.
 
 ```

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -1,188 +1,119 @@
 # The twin-iterate loop — human + AI agent protocol
 
-How an AI agent and an energy engineer take a building from vibe19 FDD dump to
-a benchmark-gated capital plan. Every step has a CLI path (agent) and a Studio
-page (human); both share the same `wattlab` modules, so numbers never diverge.
+How an AI agent and an energy engineer take **any** building from a vibe19 FDD
+dump + energy package to a benchmark-gated capital plan. Practice dumps on a
+test bench are examples only — never bake site ids into code or answers.
 
-## Step 0 — Ingest the evidence
+Every step has a CLI path (agent) and a Studio surface (human). Both share
+`wattlab` modules. Any AI agent chats **outside** Streamlit on the workspace folder;
+Studio refreshes from `uploads/`, `runs/`, `reports/`. Agents must **publish** each
+E+ iteration so Twin 08 panes appear in the browser
+(`publish_run_for_studio` / `runs/CURRENT_RUN.txt`).
+
+Full paste prompt for QA + calibrate sessions:
+[`../AGENT_TESTER_PROMPT.md`](../AGENT_TESTER_PROMPT.md).
+
+## Step 0 — Uploads (evidence)
 
 ```
 wattlab seed dump.zip            # summary
 wattlab seed dump.zip --gaps     # what the human still owes
 ```
 
-Studio: **Ingest** page. The gap report is the conversation starter: the agent
-asks the human for `required` gaps (building type, city, floor area) and
-`recommended` ones (bills, WWR, rates, measure costs). Never invent these.
+Studio: **Uploads**. Load dump v3 + energy package:
 
-## Step 1 — Benchmark the bills (before any model!)
+- Preferred: `campus.json` + bill CSVs (+ Haystack `column_map` if interval)
+- Fallback: monthly Excel → `uploads/energy/derived/` (verify with human)
+- Optional: `buildings.json` / dump `model_seed` for ids, area, type, lat/lon
+
+Gap report is the conversation starter. Ask for `required` gaps
+(`building_type`, `city`, `floor_area_ft2`) and recommended bills/rates/costs.
+**Never invent these.**
+
+## Step 1 — Fuel dashboard (before deep modeling)
+
+Studio: **Fuel dashboard**. Confirm:
+
+- Monthly kWh/gas/demand tables + ≥1 chart (Fuel-ready package)
+- Site EUI vs peer band; HDD/CDD + Open-Meteo only when lat/lon present
+- Shared-meter allocation scenarios are scenarios, not truth
+
+CLI: `wattlab benchmark campus.json` / `--scenarios`.
+
+If Fuel is empty after Excel load → bug or unmappable workbook; do not proceed
+to glossy ROI.
+
+## Step 2 — Resolve the Twin profile
+
+`resolve_profile(minimal)` with provenance. Studio: **Twin / calibrate** form
+prefilled from dump/campus — human confirms city, type, area, lat/lon.
+
+## Step 3 — ESCO proxies (screening)
+
+Measure list = catalog + FDD bridge. Bin-method proxies via `wattlab.bench.esco`.
+Studio: **ECMs** (and Twin crosscheck when proxies attached).
+
+## Step 4 — Run / iterate the twin (Docker EnergyPlus)
 
 ```
-wattlab benchmark campus.json                # annual EUIs + peer bands
-wattlab benchmark campus.json --scenarios    # shared-meter splits side-by-side
+wattlab easy-button --profile profile.json --dry-run
+wattlab easy-button --profile profile.json
 ```
 
-Studio: **Benchmark** page. Questions to answer *before* modeling:
+Studio Twin:
 
-- Is site EUI inside the peer band? Way below p20 with big savings claims
-  coming → something is wrong (area? allocation? vacancy?).
-- Does gas track heating degree days? Summer gas ≠ 0 → DHW/reheat baseload
-  the model must include.
-- Shared meters: which allocation scenario is being used, and does the story
-  change if you switch? If yes, flag it — don't pick silently.
+- Dry-run → `reports/last_dry_run_plan.json`
+- Docker run → `runs/<run_id>/` (report, eplusout, manifest)
+- Demo replay → fixture eplusout labeled replay (UI smoke without E+ image)
+- **08-style panes**: progress + console, outdoor DBT, classic 5Zone floor-plan
+  heatmap (`wattlab.studio.ep_viz`) — viz patterns only, not host Runtime API
 
-## Step 2 — Resolve the profile
+Baseline first. With bills (`reports/utility_bills.csv` or dump bills), G14
+monthly NMBE ±5% / CV(RMSE) ≤15% before calibrated savings claims.
 
-`resolve_profile(minimal)` fills archetype gaps with provenance
-(`field_sources`). Studio: **Model** page. The human confirms geometry and
-rates; everything defaulted stays visibly labeled as a default.
+**Human-in-the-loop calibrate:** one hypothesis per run (schedules, setpoints,
+capacity, weather EPW from dump/Open-Meteo). New `runs/<id>/` each time. Ask
+the engineer when gates fail or crosscheck is `investigate` / `keep_iterating`.
 
-## Step 3 — Price measures with ESCO proxies
+## Step 5 — Crosscheck
 
-Measure list = catalog measure set + FDD-suggested (bridge). Each measure gets
-a bin-method proxy estimate (`wattlab.bench.esco`) — screening-grade,
-spreadsheet-auditable. Studio: **Measures** page (editable costs).
-Agent: `wattlab bench` with explicit inputs.
-
-## Step 4 — Run the twin
-
-```
-python -m wattlab.easy_button --profile profile.json --dry-run   # plan only
-python -m wattlab.easy_button --profile profile.json             # Docker E+
-```
-
-Baseline first. If bills exist, the baseline must pass ASHRAE G14 monthly
-gates (NMBE ±5%, CV(RMSE) ≤15%) before any savings claim is "calibrated" —
-otherwise iterate: schedules from the dump, setpoints from `setpoints.csv`,
-envelope/LPD knobs from defaults, weather from the AMY EPW.
-
-Then measures run progressively; `savings_by_measure[].vs_previous` is each
-measure's incremental effect.
-
-## Step 5 — Crosscheck (the referee)
-
-Automatic when the profile carries `proxy_savings`; standalone:
-`wattlab crosscheck --report wattlab_report.json --proxies proxies.json`.
-
-| Verdict | Meaning | Agent action |
+| Verdict | Meaning | Action |
 | --- | --- | --- |
-| `in_line` (0.5–2.0×) | E+ and bin method agree | proceed |
-| `investigate` | outside band | check patch applied, schedule overlap, sizing; re-run |
-| `keep_iterating` | wrong sign / zero proxy vs big E+ | model bug until proven otherwise |
+| `in_line` (0.5–2.0×) | E+ ≈ proxy | proceed |
+| `investigate` | outside band | check patch/schedule/sizing; re-run |
+| `keep_iterating` | wrong sign / missing | model bug until proven otherwise |
 
-The spreadsheet method is the trust anchor: when they disagree, suspect the
-model first, then the proxy inputs, then (rarely) the method.
+Always area-normalize vs the 5ZoneAirCooled prototype footprint
+(`prototype_area_scale`). The prototype name is an EnergyPlus sample, not a site.
 
-**Area normalization (learned live on Liberty):** the bundled 5ZoneAirCooled
-prototype is only ~10k ft², so raw E+ kWh for a 140k ft² profile under-reports
-~14× and every verdict comes back `investigate` for the wrong reason. The
-crosscheck now auto-scales via `prototype_area_scale` (target ft² / model ft²
-from the baseline record's `building_area_m2`) and reports both raw and
-scaled values plus the `area_scale` used. G14 comparisons scale the modeled
-monthly series the same way. When the scaled ratio is *still* outside the
-band, the disagreement is real — schedule assumptions, W/cfm, kW/ton — not
-geometry. The long-term fix is a right-sized prototype; the scale factor is
-the honest screening bridge until then.
+## Step 6 — Capital guardrails
 
-**Monthly data prerequisite:** the G14 gate only fires when the baseline
-record has a `monthly` series. `easy_button` now patches monthly
-`Output:Meter,Electricity:Facility` / `NaturalGas:Facility` into every
-prototype (`apply_monthly_energy_tables`) and, because EnergyPlus 26.1 still
-writes no monthly tabular section for this prototype, results parsing falls
-back to `eplusout.mtr` (`parse_monthly_from_mtr`). If `monthly` is empty,
-fix the outputs — don't skip the gate.
+`gate_capital_plan` on every plan. Studio **ECMs** capital section. Any hit →
+`INVESTIGATE`; human overrides explicitly.
 
-Full rehearsal of steps 1–7 against the Liberty campus (real Docker E+ runs):
-`python scripts/agent_twin_demo.py --measure-set best`.
+## Workspace paths (shared with Studio)
 
-## Step 6 — Capital plan + benchmark gate
-
-`wattlab.finance.capital_plan` rolls up payback/ROI/NPV. Then — mandatory —
-`gate_capital_plan` (see [BENCHMARK_GOVERNANCE.md](BENCHMARK_GOVERNANCE.md)).
-Studio: **Capital plan** page shows `PUBLISH` / `INVESTIGATE` with the check
-table. An agent must never present ROI output from an `INVESTIGATE` plan
-without surfacing the failed checks verbatim.
-
-## Step 7 — Report ranges, not points
-
-Cost and savings statements carry range + basis + confidence, e.g. "major
-HVAC retrofit: reference band ~$3.8–7.0/ft² (median $4.6/ft², 2009$, adjust
-for market)". Single-point promises are an anti-pattern this tool exists to
-prevent.
-
-## Iteration bookkeeping
-
-Every E+ run writes `run_manifest.json` (model SHA, weather SHA, image pin).
-Studio Twin loop shows the last 10. Never compare savings across runs with
-different weather or prototype hashes.
-
-## School 30-year rehearsal
-
-`examples/school_30yr/` is a fictional 100,000 ft² K-12 school with twelve
-repository-authored 2025 bills labeled `synthetic_rehearsal`. It contains no
-measured or transformed customer, district, contractor, or utility data.
-
-Before network or simulation work, strict Pydantic contracts reject extra
-fields, invalid coordinates/date order, incomplete EPW variables, bad
-fuel-unit pairs, duplicate or non-consecutive bills, mixed fuels/units, and
-scenarios without unique measures or an explicit conceptual-surrogate flag.
-The Open-Meteo archive flow uses request-keyed atomic caching, source SHA and
-download provenance, bounded retries for timeout/429/5xx only, declared-unit
-and physical-bound validation, consecutive timestamps, and exact full-year
-coverage (8,760 rows; 8,784 in leap years).
-
-Open-Meteo archive rows arrive in UTC. A full-year frame must be rotated and
-restamped to the site's **local standard time** before EPW generation, with
-the same fixed UTC offset in the LOCATION header. DST is not applied. Writing
-UTC rows into a local EPW misaligns radiation and weather schedules.
-
-The two progressive scenarios are:
-
-- `school_30yr_hydronic`: schedule alignment → premium fan/VFD →
-  high-efficiency chiller → condensing boiler → glazing.
-- `school_30yr_electrify`: schedule alignment → premium fan/VFD →
-  high-efficiency chiller → AWHP surrogate → glazing.
-
-Both are conceptual. The AWHP is modeled as an electric boiler at a screening
-COP, glazing uses a simple-glazing envelope proxy, and fan/chiller/boiler
-replacements directly edit efficiencies or equipment parameters. These do not
-model heat-pump performance maps, plant redesign, controls integration,
-detailed fenestration, equipment selection, or constructability.
-
-```powershell
-cd vibe_code_apps_20
-
-# Focused unit suite; no network or Docker
-python -m pytest tests/test_input_contracts.py tests/test_open_meteo_weather.py tests/test_deep_retrofit_patches.py tests/test_school_30yr_rehearsal.py -q
-
-# Full suite
-python -m pytest -q
-
-# Opt-in live Open-Meteo + Docker integration
-$env:RUN_SCHOOL_30YR_LIVE="1"
-python -m pytest tests/test_school_30yr_rehearsal.py::test_live_school_30yr_rehearsal -q -s
-Remove-Item Env:RUN_SCHOOL_30YR_LIVE
-
-# Generate the canonical report directly
-python scripts/school_30yr_rehearsal.py
+```
+uploads/dump/  uploads/energy/  uploads/energy/derived/
+runs/<run_id>/eplusout.csv | run_manifest.json | progress.json | report.json
+reports/utility_bills.csv | last_dry_run_plan.json | BUG_REPORT.md | CALIBRATE_SESSION.md
 ```
 
-The script's process exit describes execution only: simulation/runtime failure
-is nonzero, while a completed `INVESTIGATE` rehearsal exits zero. The release
-guard requires separate monthly electricity and natural-gas G14 passes.
-Major-HVAC component costs use explicit shares that total one p50 package per
-scenario; controls and glazing remain separate.
+## Docker turnkey (Studio + EnergyPlus MCP image)
 
-The 2026-07-18 live rehearsal produced 12/12 `COMPLETE` records. Simulation
-completion is not publication approval: baseline electricity fails G14 at
-52.21% NMBE / 52.61% CV(RMSE), natural gas fails at 78.03% / 93.74%, and
-conceptual flags are present, so the fail-closed release guard returns
-`INVESTIGATE` for each scenario and overall.
+```bash
+docker pull ghcr.io/bbartling/vibe20:latest
+docker run -d --restart unless-stopped -p 8520:8501 \
+  -v "$HOME/wattlab_workspace:/data" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e WATTLAB_STUDIO_WORKSPACE=/data \
+  --name vibe20 ghcr.io/bbartling/vibe20:latest
+```
 
-Canonical report: `.artifacts/school_30yr_rehearsal.json`. Its `comparison`
-rollup reports:
+**Required for Twin calibrate PASS:** host image `energyplus-mcp-dev` plus a
+**multi-run live campaign** (≥3 successful Docker sims published to `runs/<id>/`
+for browser 08 panes — baseline + hypotheses). Build image per
+`third_party/README.md`. Probe: `wattlab.energyplus.mcp.capability_status()`.
+Prefer EnergyPlus-MCP inspect when the vendor tree is cloned. Demo replay ≠ PASS.
 
-- hydronic: 90,261.2 kWh and 4,864.5 therms saved/year; $17,986.53/year;
-  $716,806.94 implementation cost; -$346,521.59 NPV; `INVESTIGATE`.
-- electrify: 61,148.4 kWh and 8,085.7 therms saved/year; $17,133.43/year;
-  $716,806.94 implementation cost; -$364,084.16 NPV; `INVESTIGATE`.
+Full campaign prompt: [`../AGENT_TESTER_PROMPT.md`](../AGENT_TESTER_PROMPT.md).

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
@@ -1,83 +1,82 @@
 ---
 name: wattlab-studio
 description: >-
-  Use when working on the WattLab Studio Streamlit app: studio.py pages
-  (Ingest, Model, Benchmark, Fuel Weather, Hypothesis Lab, ECM Easy Buttons,
-  Measures, Twin loop, EP Results, Capital plan), session state keys, Plotly,
-  AppTest smoke, guardrail verdict rendering. Triggers on: Studio, Streamlit,
-  studio.py, page, AppTest, plotly chart, capital plan UI, benchmark page,
-  Fuel Weather, Hypothesis Lab, Easy Buttons.
+  Use when working on WattLab Studio Streamlit: 4 pages (Uploads, Fuel dashboard,
+  Twin/calibrate, ECMs), workspace uploads/runs/reports, Excel→campus fallback,
+  APIHelper-08 Twin panes, AppTest smoke, Plotly. Triggers on: Studio, Streamlit,
+  studio.py, Uploads, Fuel dashboard, Twin, ECMs, AppTest, eplusout, floor plan.
 ---
 
-# WattLab Studio — the ESCO cockpit (Streamlit)
+# WattLab Studio — ESCO cockpit (4 pages)
 
-Human-facing side of the twin loop. Launch: `wattlab studio` (or
-`streamlit run studio.py`). Look-and-feel follows vibe19: Plotly charts,
-lazy pages, wide layout. Page modules live under `wattlab/studio/pages/`.
+Human-facing dropzone + results viewer. Launch: `wattlab studio` or GHCR
+`ghcr.io/bbartling/vibe20:latest` on `:8520`. Any AI agent chats **outside**
+Streamlit on `WATTLAB_STUDIO_WORKSPACE` and publishes Twin runs for the browser.
+Pages: `wattlab/studio/pages/{uploads,fuel_dashboard,twin_calibrate,ecms}.py`.
 
 ## Hard rule — data-model driven sites
 
 - **Never hardcode** Liberty / Detroit / Madison / building ids / bill filenames
-  into page logic. Sites are `campus.json` + CSVs (+ optional Haystack maps).
-- `examples/liberty/` and the shared-meter fixture are **examples / CI only**.
-- Lat/lon: from `campus.json` (`lat`/`lon`) or the form — required for live
-  Open-Meteo, never a baked-in city.
-- Column maps: monthly `bill_columns` on campus/meters; interval Phase 2 must
-  reuse vibe19 Haystack `points` → CSV header maps
-  (`../vibe_code_apps_19/docs/COLUMN_MAP_JSON.md`).
+  into page logic. Sites are dump `model_seed` + `campus.json` + CSVs
+  (+ optional Haystack maps / Excel derive + `buildings.json`).
+- `examples/liberty/` and shared-meter fixture are **examples / CI only**.
+- Lat/lon: from campus / dump / form — required for live Open-Meteo.
+- Column maps: monthly `bill_columns`; interval Phase 2 reuses vibe19 Haystack
+  `points` → CSV headers.
 
 ## Pages and state keys
 
 | Page | Does | Key session keys |
 | --- | --- | --- |
-| Ingest | vibe19 dump upload → summary, gap checklist, fault highlights | `studio_bundle` |
-| Data Explorer | dump tables + telemetry browse | (bundle) |
-| Assumption Ledger | read-only provenance | profile / bundle / hypothesis |
-| Model | resolve_profile form + provenance + calibration badge | `studio_profile` |
-| Benchmark | campus.json bills → EUIs vs peer bands, allocation scenarios | `studio_campus`, `studio_benchmark_summary`, `studio_allocation` |
-| Fuel Weather | campus bills × Open-Meteo/synthetic HDD/CDD, heatmaps, R² | `fuel_weather_campus`, `fuel_weather_hourly`, `fuel_weather_meta` |
-| Existing Building Hypothesis Lab | sparse-input explore-existing ladder + downloads | `hypothesis_lab.*` |
-| ECM Easy Buttons | catalog-driven proxy / conceptual E+ cards + packages | `ecm_easy.*` |
-| Measures | measure set + bridge suggestions, ESCO proxy savings, editable costs | `studio_measures`, `studio_proxies`, `studio_costs` |
-| Twin loop | dry-run plan / Docker E+ runs, crosscheck verdicts, manifest history | `studio_plan`, `studio_report` |
-| EP Results | post-sim charts / scorecards | `studio_ep_results` |
-| Capital plan | finance rollup + **guardrail gate** + downloads | `studio_capital_plan`, `studio_guardrail_gate` |
+| Uploads | dump v3 + energy package (campus / Excel / Haystack); workspace listing | `studio_bundle`, `studio_energy`, `studio_campus`, `studio_utility_bills_path` |
+| Fuel dashboard | monthly fuel, peers, HDD/CDD, gap-aware charts | `studio_campus` / `fuel_weather_*` |
+| Twin / calibrate | profile, dry-run, Docker E+, 08 panes (progress/OA/floor plan), modeled vs bills, iteration history | `studio_profile`, `studio_plan`, `studio_report`, `studio_active_run` |
+| ECMs | catalog Easy Buttons + capital guardrails | `studio_measures`, `studio_proxies`, `studio_capital_plan`, `studio_guardrail_gate` |
 
-Navigation: `st.sidebar.radio(key="studio_page")`. Campus path fields default
-to the **fixture** (or a local example campus when its CSVs exist) — operators
-point at any production `campus.json`. Profile/bundle changes must invalidate
-stale hypothesis/report state.
+Navigation: `st.sidebar.radio(key="studio_page")` with only those four entries
+in `studio.py` `PAGES`.
+
+## Workspace contract
+
+```
+uploads/dump/  uploads/energy/  uploads/energy/derived/
+runs/<run_id>/   # eplusout.csv, run_manifest.json, progress.json, report.json
+reports/         # utility_bills.csv, dry-run plan, BUG_REPORT.md
+```
+
+Excel without `campus.json` → derive under `derived/` via
+`wattlab.energy_use.excel_campus` (hints from `buildings.json` or dump seed).
+Uploads success toast only when `fuel_ready`; otherwise warning.
+
+Twin 08 viz: `wattlab.studio.ep_viz` (classic 5Zone floor plan = prototype
+geometry convention, not a site id). Demo replay from
+`tests/fixtures/eplusout/eplusout.csv` when Docker E+ image missing.
+
+Docker sock: document `-v /var/run/docker.sock:/var/run/docker.sock` so Studio
+container can spawn `energyplus-mcp-dev`.
 
 ## Conventions (do not regress)
 
-1. `width='stretch'` — never the deprecated `use_container_width`.
-2. Unique `key=` on every widget and `st.plotly_chart` (prevents stale reuse).
-3. Dry-run path must work with zero Docker/network. Docker failures show
-   `st.error`, never a traceback. Fuel Weather offline path = synthetic OAT.
-4. Guardrail gate always renders on Capital plan: green `PUBLISH` banner or
-   red `INVESTIGATE` with the check table expanded. Never hide failed checks.
-5. Proxy pricing goes through `estimate_proxy_savings` →
-   `wattlab.bench.esco`; EnergyPlus `vs_previous` savings take precedence
-   when a report exists (caption states which source is live).
-6. Charts are Plotly (`go`/`px`); peer-band charts draw p50 dash + p80 dot
-   reference lines; allocation scenarios are grouped bars.
+1. `width='stretch'` — never deprecated `use_container_width`.
+2. Unique `key=` on every widget and `st.plotly_chart`.
+3. Dry-run + demo replay work with zero Docker E+. Missing image → clear banner.
+4. Guardrail gate always renders on ECMs capital section.
+5. Proxy pricing via `estimate_proxy_savings` / ESCO; E+ savings when report exists.
+6. Charts are Plotly; Fuel gaps are explicit blanks, not fake continuity.
 
 ## Smoke (before claiming done)
 
-```powershell
-python scripts/smoke_studio.py     # AppTest: all pages + fixture campus + Fuel Weather
-python -m pytest tests/test_studio_app.py -q
-# live: wattlab studio → http://localhost:8501/_stcore/health → "ok"
+```text
+python scripts/smoke_studio.py
+python -m pytest tests/test_studio_app.py tests/test_excel_campus.py tests/test_ep_viz.py -q
+# live: http://localhost:8520/_stcore/health → ok
 ```
 
-AppTest gotchas: form submit is `at.button[0]` (forms don't expose keys);
-`at.radio(key="studio_page").set_value(...).run()` to switch pages; keep
-console output ASCII (Windows cp1252).
+Tester / calibrate loop prompt: `vibe20_agent_spec/AGENT_TESTER_PROMPT.md`
+(live `energyplus-mcp-dev` + optional EnergyPlus-MCP required for Twin calibrate PASS).
 
 ## Adding a page
 
-1. Prefer `wattlab/studio/pages/<name>.py` + entry in `PAGES` + branch in `main()`.
-2. Namespaced state keys (`studio_*` / page prefix), unique widget keys.
-3. Extend `scripts/smoke_studio.py` walk + an AppTest in
-   `tests/test_studio_app.py`.
-4. Update this skill + `vibe20_agent_spec/AGENTS.md` + `DATA_CONTRACT.md` + README.
+Prefer folding into the four surfaces. If a new page is unavoidable: add
+`wattlab/studio/pages/<name>.py`, `PAGES` entry, smoke + AppTest, then update
+this skill + `AGENTS.md` + `DATA_CONTRACT.md` + README.

--- a/vibe_code_apps_20/wattlab/easy_button.py
+++ b/vibe_code_apps_20/wattlab/easy_button.py
@@ -414,6 +414,19 @@ def run_easy_button(
     )
     if profile_path is not None and profile_path.is_file():
         shutil.copy2(profile_path, run_dir / "building_profile.json")
+
+    # Publish into Studio workspace so any external AI agent / human browser
+    # Twin page can show APIHelper-08 panes without copying by hand.
+    try:
+        from wattlab.studio.ep_viz import publish_run_for_studio
+        from wattlab.studio.workspace import workspace_root
+
+        _ = workspace_root()  # ensure env-aware root
+        published = publish_run_for_studio(run_dir, run_id=run_id, report=report)
+        report["studio_run_dir"] = str(published)
+    except Exception as exc:
+        report["studio_publish_error"] = str(exc)
+
     return report
 
 

--- a/vibe_code_apps_20/wattlab/energy_use/excel_campus.py
+++ b/vibe_code_apps_20/wattlab/energy_use/excel_campus.py
@@ -1,0 +1,545 @@
+"""Best-effort Excel → campus.json + bill CSVs for Fuel / Twin.
+
+Monthly fuel workbooks without ``campus.json`` are common practice packages.
+Prefer an existing campus package; Excel is a fallback so Fuel charts are not
+silently empty. Building ids / areas / coords come from optional package
+sidecars or caller hints (dump ``model_seed``) — never site-specific hardcodes.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+_MONTH_RE = re.compile(r"^(\d{4})[-/](\d{1,2})$")
+_MONTH_NAME_RE = re.compile(
+    r"^(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*[\s\-_/]*(\d{2,4})$",
+    re.I,
+)
+_MONTH_NUM = {
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "may": 5,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
+
+
+@dataclass
+class DerivedMeter:
+    meter_id: str
+    fuel: str  # electricity | gas
+    unit: str  # kwh | mcf | therm
+    serves: list[str]
+    rows: list[dict[str, Any]] = field(default_factory=list)
+    shared: bool = False
+    source_sheet: str = ""
+
+
+@dataclass
+class ExcelCampusResult:
+    out_dir: Path
+    campus_path: Path
+    campus_id: str
+    meters: list[DerivedMeter]
+    notes: list[str] = field(default_factory=list)
+
+
+def _norm_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m")
+    if isinstance(value, date):
+        return value.strftime("%Y-%m")
+    return str(value).strip()
+
+
+def _to_month(value: Any) -> str | None:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    if isinstance(value, datetime):
+        return f"{value.year:04d}-{value.month:02d}"
+    if isinstance(value, date):
+        return f"{value.year:04d}-{value.month:02d}"
+    text = str(value).strip().replace(",", "")
+    if not text:
+        return None
+    m = _MONTH_RE.match(text[:7].replace("/", "-") if len(text) >= 7 else text)
+    if m:
+        return f"{int(m.group(1)):04d}-{int(m.group(2)):02d}"
+    # Excel serial as number
+    if isinstance(value, (int, float)) and 20000 < float(value) < 60000:
+        try:
+            from openpyxl.utils.datetime import from_excel
+
+            dt = from_excel(float(value))
+            return f"{dt.year:04d}-{dt.month:02d}"
+        except Exception:
+            pass
+    m2 = _MONTH_NAME_RE.match(text.replace(".", ""))
+    if m2:
+        mon = _MONTH_NUM[m2.group(1).lower()[:3]]
+        year = int(m2.group(2))
+        if year < 100:
+            year += 2000
+        return f"{year:04d}-{mon:02d}"
+    # pandas Timestamp string
+    try:
+        ts = pd.to_datetime(text, errors="coerce")
+        if pd.notna(ts):
+            return f"{int(ts.year):04d}-{int(ts.month):02d}"
+    except Exception:
+        pass
+    return None
+
+
+def _classify_header(text: str) -> str | None:
+    t = text.lower().strip()
+    if not t:
+        return None
+    if any(k in t for k in ("month", "period", "billing", "bill date", "read date")):
+        return "month"
+    if "demand" in t and ("kw" in t or "kW" in text or "billed" in t):
+        return "demand_kw"
+    if any(k in t for k in ("charge", "cost", "$", "amount")):
+        return "cost_usd"
+    if any(k in t for k in ("kwh", "kw-h", "electric", "elec")) and "demand" not in t:
+        return "usage_elec"
+    if any(k in t for k in ("mcf", "ccf", "therm", "gas", "nat gas", "natural gas")):
+        return "usage_gas"
+    if "usage" in t or "consumption" in t or "quantity" in t:
+        return "usage"
+    return None
+
+
+def _sheet_matrix(ws: Any) -> list[list[Any]]:
+    rows: list[list[Any]] = []
+    for row in ws.iter_rows(values_only=True):
+        rows.append(list(row))
+        if len(rows) >= 400:
+            break
+    return rows
+
+
+def _parse_long_table(matrix: list[list[Any]], sheet_name: str) -> DerivedMeter | None:
+    header_idx = None
+    roles: dict[int, str] = {}
+    for i, row in enumerate(matrix[:40]):
+        found: dict[str, int] = {}
+        for j, cell in enumerate(row):
+            role = _classify_header(_norm_cell(cell))
+            if role and role not in found:
+                found[role] = j
+        if "month" in found and (
+            "usage_elec" in found or "usage_gas" in found or "usage" in found
+        ):
+            header_idx = i
+            roles = {j: r for r, j in found.items()}
+            break
+    if header_idx is None:
+        return None
+
+    fuel = "electricity"
+    unit = "kwh"
+    role_values = set(roles.values())
+    if "usage_gas" in role_values:
+        fuel = "gas"
+        unit = "mcf"
+    sheet_l = sheet_name.lower()
+    if any(k in sheet_l for k in ("gas", "therm", "mcf")):
+        fuel = "gas"
+        unit = "mcf" if "therm" not in sheet_l else "therm"
+    if any(k in sheet_l for k in ("elec", "electric", "kwh")):
+        fuel = "electricity"
+        unit = "kwh"
+
+    usage_role = (
+        "usage_elec"
+        if "usage_elec" in role_values
+        else ("usage_gas" if "usage_gas" in role_values else "usage")
+    )
+    month_j = next(j for j, r in roles.items() if r == "month")
+    usage_j = next(j for j, r in roles.items() if r == usage_role)
+    demand_j = next((j for j, r in roles.items() if r == "demand_kw"), None)
+    cost_j = next((j for j, r in roles.items() if r == "cost_usd"), None)
+
+    out_rows: list[dict[str, Any]] = []
+    for row in matrix[header_idx + 1 :]:
+        if month_j >= len(row) or usage_j >= len(row):
+            continue
+        month = _to_month(row[month_j])
+        if not month:
+            continue
+        usage = pd.to_numeric(_norm_cell(row[usage_j]).replace(",", ""), errors="coerce")
+        if pd.isna(usage):
+            continue
+        rec: dict[str, Any] = {"month": month, "usage": float(usage)}
+        if demand_j is not None and demand_j < len(row):
+            dem = pd.to_numeric(_norm_cell(row[demand_j]).replace(",", ""), errors="coerce")
+            if pd.notna(dem):
+                rec["demand_kw"] = float(dem)
+        if cost_j is not None and cost_j < len(row):
+            cost = pd.to_numeric(_norm_cell(row[cost_j]).replace(",", ""), errors="coerce")
+            if pd.notna(cost):
+                rec["cost_usd"] = float(cost)
+        out_rows.append(rec)
+
+    if len(out_rows) < 3:
+        return None
+
+    # Aggregate duplicate months
+    df = pd.DataFrame(out_rows)
+    agg: dict[str, str] = {"usage": "sum"}
+    if "demand_kw" in df.columns:
+        agg["demand_kw"] = "max"
+    if "cost_usd" in df.columns:
+        agg["cost_usd"] = "sum"
+    df = df.groupby("month", as_index=False).agg(agg).sort_values("month")
+    rows = df.to_dict(orient="records")
+
+    meter_id = re.sub(r"[^a-zA-Z0-9_]+", "_", sheet_name).strip("_").lower() or "meter"
+    return DerivedMeter(
+        meter_id=meter_id[:48],
+        fuel=fuel,
+        unit=unit,
+        serves=[],
+        rows=rows,
+        source_sheet=sheet_name,
+    )
+
+
+_BLDG_TOKEN_RE = re.compile(
+    r"(?:building|bldg|bld|site|facility)[\s_\-#]*([a-zA-Z0-9]+)",
+    re.I,
+)
+_FUEL_WORDS = {
+    "electric",
+    "electricity",
+    "elec",
+    "kwh",
+    "gas",
+    "therm",
+    "mcf",
+    "shared",
+    "meter",
+    "monthly",
+    "consumption",
+    "summary",
+    "analysis",
+    "energy",
+    "dte",
+    "fuel",
+}
+
+
+def _slug(text: str, fallback: str = "building") -> str:
+    s = re.sub(r"[^a-zA-Z0-9_]+", "_", text).strip("_").lower()
+    return (s or fallback)[:48]
+
+
+def _load_building_hints(root: Path) -> list[dict[str, Any]]:
+    """Optional data-model sidecars: buildings.json or campus_hint.json."""
+    for name in ("buildings.json", "campus_hint.json", "site.json"):
+        path = root / name
+        if not path.is_file():
+            continue
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        buildings = doc.get("buildings") if isinstance(doc, dict) else doc
+        if isinstance(buildings, list) and buildings:
+            out: list[dict[str, Any]] = []
+            for b in buildings:
+                if not isinstance(b, dict) or not b.get("building_id"):
+                    continue
+                out.append(
+                    {
+                        "building_id": str(b["building_id"]),
+                        "label": str(b.get("label") or b["building_id"]),
+                        "floor_area_ft2": float(b.get("floor_area_ft2") or 0) or 1.0,
+                        "property_type": str(b.get("property_type") or "office"),
+                    }
+                )
+            if out:
+                return out
+    return []
+
+
+def _guess_buildings(
+    stem: str,
+    sheet_names: list[str],
+    *,
+    building_hints: list[dict[str, Any]] | None = None,
+    default_area_ft2: float | None = None,
+    property_type: str | None = None,
+) -> list[dict[str, Any]]:
+    if building_hints:
+        return building_hints
+    area = float(default_area_ft2) if default_area_ft2 and default_area_ft2 > 0 else 1.0
+    ptype = (property_type or "office").strip() or "office"
+
+    tokens: list[str] = []
+    for name in sheet_names:
+        for m in _BLDG_TOKEN_RE.finditer(name):
+            tok = m.group(1)
+            if tok.lower() in _FUEL_WORDS:
+                continue
+            if tok not in tokens:
+                tokens.append(tok)
+    if len(tokens) >= 2:
+        return [
+            {
+                "building_id": _slug(f"bldg_{tok}"),
+                "label": f"Building {tok}",
+                "floor_area_ft2": area,
+                "property_type": ptype,
+            }
+            for tok in tokens
+        ]
+
+    bid = _slug(stem, "building_1")
+    return [
+        {
+            "building_id": bid,
+            "label": stem or "Building",
+            "floor_area_ft2": area,
+            "property_type": ptype,
+        }
+    ]
+
+
+def _assign_serves(meters: list[DerivedMeter], building_ids: list[str]) -> None:
+    if not building_ids:
+        return
+    for m in meters:
+        sheet = m.source_sheet.lower()
+        matched = [bid for bid in building_ids if bid.lower() in sheet or bid.split("_")[-1].lower() in sheet]
+        # Also match Building <token> style labels embedded in sheet names
+        if not matched:
+            for bid in building_ids:
+                token = bid.split("_")[-1].lower()
+                if token and token in sheet and token not in _FUEL_WORDS:
+                    matched.append(bid)
+        if matched:
+            m.serves = matched[:1] if m.fuel == "gas" else matched
+            m.shared = m.fuel == "electricity" and len(m.serves) > 1
+        elif m.fuel == "electricity" and len(building_ids) > 1:
+            m.serves = list(building_ids)
+            m.shared = True
+        else:
+            m.serves = [building_ids[0]]
+
+
+def derive_campus_from_excel(
+    root: Path,
+    *,
+    out_dir: Path | None = None,
+    campus_id: str | None = None,
+    lat: float | None = None,
+    lon: float | None = None,
+    building_hints: list[dict[str, Any]] | None = None,
+    default_area_ft2: float | None = None,
+    property_type: str | None = None,
+) -> ExcelCampusResult:
+    """Scan ``*.xlsx`` under ``root`` and write campus.json + bill CSVs."""
+    try:
+        from openpyxl import load_workbook
+    except ImportError as exc:
+        raise RuntimeError(
+            'Excel intake requires openpyxl — install with: pip install -e ".[excel]"'
+        ) from exc
+
+    root = Path(root)
+    workbooks = sorted(
+        p for p in root.rglob("*.xlsx") if not p.name.startswith("~$") and p.is_file()
+    )
+    if not workbooks:
+        raise ValueError(
+            "No campus.json and no .xlsx workbooks found. "
+            "Provide campus.json + bill CSVs, or a monthly fuel Excel package."
+        )
+
+    meters: list[DerivedMeter] = []
+    notes: list[str] = []
+    sheet_names: list[str] = []
+    for wb_path in workbooks:
+        try:
+            wb = load_workbook(wb_path, data_only=True, read_only=True)
+        except Exception as exc:
+            notes.append(f"Skipped unreadable workbook {wb_path.name}: {exc}")
+            continue
+        for ws in wb.worksheets:
+            sheet_names.append(ws.title)
+            matrix = _sheet_matrix(ws)
+            parsed = _parse_long_table(matrix, ws.title)
+            if parsed is None:
+                continue
+            # Prefer workbook stem in meter id when sheet is generic
+            if parsed.meter_id in {"sheet1", "sheet", "data", "summary"}:
+                parsed.meter_id = (
+                    re.sub(r"[^a-zA-Z0-9_]+", "_", wb_path.stem).strip("_").lower()[:40]
+                    + f"_{parsed.fuel[:4]}"
+                )
+            meters.append(parsed)
+            notes.append(
+                f"Excel sheet '{ws.title}' → {parsed.fuel} ({len(parsed.rows)} months) "
+                f"from {wb_path.name}"
+            )
+
+    if not meters:
+        raise ValueError(
+            "Found Excel workbooks but no monthly bill tables "
+            "(need a Month column plus kWh / Mcf / therm / usage)."
+        )
+
+    # Deduplicate: keep largest series per (fuel, serves hint)
+    meters.sort(key=lambda m: len(m.rows), reverse=True)
+    chosen: list[DerivedMeter] = []
+    seen_keys: set[str] = set()
+    for m in meters:
+        key = f"{m.fuel}:{m.source_sheet.lower()}"
+        if key in seen_keys:
+            continue
+        # One shared electric + per-building gas preferred
+        if m.fuel == "electricity" and any(c.fuel == "electricity" for c in chosen):
+            continue
+        seen_keys.add(key)
+        chosen.append(m)
+
+    stem = root.name if root.name else "campus"
+    hints = building_hints or _load_building_hints(root)
+    buildings = _guess_buildings(
+        stem,
+        sheet_names,
+        building_hints=hints or None,
+        default_area_ft2=default_area_ft2,
+        property_type=property_type,
+    )
+    if not hints and (not default_area_ft2 or default_area_ft2 <= 0):
+        notes.append(
+            "NEEDS_INPUT: floor_area_ft2 (set via buildings.json / dump model_seed / Twin form)"
+        )
+    bids = [b["building_id"] for b in buildings]
+    _assign_serves(chosen, bids)
+
+    dest = Path(out_dir) if out_dir is not None else (root / "derived")
+    dest.mkdir(parents=True, exist_ok=True)
+
+    cid = campus_id or re.sub(r"[^a-zA-Z0-9_]+", "_", stem).strip("_").lower() or "excel_campus"
+    meter_specs: list[dict[str, Any]] = []
+    for m in chosen:
+        fname = f"{m.meter_id}.csv"
+        csv_path = dest / fname
+        cols = [
+            "Bill Month",
+            "kWh Total" if m.fuel == "electricity" else "Usage",
+            "Billed Demand (kW)",
+            "Total Current Charges ($)",
+        ]
+        lines = [",".join(cols)]
+        for r in m.rows:
+            usage = r["usage"]
+            dem = r.get("demand_kw", "")
+            cost = r.get("cost_usd", "")
+            lines.append(f"{r['month']},{usage},{dem},{cost}")
+        csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        spec: dict[str, Any] = {
+            "meter_id": m.meter_id,
+            "fuel": m.fuel,
+            "unit": "kwh" if m.fuel == "electricity" else ("mcf" if m.unit != "therm" else "therm"),
+            "file": fname,
+            "serves": m.serves or bids[:1],
+        }
+        if m.shared or len(spec["serves"]) > 1:
+            spec["allocation"] = {"method": "area_weighted"}
+        meter_specs.append(spec)
+
+    campus_doc = {
+        "campus_id": cid,
+        "label": f"Derived from Excel ({stem})",
+        "notes": "Auto-derived from monthly fuel workbook(s); verify meters before publishing ROI.",
+        "siteRef": cid,
+        "lat": lat,
+        "lon": lon,
+        "buildings": buildings,
+        "meters": meter_specs,
+    }
+    campus_path = dest / "campus.json"
+    campus_path.write_text(json.dumps(campus_doc, indent=2), encoding="utf-8")
+    notes.insert(0, f"Derived campus.json + {len(meter_specs)} bill CSV(s) under {dest}")
+
+    return ExcelCampusResult(
+        out_dir=dest,
+        campus_path=campus_path,
+        campus_id=cid,
+        meters=chosen,
+        notes=notes,
+    )
+
+
+def campus_to_utility_bills_csv(campus: Any, out_path: Path) -> Path:
+    """Write a Twin-friendly utility_bills.csv from a loaded Campus."""
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    from wattlab.benchmarks.meters import latest_complete_window
+
+    month_sets = [m.months() for m in campus.meters if not m.bills.empty]
+    window = latest_complete_window(month_sets, months=12) if month_sets else None
+    months = list(window) if window else sorted(
+        {str(m)[:7] for meter in campus.meters for m in meter.bills["month"].astype(str)}
+    )
+    elec: dict[str, float] = {}
+    gas: dict[str, float] = {}
+    for meter in campus.meters:
+        for _, row in meter.bills.iterrows():
+            month = str(row["month"])[:7]
+            if months and month not in months:
+                continue
+            usage = float(row["usage"])
+            if meter.fuel == "electricity":
+                share = 1.0 / max(1, len(meter.serves))
+                elec[month] = elec.get(month, 0.0) + usage * share
+            else:
+                if meter.unit.lower() == "mcf":
+                    therms = usage * 10.37
+                elif meter.unit.lower() == "therm":
+                    therms = usage
+                else:
+                    therms = usage
+                gas[month] = gas.get(month, 0.0) + therms
+
+    rows = []
+    for month in sorted(set(elec) | set(gas)):
+        rows.append(
+            {
+                "month": month,
+                "period": month,
+                "kwh": elec.get(month),
+                "therms": gas.get(month),
+            }
+        )
+    pd.DataFrame(rows).to_csv(out_path, index=False)
+    return out_path
+
+
+__all__ = [
+    "DerivedMeter",
+    "ExcelCampusResult",
+    "campus_to_utility_bills_csv",
+    "derive_campus_from_excel",
+]

--- a/vibe_code_apps_20/wattlab/energy_use/package.py
+++ b/vibe_code_apps_20/wattlab/energy_use/package.py
@@ -29,6 +29,8 @@ class EnergyUsePackage:
     monthly_long: pd.DataFrame = field(default_factory=pd.DataFrame)
     notes: list[str] = field(default_factory=list)
     source: str = ""
+    derived_from_excel: bool = False
+    fuel_ready: bool = False
 
     @property
     def lat(self) -> float | None:
@@ -162,9 +164,8 @@ def _load_interval_frames(root: Path, column_map: dict[str, Any]) -> dict[str, p
         if not d.is_dir():
             continue
         for csv in d.glob("*.csv"):
-            if csv.name.lower().startswith("liberty") or "summary" in csv.name.lower():
-                continue
-            if csv.name.lower() in {"campus.json"}:
+            # Skip bill-summary style CSVs; interval frames need timestamps.
+            if "summary" in csv.name.lower() and "interval" not in str(d).lower():
                 continue
             try:
                 df = pd.read_csv(csv)
@@ -180,11 +181,25 @@ def _load_interval_frames(root: Path, column_map: dict[str, Any]) -> dict[str, p
     return frames
 
 
-def load_energy_use_package(path: str | Path) -> EnergyUsePackage:
-    """Load a folder or zip containing campus bills and/or Haystack meter maps."""
+def load_energy_use_package(
+    path: str | Path,
+    *,
+    derive_dir: str | Path | None = None,
+    building_hints: list[dict[str, Any]] | None = None,
+    default_area_ft2: float | None = None,
+    property_type: str | None = None,
+    lat: float | None = None,
+    lon: float | None = None,
+) -> EnergyUsePackage:
+    """Load a folder or zip containing campus bills and/or Haystack meter maps.
+
+    When ``campus.json`` is missing but ``.xlsx`` workbooks are present, derive a
+    campus package under ``derive_dir`` (or ``<root>/derived``).
+    """
     p = Path(path)
     notes: list[str] = []
     cleanup: Path | None = None
+    derived_from_excel = False
     if p.is_file() and p.suffix.lower() == ".zip":
         root = _extract_zip(p)
         cleanup = root if root.parent.name.startswith("energy_use_") else root.parent
@@ -202,7 +217,28 @@ def load_energy_use_package(path: str | Path) -> EnergyUsePackage:
             campus = Campus.from_json(campus_path)
             notes.append(f"Loaded campus.json ({campus.campus_id})")
         else:
-            notes.append("No campus.json — monthly campus analytics unavailable until provided")
+            xlsx = list(root.rglob("*.xlsx"))
+            if xlsx:
+                from wattlab.energy_use.excel_campus import derive_campus_from_excel
+
+                out = Path(derive_dir) if derive_dir else (root / "derived")
+                result = derive_campus_from_excel(
+                    root,
+                    out_dir=out,
+                    building_hints=building_hints,
+                    default_area_ft2=default_area_ft2,
+                    property_type=property_type,
+                    lat=lat,
+                    lon=lon,
+                )
+                campus = Campus.from_json(result.campus_path)
+                notes.extend(result.notes)
+                derived_from_excel = True
+                root = result.out_dir
+            else:
+                notes.append(
+                    "No campus.json — monthly campus analytics unavailable until provided"
+                )
 
         column_map = _load_column_map(root)
         if column_map:
@@ -213,6 +249,7 @@ def load_energy_use_package(path: str | Path) -> EnergyUsePackage:
             notes.append(f"Interval meter frames: {', '.join(sorted(meter_frames))}")
 
         monthly = meter_monthly_long(campus) if campus is not None else pd.DataFrame()
+        fuel_ready = campus is not None and bool(campus.meters) and not monthly.empty
 
         return EnergyUsePackage(
             root=root,
@@ -222,12 +259,12 @@ def load_energy_use_package(path: str | Path) -> EnergyUsePackage:
             monthly_long=monthly,
             notes=notes,
             source=source,
+            derived_from_excel=derived_from_excel,
+            fuel_ready=fuel_ready,
         )
     finally:
-        # Keep extracted tree for the session; caller may copy into workspace.
-        # Only auto-clean if we want — for Studio we keep temp until process ends.
         _ = cleanup
-        _ = shutil  # retained for future copy helpers
+        _ = shutil
 
 
 __all__ = [

--- a/vibe_code_apps_20/wattlab/studio/ep_viz.py
+++ b/vibe_code_apps_20/wattlab/studio/ep_viz.py
@@ -1,0 +1,346 @@
+"""EnergyPlusAPIHelper-08-style viz helpers (post-sim, Docker outputs only).
+
+Replicates the classic 5Zone floor-plan heatmap + OA chart patterns from
+``08_server_advanced`` without host ``pyenergyplus``. Zone geometry uses the
+standard DOE 5ZoneAirCooled compass layout (SPACE1-1…SPACE5-1); other zone
+names are mapped by discovery order or nickname heuristics.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+# Classic 5ZoneAirCooled floor-plan vertices (same layout as APIHelper 08 HTML).
+# Coordinates are unitless; Plotly scales them.
+ZONE_VERTICES: dict[str, list[list[float]]] = {
+    "north": [[0, 3], [1, 2], [4, 2], [5, 3]],
+    "south": [[0, 0], [5, 0], [4, 1], [1, 1]],
+    "east": [[5, 3], [4, 2], [4, 1], [5, 0]],
+    "west": [[0, 3], [0, 0], [1, 1], [1, 2]],
+    "center": [[1, 1], [1, 2], [4, 2], [4, 1]],
+}
+
+# Prototype zone name → compass role (EnergyPlus 5Zone convention, not a site id).
+PROTOTYPE_ZONE_ROLES: dict[str, str] = {
+    "SPACE1-1": "south",
+    "SPACE2-1": "west",
+    "SPACE3-1": "east",
+    "SPACE4-1": "north",
+    "SPACE5-1": "center",
+    "space1-1": "south",
+    "space2-1": "west",
+    "space3-1": "east",
+    "space4-1": "north",
+    "space5-1": "center",
+}
+
+
+def map_zones_to_roles(zone_names: list[str]) -> dict[str, str]:
+    """Map discovered zone names → north/south/east/west/center."""
+    roles: dict[str, str] = {}
+    remaining = ["south", "west", "east", "north", "center"]
+    for name in zone_names:
+        key = name.strip()
+        role = PROTOTYPE_ZONE_ROLES.get(key) or PROTOTYPE_ZONE_ROLES.get(key.upper())
+        if role and role not in roles.values():
+            roles[key] = role
+            if role in remaining:
+                remaining.remove(role)
+    for name in zone_names:
+        if name in roles:
+            continue
+        low = name.lower()
+        for role in list(remaining):
+            if role in low:
+                roles[name] = role
+                remaining.remove(role)
+                break
+    for name in zone_names:
+        if name in roles or not remaining:
+            continue
+        roles[name] = remaining.pop(0)
+    return roles
+
+
+def rgb_from_temperature(zone_temp: float, *, min_temp: float = 20.0, max_temp: float = 24.0) -> str:
+    t = max(min_temp, min(max_temp, float(zone_temp)))
+    ratio = (t - min_temp) / (max_temp - min_temp) if max_temp > min_temp else 0.5
+    red = int(ratio * 255)
+    blue = int(255 - red)
+    return f"rgb({red},0,{blue})"
+
+
+def zone_mean_by_role(ts: Any) -> dict[str, float]:
+    """Return {role: mean_temp_c} from an EplusTimeseries."""
+    means = ts.zone_mean_temps() if ts is not None else pd.DataFrame()
+    if means.empty:
+        return {}
+    names = [str(z) for z in means["zone"].tolist()]
+    roles = map_zones_to_roles(names)
+    out: dict[str, float] = {}
+    for _, row in means.iterrows():
+        role = roles.get(str(row["zone"]))
+        if role:
+            out[role] = float(row["mean_c"])
+    return out
+
+
+def floor_plan_figure(role_temps: dict[str, float]):
+    """Plotly floor-plan heatmap matching APIHelper 08 zone layout."""
+    import plotly.graph_objects as go
+
+    fig = go.Figure()
+    for role, vertices in ZONE_VERTICES.items():
+        temp = role_temps.get(role)
+        fill = rgb_from_temperature(temp) if temp is not None else "rgb(200,200,200)"
+        xs = [v[0] for v in vertices] + [vertices[0][0]]
+        ys = [v[1] for v in vertices] + [vertices[0][1]]
+        label = f"{role}: {temp:.1f} C" if temp is not None else f"{role}: n/a"
+        fig.add_trace(
+            go.Scatter(
+                x=xs,
+                y=ys,
+                fill="toself",
+                fillcolor=fill,
+                line={"color": "#000", "width": 1},
+                mode="lines",
+                name=label,
+                hoverinfo="name",
+            )
+        )
+    fig.update_layout(
+        title="Zone air temperatures (classic 5Zone floor plan)",
+        xaxis={"visible": False, "scaleanchor": "y"},
+        yaxis={"visible": False},
+        showlegend=True,
+        height=360,
+        margin={"l": 20, "r": 20, "t": 40, "b": 20},
+    )
+    return fig
+
+
+def outdoor_figure(outdoor: pd.DataFrame):
+    """OA drybulb over sim timesteps (08 right-hand chart)."""
+    import plotly.graph_objects as go
+
+    df = outdoor.copy()
+    if df.empty or "outdoor_db_c" not in df.columns:
+        fig = go.Figure()
+        fig.update_layout(title="Outdoor drybulb (no data)")
+        return fig
+    if "timestamp" not in df.columns:
+        df = df.reset_index(drop=True)
+        df["timestamp"] = df.index.astype(str)
+    # Downsample for UI
+    if len(df) > 2000:
+        stride = max(1, len(df) // 2000)
+        df = df.iloc[::stride]
+    fig = go.Figure(
+        data=[
+            go.Scatter(
+                x=list(range(len(df))),
+                y=df["outdoor_db_c"],
+                mode="lines",
+                name="Outdoor DBT C",
+                line={"width": 1},
+            )
+        ]
+    )
+    fig.update_layout(
+        title="Outdoor air drybulb (post-sim)",
+        xaxis_title="timestep",
+        yaxis_title="C",
+        height=280,
+        margin={"l": 40, "r": 20, "t": 40, "b": 40},
+    )
+    return fig
+
+
+def read_run_progress(run_dir: Path) -> dict[str, Any]:
+    """Load progress/log/manifest for the 08 left-hand manage card."""
+    run_dir = Path(run_dir)
+    out: dict[str, Any] = {
+        "run_id": run_dir.name,
+        "progress": 0,
+        "status": "unknown",
+        "log_tail": "",
+        "manifest": {},
+        "replay": False,
+    }
+    manifest_path = run_dir / "run_manifest.json"
+    if manifest_path.is_file():
+        try:
+            out["manifest"] = json.loads(manifest_path.read_text(encoding="utf-8"))
+            out["status"] = str(out["manifest"].get("status") or out["status"])
+            out["run_id"] = str(out["manifest"].get("run_id") or out["run_id"])
+        except (OSError, json.JSONDecodeError):
+            pass
+    progress_path = run_dir / "progress.json"
+    if progress_path.is_file():
+        try:
+            prog = json.loads(progress_path.read_text(encoding="utf-8"))
+            out["progress"] = int(prog.get("percent") or prog.get("progress") or 0)
+            out["status"] = str(prog.get("status") or out["status"])
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            pass
+    elif out["status"] in {"ok", "success", "completed", "complete"}:
+        out["progress"] = 100
+    for log_name in ("eplusout.err", "energyplus.log", "console.log", "run.log"):
+        lp = run_dir / log_name
+        if lp.is_file():
+            try:
+                text = lp.read_text(encoding="utf-8", errors="replace")
+                out["log_tail"] = text[-4000:]
+                break
+            except OSError:
+                continue
+    if (run_dir / "REPLAY.txt").is_file() or out["manifest"].get("replay"):
+        out["replay"] = True
+        out["progress"] = max(out["progress"], 100)
+        out["status"] = out["status"] if out["status"] != "unknown" else "replay"
+    return out
+
+
+def list_iteration_runs(runs_root: Path, limit: int = 20) -> list[dict[str, Any]]:
+    root = Path(runs_root)
+    if not root.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    for d in sorted(root.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        if not d.is_dir():
+            continue
+        info = read_run_progress(d)
+        info["dir"] = str(d)
+        info["has_eplusout"] = (d / "eplusout.csv").is_file() or bool(
+            list(d.glob("**/eplusout.csv"))
+        )
+        rows.append(info)
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def publish_run_for_studio(
+    source: Path | str,
+    *,
+    run_id: str | None = None,
+    report: dict[str, Any] | None = None,
+    dest_root: Path | None = None,
+) -> Path:
+    """Copy an EnergyPlus / easy-button artifact tree into Studio ``runs/<id>/``.
+
+    Agents and CLI write here so the human Twin page can render APIHelper-08
+    panes (progress, OA chart, classic 5Zone floor plan) in the browser.
+    Prefers ``sim_baseline/eplusout.csv`` when present.
+    """
+    from wattlab.studio.workspace import runs_dir
+
+    src = Path(source)
+    if not src.exists():
+        raise FileNotFoundError(f"publish_run_for_studio: missing {src}")
+
+    rid = run_id or src.name.replace("wattlab_", "") or src.name
+    dest = Path(dest_root) if dest_root is not None else (runs_dir() / rid)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    # Locate best eplusout.csv (baseline first)
+    candidates: list[Path] = []
+    if src.is_file() and src.name.startswith("eplusout") and src.suffix == ".csv":
+        candidates.append(src)
+    elif src.is_dir():
+        for prefer in ("sim_baseline/eplusout.csv", "eplusout.csv"):
+            p = src / prefer
+            if p.is_file():
+                candidates.append(p)
+        candidates.extend(sorted(src.rglob("eplusout.csv")))
+    if candidates:
+        shutil.copy2(candidates[0], dest / "eplusout.csv")
+
+    for name in ("eplusout.err", "run_manifest.json", "progress.json", "wattlab_report.json"):
+        p = src / name if src.is_dir() else None
+        if p is not None and p.is_file():
+            shutil.copy2(p, dest / name)
+
+    if report is not None:
+        (dest / "report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    elif src.is_dir() and (src / "wattlab_report.json").is_file() and not (dest / "report.json").is_file():
+        shutil.copy2(src / "wattlab_report.json", dest / "report.json")
+
+    if not (dest / "run_manifest.json").is_file():
+        (dest / "run_manifest.json").write_text(
+            json.dumps(
+                {
+                    "run_id": rid,
+                    "status": "SUCCESS" if (dest / "eplusout.csv").is_file() else "partial",
+                    "published_from": str(src),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    if not (dest / "progress.json").is_file():
+        (dest / "progress.json").write_text(
+            json.dumps(
+                {
+                    "percent": 100 if (dest / "eplusout.csv").is_file() else 0,
+                    "status": "published",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    # Pointer so Twin auto-selects the latest agent publish
+    pointer = dest.parent / "CURRENT_RUN.txt"
+    pointer.write_text(str(dest.resolve()), encoding="utf-8")
+    return dest
+
+
+def install_demo_replay(run_dir: Path, fixture_csv: Path) -> Path:
+    """Copy fixture eplusout into a run dir labeled as demo replay (no Docker)."""
+    run_dir = Path(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    dest = run_dir / "eplusout.csv"
+    dest.write_bytes(Path(fixture_csv).read_bytes())
+    (run_dir / "REPLAY.txt").write_text(
+        "Demo replay from fixture eplusout.csv — not a live EnergyPlus run.\n",
+        encoding="utf-8",
+    )
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_dir.name,
+                "status": "replay",
+                "replay": True,
+                "source": str(fixture_csv),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "progress.json").write_text(
+        json.dumps({"percent": 100, "status": "replay"}),
+        encoding="utf-8",
+    )
+    pointer = run_dir.parent / "CURRENT_RUN.txt"
+    pointer.write_text(str(run_dir.resolve()), encoding="utf-8")
+    return dest
+
+
+__all__ = [
+    "PROTOTYPE_ZONE_ROLES",
+    "ZONE_VERTICES",
+    "floor_plan_figure",
+    "install_demo_replay",
+    "list_iteration_runs",
+    "map_zones_to_roles",
+    "outdoor_figure",
+    "publish_run_for_studio",
+    "read_run_progress",
+    "rgb_from_temperature",
+    "zone_mean_by_role",
+]

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -1,4 +1,4 @@
-"""Twin / calibrate — profile + Docker sims + modeled vs actual."""
+"""Twin / calibrate — profile + Docker sims + 08-style iteration viewer."""
 
 from __future__ import annotations
 
@@ -9,9 +9,19 @@ from typing import Any
 import pandas as pd
 import streamlit as st
 
-from wattlab.config import ARTIFACTS
+from wattlab.config import ARTIFACTS, ROOT
 from wattlab.defaults import resolve_profile
+from wattlab.energyplus.timeseries import find_eplusout_csv, load_sim_timeseries
 from wattlab.seed import gap_report
+from wattlab.studio.ep_viz import (
+    floor_plan_figure,
+    install_demo_replay,
+    list_iteration_runs,
+    outdoor_figure,
+    publish_run_for_studio,
+    read_run_progress,
+    zone_mean_by_role,
+)
 from wattlab.studio.workspace import reports_dir, runs_dir
 
 
@@ -23,13 +33,88 @@ def _profile() -> dict[str, Any] | None:
     return st.session_state.get("studio_profile")
 
 
+def _fixture_eplusout() -> Path | None:
+    cand = ROOT / "tests" / "fixtures" / "eplusout" / "eplusout.csv"
+    return cand if cand.is_file() else None
+
+
+def _resolve_active_run() -> Path | None:
+    """Prefer session selection, then CURRENT_RUN.txt, then latest runs/ entry."""
+    active = st.session_state.get("studio_active_run")
+    if active and Path(active).is_dir():
+        return Path(active)
+    pointer = runs_dir() / "CURRENT_RUN.txt"
+    if pointer.is_file():
+        try:
+            p = Path(pointer.read_text(encoding="utf-8").strip())
+            if p.is_dir():
+                return p
+        except OSError:
+            pass
+    hist = list_iteration_runs(runs_dir(), limit=1)
+    if hist and hist[0].get("dir"):
+        return Path(str(hist[0]["dir"]))
+    return None
+
+
+def _render_08_panes(run_dir: Path) -> None:
+    st.subheader("EnergyPlus visualizer (APIHelper 08 — browser)")
+    st.caption(
+        "Populated by any AI agent (or Studio buttons) writing `runs/<id>/` "
+        "with eplusout.csv. Human: use **Refresh agent runs** after each iteration."
+    )
+    info = read_run_progress(run_dir)
+    if info.get("replay"):
+        st.info("Demo replay — fixture eplusout.csv (no live Docker EnergyPlus run).")
+
+    left, right = st.columns([2, 3])
+    with left:
+        st.markdown("**Manage simulation**")
+        st.progress(min(100, max(0, int(info.get("progress") or 0))) / 100.0)
+        st.caption(f"status={info.get('status')} · run_id={info.get('run_id')}")
+        log = info.get("log_tail") or "(no eplusout.err / console log yet)"
+        st.text_area("EnergyPlus output", value=log, height=220, key=f"twin_ep_log_{run_dir.name}")
+    with right:
+        ts = load_sim_timeseries(run_dir)
+        if ts is None:
+            nested = find_eplusout_csv(run_dir)
+            ts = load_sim_timeseries(nested.parent) if nested else None
+        if ts is not None and not ts.outdoor.empty:
+            st.plotly_chart(outdoor_figure(ts.outdoor), width="stretch", key=f"twin_oa_{run_dir.name}")
+        else:
+            st.caption("No outdoor timeseries yet (need eplusout.csv in this run folder).")
+
+    ts2 = load_sim_timeseries(run_dir)
+    if ts2 is None:
+        nested = find_eplusout_csv(run_dir)
+        if nested:
+            ts2 = load_sim_timeseries(nested.parent)
+    if ts2 is not None:
+        roles = zone_mean_by_role(ts2)
+        if roles:
+            st.plotly_chart(
+                floor_plan_figure(roles),
+                width="stretch",
+                key=f"twin_floor_{run_dir.name}",
+            )
+        means = ts2.zone_mean_temps()
+        if not means.empty:
+            st.dataframe(means, width="stretch", hide_index=True)
+
+
 def render() -> None:
     st.header("Twin / calibrate — EnergyPlus vs bills")
     st.caption(
-        "Resolve building inputs (data-model driven — no city hardcodes). "
-        "Dry-run or Docker EnergyPlus; compare modeled months to actual fuel. "
-        "Charts follow EnergyPlusAPIHelper post-sim patterns (OA/zone vibe) without host pyenergyplus."
+        "Resolve building inputs from the dump / campus data model (no city hardcodes). "
+        "Dry-run or Docker EnergyPlus; AI agents outside Streamlit publish iterations to "
+        "`runs/` so this browser page shows APIHelper-08 progress, OA, and floor-plan panes."
     )
+
+    if st.button("Refresh agent runs", key="twin_refresh_runs"):
+        active = _resolve_active_run()
+        if active is not None:
+            st.session_state["studio_active_run"] = str(active)
+        st.rerun()
 
     bundle = _bundle()
     seed: dict[str, Any] = {}
@@ -39,12 +124,11 @@ def render() -> None:
     defaults = {
         "building_type": seed.get("building_type") or "",
         "city": seed.get("city") or "",
-        "floor_area_ft2": float(seed.get("floor_area_ft2") or 0) or 100000.0,
-        "floors": int(seed.get("floors") or 3),
+        "floor_area_ft2": float(seed.get("floor_area_ft2") or 0) or 1.0,
+        "floors": int(seed.get("floors") or 1),
         "lat": seed.get("lat"),
         "lon": seed.get("lon"),
     }
-    energy = st.session_state.get("studio_energy")
     campus = st.session_state.get("studio_campus")
     if campus is not None:
         if defaults["lat"] is None and campus.lat is not None:
@@ -52,14 +136,19 @@ def render() -> None:
         if defaults["lon"] is None and campus.lon is not None:
             defaults["lon"] = campus.lon
         if campus.buildings:
-            defaults["floor_area_ft2"] = float(campus.buildings[0].floor_area_ft2)
+            defaults["floor_area_ft2"] = float(campus.buildings[0].floor_area_ft2) or defaults["floor_area_ft2"]
             defaults["building_type"] = defaults["building_type"] or campus.buildings[0].property_type
 
     with st.form("twin_profile_form"):
         c1, c2, c3 = st.columns(3)
         btype = c1.text_input("building_type", value=str(defaults["building_type"] or ""), key="twin_btype")
         city = c2.text_input("city", value=str(defaults["city"] or ""), key="twin_city")
-        area = c3.number_input("floor_area_ft2", value=float(defaults["floor_area_ft2"]), min_value=1.0, key="twin_area")
+        area = c3.number_input(
+            "floor_area_ft2",
+            value=float(defaults["floor_area_ft2"]),
+            min_value=1.0,
+            key="twin_area",
+        )
         c4, c5, c6 = st.columns(3)
         floors = c4.number_input("floors", value=int(defaults["floors"]), min_value=1, key="twin_floors")
         lat = c5.text_input("lat", value="" if defaults["lat"] is None else str(defaults["lat"]), key="twin_lat")
@@ -95,7 +184,14 @@ def render() -> None:
 
     profile = _profile()
     if not profile:
-        st.info("Resolve a profile above (or have Codex write answers.json → wattlab twin).")
+        st.info(
+            "Resolve a profile above (or have an AI agent write answers.json → wattlab twin). "
+            "Agent prompt: vibe20_agent_spec/AGENT_TESTER_PROMPT.md"
+        )
+        # Still show any published 08 panes so agent work is visible before profile
+        active_early = _resolve_active_run()
+        if active_early is not None:
+            _render_08_panes(active_early)
         return
 
     with st.expander("Resolved profile", expanded=False):
@@ -108,7 +204,24 @@ def render() -> None:
     if proxies:
         run_profile["proxy_savings"] = proxies
 
-    d1, d2 = st.columns(2)
+    try:
+        from wattlab.energyplus.docker import docker_info_ok, image_present
+        from wattlab.config import DOCKER_IMAGE
+
+        docker_ok = docker_info_ok()
+        img_ok = image_present() if docker_ok else False
+    except Exception:
+        docker_ok, img_ok = False, False
+        DOCKER_IMAGE = "energyplus-mcp-dev"
+
+    if not docker_ok or not img_ok:
+        st.warning(
+            f"ENVIRONMENT: Docker EnergyPlus image `{DOCKER_IMAGE}` not available from this process. "
+            "Mount docker.sock when running Studio in a container. Dry-run and demo replay still work; "
+            "AI agents can still publish fixture/replay runs into `runs/` for the browser panes."
+        )
+
+    d1, d2, d3 = st.columns(3)
     if d1.button("Dry-run plan (no Docker)", key="twin_dry_run"):
         from wattlab.easy_button import run_easy_button
 
@@ -121,17 +234,44 @@ def render() -> None:
     if d2.button("Run EnergyPlus (Docker)", key="twin_real_run"):
         from wattlab.easy_button import run_easy_button
 
-        with st.spinner("Running EnergyPlus via Docker…"):
-            try:
-                report = run_easy_button(profile=run_profile, measure_set=measure_set)
-                st.session_state["studio_report"] = report
-                rid = report.get("run_id") or "run"
-                dest = runs_dir() / str(rid)
-                dest.mkdir(parents=True, exist_ok=True)
-                (dest / "report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
-                st.success(f"Run complete: {rid}")
-            except Exception as exc:
-                st.error(f"EnergyPlus run failed (is Docker up?): {exc}")
+        if not img_ok:
+            st.error(f"Cannot run: `{DOCKER_IMAGE}` missing. Use dry-run or demo replay.")
+        else:
+            with st.spinner("Running EnergyPlus via Docker…"):
+                try:
+                    report = run_easy_button(profile=run_profile, measure_set=measure_set)
+                    st.session_state["studio_report"] = report
+                    rid = str(report.get("run_id") or "run")
+                    art = Path(
+                        report.get("studio_run_dir")
+                        or report.get("artifacts_dir")
+                        or report.get("artifact_dir")
+                        or ""
+                    )
+                    if art.is_dir() and (runs_dir() / rid).is_dir():
+                        dest = runs_dir() / rid
+                    elif art.is_dir():
+                        dest = publish_run_for_studio(art, run_id=rid, report=report)
+                    else:
+                        dest = publish_run_for_studio(
+                            Path(report.get("artifacts_dir") or "."),
+                            run_id=rid,
+                            report=report,
+                        )
+                    st.session_state["studio_active_run"] = str(dest)
+                    st.success(f"Run published for browser Twin panes → {dest}")
+                except Exception as exc:
+                    st.error(f"EnergyPlus run failed: {exc}")
+
+    if d3.button("Load demo replay (fixture eplusout)", key="twin_demo_replay"):
+        fixture = _fixture_eplusout()
+        if fixture is None:
+            st.error("Fixture eplusout.csv not found in package tests/fixtures.")
+        else:
+            dest = runs_dir() / "demo_replay"
+            install_demo_replay(dest, fixture)
+            st.session_state["studio_active_run"] = str(dest)
+            st.success(f"Demo replay ready for browser → {dest}")
 
     plan = st.session_state.get("studio_plan")
     if plan:
@@ -158,30 +298,48 @@ def render() -> None:
             if cross.get("g14"):
                 st.json(cross["g14"], expanded=False)
 
-    # Modeled vs bills (from dump or scorecard)
+    active = _resolve_active_run()
+    if active is not None:
+        st.session_state["studio_active_run"] = str(active)
+        _render_08_panes(active)
+    else:
+        st.info(
+            "No published Twin runs yet. An AI agent should write `runs/<id>/eplusout.csv` "
+            "(or click demo replay / Docker run). See AGENT_TESTER_PROMPT.md."
+        )
+
     st.subheader("Modeled vs actual fuel")
+    ub_path = st.session_state.get("studio_utility_bills_path")
     scorecard_path = st.text_input(
         "calibration_scorecard.json (optional)",
         key="twin_scorecard",
         placeholder=str(ARTIFACTS / "…/calibration_scorecard.json"),
     )
-    monthly_model: list[dict[str, Any]] = []
     bills_rows: list[dict[str, Any]] = []
+    monthly_model: list[dict[str, Any]] = []
     if scorecard_path.strip():
         sp = Path(scorecard_path.strip())
         if sp.is_file():
             sc = json.loads(sp.read_text(encoding="utf-8"))
             monthly_model = list((sc.get("annual") or {}).get("monthly") or [])
             for pm in (sc.get("utility_bills") or {}).get("per_month") or []:
-                bills_rows.append({
-                    "month": pm.get("month"),
-                    "observed_kwh": pm.get("observed_kwh"),
-                    "modeled_kwh": pm.get("modeled_kwh"),
-                    "delta_kwh": pm.get("delta_kwh"),
-                })
+                bills_rows.append(
+                    {
+                        "month": pm.get("month"),
+                        "observed_kwh": pm.get("observed_kwh"),
+                        "modeled_kwh": pm.get("modeled_kwh"),
+                        "delta_kwh": pm.get("delta_kwh"),
+                    }
+                )
             st.caption(f"Scorecard status: {sc.get('status') or sc.get('overall')}")
+
     if bundle is not None and not getattr(bundle, "utility_bills", pd.DataFrame()).empty:
         ub = bundle.utility_bills
+        st.caption("utility_bills from dump / energy bridge")
+        st.dataframe(ub.head(24), width="stretch", hide_index=True)
+    elif ub_path and Path(ub_path).is_file():
+        ub = pd.read_csv(ub_path)
+        st.caption(f"utility_bills bridge → {ub_path}")
         st.dataframe(ub.head(24), width="stretch", hide_index=True)
 
     if bills_rows:
@@ -192,21 +350,32 @@ def render() -> None:
     elif monthly_model:
         st.dataframe(pd.DataFrame(monthly_model).head(24), width="stretch", hide_index=True)
 
-    st.subheader("Iteration history")
-    manifests = sorted(ARTIFACTS.glob("wattlab_*/run_manifest.json"), reverse=True)[:10]
-    if not manifests:
-        st.caption("No prior runs in .artifacts/")
-    else:
-        hist = []
+    st.subheader("Iteration history (agent + Studio)")
+    hist = list_iteration_runs(runs_dir(), limit=15)
+    if not hist:
+        manifests = sorted(ARTIFACTS.glob("wattlab_*/run_manifest.json"), reverse=True)[:10]
         for mp in manifests:
             try:
                 m = json.loads(mp.read_text(encoding="utf-8"))
-                hist.append({
-                    "run_id": m.get("run_id"),
-                    "status": m.get("status"),
-                    "started_at": m.get("started_at"),
-                    "dir": str(mp.parent),
-                })
+                hist.append(
+                    {
+                        "run_id": m.get("run_id"),
+                        "status": m.get("status"),
+                        "dir": str(mp.parent),
+                        "progress": 100 if m.get("status") in {"ok", "success", "SUCCESS"} else 0,
+                    }
+                )
             except Exception:
                 continue
+    if not hist:
+        st.caption("No prior runs in workspace runs/.")
+    else:
         st.dataframe(pd.DataFrame(hist), width="stretch", hide_index=True)
+        pick = st.selectbox(
+            "Inspect iteration",
+            options=[h.get("dir") for h in hist if h.get("dir")],
+            key="twin_iter_pick",
+        )
+        if pick and st.button("Show 08 panes for selection", key="twin_show_iter"):
+            st.session_state["studio_active_run"] = pick
+            st.rerun()

--- a/vibe_code_apps_20/wattlab/studio/pages/uploads.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/uploads.py
@@ -9,21 +9,78 @@ import pandas as pd
 import streamlit as st
 
 from wattlab.energy_use import load_energy_use_package
+from wattlab.energy_use.excel_campus import campus_to_utility_bills_csv
 from wattlab.seed import gap_report, load_bundle
 from wattlab.studio.workspace import (
     ensure_workspace,
     list_workspace_summary,
+    reports_dir,
     save_upload_bytes,
     workspace_root,
 )
 
 
+def _hints_from_bundle() -> dict[str, Any]:
+    """Pull building/area/coords from the loaded dump — data-model, not site hardcodes."""
+    bundle = st.session_state.get("studio_bundle")
+    out: dict[str, Any] = {}
+    if bundle is None:
+        return out
+    seed = getattr(bundle, "model_seed", None) or {}
+    if isinstance(seed, dict):
+        area = seed.get("floor_area_ft2")
+        if area:
+            out["default_area_ft2"] = float(area)
+        if seed.get("building_type"):
+            out["property_type"] = str(seed["building_type"])
+        if seed.get("lat") is not None:
+            out["lat"] = float(seed["lat"])
+        if seed.get("lon") is not None:
+            out["lon"] = float(seed["lon"])
+        bid = seed.get("building_id") or getattr(bundle, "building_id", None)
+        if bid and area:
+            out["building_hints"] = [
+                {
+                    "building_id": str(bid),
+                    "label": str(seed.get("label") or bid),
+                    "floor_area_ft2": float(area),
+                    "property_type": str(seed.get("building_type") or "office"),
+                }
+            ]
+    return out
+
+
+def _load_energy(path: Path):
+    derive = ensure_workspace() / "uploads" / "energy" / "derived"
+    hints = _hints_from_bundle()
+    return load_energy_use_package(path, derive_dir=derive, **hints)
+
+
+def _bridge_utility_bills(pkg: Any) -> None:
+    """Write utility_bills.csv for Twin when campus bills exist."""
+    campus = getattr(pkg, "campus", None)
+    if campus is None or not campus.meters:
+        return
+    out = reports_dir() / "utility_bills.csv"
+    campus_to_utility_bills_csv(campus, out)
+    st.session_state["studio_utility_bills_path"] = str(out)
+    bundle = st.session_state.get("studio_bundle")
+    if bundle is not None:
+        try:
+            ub = pd.read_csv(out)
+            bundle.utility_bills = ub
+            st.session_state["studio_bundle"] = bundle
+        except Exception:
+            pass
+
+
 def render() -> None:
     st.header("Uploads — dump + energy use")
     st.caption(
-        "Drop a vibe19 **wattlab_dump_*.zip** (v3) and an **energy-use** zip "
-        "(campus.json + bill CSVs + optional Haystack column_map). "
-        "Chat with Codex/agents on this workspace folder — Studio only displays results."
+        "Drop a vibe19 **wattlab_dump_*.zip** (v3) and an **energy-use** package: "
+        "`campus.json` + bill CSVs, Haystack `column_map`, **or** Liberty-style monthly "
+        "Excel workbooks (auto-derived to campus). "
+        "Chat with any AI agent on this workspace folder — Studio only displays results."
     )
 
     root = ensure_workspace()
@@ -62,29 +119,29 @@ def render() -> None:
                 st.error(f"Dump load failed: {exc}")
 
     with c2:
-        st.subheader("2 · Energy use (Haystack / campus)")
+        st.subheader("2 · Energy use (campus / Excel / Haystack)")
         energy_up = st.file_uploader(
-            "energy-use zip (campus + maps)", type=["zip"], key="uploads_energy_zip"
+            "energy-use zip", type=["zip"], key="uploads_energy_zip"
         )
         energy_path = st.text_input(
             "…or path to campus folder / zip",
             key="uploads_energy_path",
-            help="Must contain campus.json and meter CSVs, or Haystack column_map + interval CSVs.",
+            help="campus.json + meter CSVs, Excel monthly fuel workbooks, or Haystack maps.",
         )
         if st.button("Load energy use", key="uploads_load_energy"):
             try:
                 if energy_up is not None:
                     saved = save_upload_bytes("energy", energy_up.name, energy_up.getvalue())
-                    pkg = load_energy_use_package(saved)
+                    pkg = _load_energy(saved)
                     st.session_state["studio_energy_path"] = str(saved)
                 elif energy_path.strip():
                     p = Path(energy_path.strip())
                     if p.is_file() and p.suffix.lower() == ".zip":
                         saved = save_upload_bytes("energy", p.name, p.read_bytes())
-                        pkg = load_energy_use_package(saved)
+                        pkg = _load_energy(saved)
                         st.session_state["studio_energy_path"] = str(saved)
                     else:
-                        pkg = load_energy_use_package(p)
+                        pkg = _load_energy(p)
                         st.session_state["studio_energy_path"] = str(p)
                 else:
                     st.warning("Upload an energy zip or enter a path.")
@@ -93,10 +150,19 @@ def render() -> None:
                 if pkg.campus is not None:
                     st.session_state["studio_campus"] = pkg.campus
                     st.session_state["fuel_weather_campus"] = pkg.campus
-                st.success(
-                    f"Energy package loaded"
-                    + (f" — campus {pkg.campus.campus_id}" if pkg.campus else "")
-                )
+                    _bridge_utility_bills(pkg)
+
+                if getattr(pkg, "fuel_ready", False):
+                    msg = f"Energy package ready for Fuel — campus {pkg.campus.campus_id}"
+                    if getattr(pkg, "derived_from_excel", False):
+                        msg += " (derived from Excel)"
+                    st.success(msg)
+                else:
+                    st.warning(
+                        "Energy package loaded but Fuel dashboard is empty — "
+                        "need campus.json + bill CSVs or a monthly Excel workbook "
+                        "with Month + kWh/Mcf columns."
+                    )
                 for note in pkg.notes:
                     st.caption(note)
             except Exception as exc:
@@ -123,7 +189,7 @@ def render() -> None:
             st.warning(
                 "NEEDS_INPUT: "
                 + ", ".join(str(g["field"]) for g in missing)
-                + " — fill on Twin / calibrate (or via Codex answers.json)."
+                + " — fill on Twin / calibrate (or via agent answers.json)."
             )
         if bundle.manifest:
             with st.expander("MANIFEST.json", expanded=False):
@@ -146,6 +212,7 @@ def render() -> None:
         st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
 
     st.caption(
-        f"Agent tip: point Codex at `{workspace_root()}` — "
-        "uploads/dump, uploads/energy, runs/, reports/."
+        f"Agent tip: point any AI agent at `{workspace_root()}` — "
+        "uploads/dump, uploads/energy, runs/, reports/. "
+        "Publish Twin sims with publish_run_for_studio so the browser shows 08 panes."
     )

--- a/vibe_code_apps_20/wattlab/studio/workspace.py
+++ b/vibe_code_apps_20/wattlab/studio/workspace.py
@@ -1,6 +1,6 @@
 """Shared Studio workspace for uploads + agent artifacts.
 
-Codex / agents work on this tree outside Streamlit; Studio is a dropzone + viewer.
+Any AI agent works on this tree outside Streamlit; Studio is a dropzone + viewer.
 """
 
 from __future__ import annotations
@@ -13,12 +13,12 @@ from wattlab.config import ARTIFACTS
 
 _WORKSPACE_MD = """# WattLab Studio workspace
 
-Shared between Streamlit Uploads and external agents (Codex CLI).
+Shared between Streamlit Uploads and external AI agents.
 
 ```
 uploads/dump/     # wattlab_dump_*.zip (vibe19 v3)
-uploads/energy/   # energy-use zip/folder (campus.json + Haystack maps)
-runs/             # twin / calibrate / easy-button run dirs
+uploads/energy/   # energy-use zip/folder (campus.json + Haystack maps + Excel)
+runs/             # twin / calibrate iterations (eplusout → browser 08 panes)
 reports/          # scorecards, dashboard JSON, capital plans
 ```
 


### PR DESCRIPTION
## Summary
- Best-effort Excel → campus/bills intake (data-model hints; no Liberty hardcodes) with honest Uploads Fuel-ready toasts and utility_bills bridge
- Twin APIHelper-08 browser panes (progress, OA, 5Zone floor plan) fed by published `runs/<id>/`; easy_button auto-publishes to workspace
- Agent tester prompt requires ≥3 live `energyplus-mcp-dev` sims; docs/README docker.sock + MCP runbook

## Test plan
- [x] `pytest` focused excel/ep_viz/studio + full suite (611 passed, 8 skipped)
- [x] `scripts/smoke_studio.py` 4-page walk OK
- [ ] GHCR multi-arch `:latest` / `:sha-*` after merge
- [ ] Recreate local `vibe20` container from `:latest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Excel-based energy data intake, automatically generating campus and utility-bill information when needed.
  * Enhanced Twin / calibrate with EnergyPlus progress, floor-plan and outdoor-condition visualizations, modeled-versus-bill comparisons, and iteration history.
  * Published completed simulation runs to the Studio workspace for browsing.
  * Added demo replay support when live simulation is unavailable.

* **Bug Fixes**
  * Improved handling of Excel-only packages and Windows-style archive paths.

* **Documentation**
  * Updated setup, workspace, agent, QA, and four-page Studio guidance.

* **Tests**
  * Added coverage for Excel intake, visualization, run publishing, and Studio workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->