### PR TITLE
fix(vibe20): DinD sibling mounts + EUI index UI + AMY RunPeriod

### DIFF
--- a/vibe_code_apps_20/tests/test_dind_readvars_city.py
+++ b/vibe_code_apps_20/tests/test_dind_readvars_city.py
@@ -67,9 +67,12 @@ def test_troy_resolves_detroit_not_madison() -> None:
     profile = resolve_profile(
         {"building_type": "office", "city": "troy", "floor_area_ft2": 140_000}
     )
-    assert profile["field_sources"]["city"]["value"] == "detroit"
+    # Keep user city wording; catalog id is for EPW / climate only.
+    assert profile["field_sources"]["city"]["value"] == "troy"
+    assert profile["climate_catalog_id"] == "detroit"
+    assert profile["climate_city"] == "troy"
     note = profile["field_sources"]["city"].get("note") or ""
-    assert "troy" in note.lower()
+    assert "detroit" in note.lower()
     assert "madison" not in (profile.get("climate_city") or "").lower()
 
 
@@ -83,7 +86,7 @@ def test_unknown_city_keeps_label_not_madison() -> None:
     assert "conceptual" in (meta.get("epw_note") or "").lower()
 
     profile = resolve_profile({"building_type": "office", "city": "Springfield_IL_Custom"})
-    assert profile["field_sources"]["city"]["value"] == "springfield_il_custom"
+    assert profile["field_sources"]["city"]["value"] == "Springfield_IL_Custom"
     assert profile["field_sources"]["city"]["source"] == "user"
 
 
@@ -123,7 +126,10 @@ def test_run_energyplus_passes_readvars_and_host_mounts(
     host_ws = str(host.resolve()).replace("\\", "/")
     vol_flags = [args[i + 1] for i, a in enumerate(args) if a == "-v"]
     assert vol_flags
-    # Windows mounts look like C:/host/...:/work/in — match host workspace substring.
+    joined = " ".join(v.replace("\\", "/") for v in vol_flags)
+    # Sibling stage (…/out__stage_in), not nested …/out/_stage_in
+    assert "out__stage_in" in joined
+    assert "/out/_stage_in" not in joined
     for v in vol_flags:
         assert host_ws in v.replace("\\", "/"), (v, host_ws)
 
@@ -151,3 +157,61 @@ def test_run_energyplus_can_disable_readvars(
         dmod.run_energyplus(idf, epw, out, readvars=False)
 
     assert "-r" not in captured[0]
+
+
+def test_epw_data_period_chicago_full_year() -> None:
+    from wattlab.config import DEFAULT_MADISON_EPW
+    from wattlab.weather.epw import epw_data_period
+
+    if not DEFAULT_MADISON_EPW.is_file():
+        pytest.skip("bundled EPW missing")
+    span = epw_data_period(DEFAULT_MADISON_EPW)
+    assert span is not None
+    assert span["full_calendar_year"] is True
+
+
+def test_epw_data_period_partial(tmp_path: Path) -> None:
+    from wattlab.weather.epw import epw_data_period
+
+    epw = tmp_path / "partial.epw"
+    lines = [
+        "LOCATION,Test,MI,USA,AMY,0,42.5,-83.1,-5.0,200.0",
+        "DESIGN CONDITIONS,0",
+        "TYPICAL/EXTREME PERIODS,0",
+        "GROUND TEMPERATURES,0",
+        "HOLIDAYS/DAYLIGHT SAVINGS,No,0,0,0",
+        "COMMENTS 1,",
+        "COMMENTS 2,",
+        "DATA PERIODS,1,1,Data,Monday, 3/16, 7/16",
+        "2026,3,16,1,0," + ",".join(["0"] * 30),
+        "2026,7,16,24,0," + ",".join(["0"] * 30),
+    ]
+    epw.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    span = epw_data_period(epw)
+    assert span is not None
+    assert span["full_calendar_year"] is False
+    assert span["begin"] == "2026-03-16"
+    assert span["end"] == "2026-07-16"
+
+
+def test_build_eui_index_bills_peers_model() -> None:
+    from wattlab.studio.eui_compare import build_eui_index
+
+    # Liberty-style screening numbers from bensbench calibrate session
+    idx = build_eui_index(
+        bill_eui_kbtu_ft2=71.6,
+        property_type="office",
+        model_eui_kbtu_ft2=23.21,
+        prototype_area_scale=14.028,
+        target_floor_area_ft2=140_000,
+    )
+    assert idx["bill_eui_kbtu_ft2"] == 71.6
+    assert idx["peer_p50"] > 0
+    assert idx["model_eui_kbtu_ft2"] == 23.2
+    series = {r["series"] for r in idx["rows"]}
+    assert "Bills (site)" in series
+    assert "Peer p50 (typical)" in series
+    assert "Model (prototype EUI)" in series
+    # Bills above typical peer (session: 71.6 vs ~52.9)
+    bill_row = next(r for r in idx["rows"] if r["series"] == "Bills (site)")
+    assert bill_row["band"] in {"above_p80", "within_band", "below_p20"}

--- a/vibe_code_apps_20/tests/test_studio_app.py
+++ b/vibe_code_apps_20/tests/test_studio_app.py
@@ -91,8 +91,19 @@ def test_studio_fuel_dashboard_with_fixture_campus():
     assert "studio_campus" in at.session_state or "studio_energy" in at.session_state
     at.radio(key="studio_page").set_value("Fuel dashboard").run()
     assert not at.exception
+    # Metrics must include campus EUI + peer typical bands
+    metric_labels = [m.label for m in at.metric]
+    assert any("EUI" in (lab or "") for lab in metric_labels)
+    assert any("p50" in (lab or "") or "typical" in (lab or "").lower() for lab in metric_labels)
     at.button(key="fuel_dash_synth").click().run()
     assert not at.exception
+
+
+def test_studio_twin_eui_index_section():
+    at = _boot("Twin / calibrate")
+    assert not at.exception
+    # EUI index subheader always renders
+    assert any("EUI" in str(getattr(el, "value", el)) for el in at.subheader)
 
 
 def test_studio_twin_and_ecms_dry_path():

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -96,7 +96,8 @@ curl -sf http://127.0.0.1:8520/_stcore/health
 
 `WATTLAB_HOST_WORKSPACE` = host path for the `/data` bind (required for Twin →
 Docker E+ / DinD). Artifacts land under `/data/.artifacts`. Sims use `-r` so
-`eplusout.csv` appears for Twin panes.
+`eplusout.csv` appears for Twin panes. Stage mounts are **siblings** of the
+output dir (`…/sim__stage_in` + `…/sim`), never nested `_stage_in` under out.
 
 ## SETUP — EnergyPlus + EnergyPlus-MCP
 

--- a/vibe_code_apps_20/wattlab/defaults.py
+++ b/vibe_code_apps_20/wattlab/defaults.py
@@ -187,13 +187,18 @@ def resolve_profile(minimal: dict[str, Any] | None = None) -> dict[str, Any]:
 
     city_raw = m.get("city") or m.get("climate_city")
     city_id, city_meta = resolve_city(city_raw)
+    user_city = str(city_raw).strip() if city_raw else None
+    # Keep the human's city wording in field_sources; catalog id is for EPW only.
     city_note = None
-    if city_raw and _norm(str(city_raw)) != city_id:
-        city_note = f"catalog id {city_id!r} from user city {str(city_raw).strip()!r}"
+    if user_city and _norm(user_city) != city_id:
+        city_note = (
+            f"climate catalog={city_id!r} ({city_meta.get('label')}); "
+            f"{city_meta.get('epw_note') or 'substitute EPW may apply'}"
+        )
     elif city_meta.get("user_supplied"):
         city_note = city_meta.get("epw_note")
     field_sources["city"] = _tagged(
-        city_id, "user" if city_raw else "default", note=city_note
+        user_city or city_id, "user" if city_raw else "default", note=city_note
     )
 
     code_raw = m.get("code_year") or m.get("energy_code")
@@ -292,7 +297,14 @@ def resolve_profile(minimal: dict[str, Any] | None = None) -> dict[str, Any]:
     field_sources["project_id"] = _tagged(
         project_id, "user" if m.get("project_id") else "default"
     )
-    display = m.get("display_name") or f"{city_meta.get('label')} {arch.get('label')}"
+    # Prefer user city label (e.g. troy) over silent remap to catalog city name.
+    if user_city and _norm(user_city) != city_id and not city_meta.get("user_supplied"):
+        climate_label = user_city
+        catalog_label = city_meta.get("label")
+    else:
+        climate_label = city_meta.get("label") or user_city or city_id
+        catalog_label = city_meta.get("label")
+    display = m.get("display_name") or f"{climate_label} {arch.get('label')}"
     field_sources["display_name"] = _tagged(
         display, "user" if m.get("display_name") else "default"
     )
@@ -326,9 +338,19 @@ def resolve_profile(minimal: dict[str, Any] | None = None) -> dict[str, Any]:
         "number_of_floors": int(floors),
         "floor_to_floor_ft": float(floor_to_floor),
         "wwr": float(wwr),
-        "climate_city": city_meta.get("label"),
+        "climate_city": climate_label,
+        "climate_catalog_id": city_id,
+        "climate_catalog_label": catalog_label,
         "climate_state": city_meta.get("state"),
         "climate_zone": city_meta.get("climate_zone"),
+        "location": {
+            "city_id": city_id,
+            "user_city": user_city,
+            "label": climate_label,
+            "catalog_label": catalog_label,
+            "state": city_meta.get("state"),
+            "climate_zone": city_meta.get("climate_zone"),
+        },
         "energy_code": code_meta.get("label") or code_id,
         "code_id": code_id,
         "shells": [

--- a/vibe_code_apps_20/wattlab/easy_button.py
+++ b/vibe_code_apps_20/wattlab/easy_button.py
@@ -275,6 +275,28 @@ def run_easy_button(
     # BUILDING ENERGY PERFORMANCE tables (G14 bill gate needs them).
     prepped_idf = run_dir / "prototype_prepped.idf"
     monthly_meta = apply_monthly_energy_tables(prototype, prepped_idf)
+    # Partial-year AMY / short EPW: align RunPeriod or EnergyPlus fatals on EOF.
+    run_period_meta: dict[str, Any] | None = None
+    try:
+        from wattlab.weather.epw import epw_data_period
+        from wattlab.energyplus.patches import apply_run_period
+
+        span = epw_data_period(epw)
+        if span and not span.get("full_calendar_year"):
+            aligned = run_dir / "prototype_runperiod.idf"
+            run_period_meta = apply_run_period(
+                prepped_idf,
+                aligned,
+                begin=span["begin"],
+                end=span["end"],
+            )
+            run_period_meta["reason"] = (
+                f"EPW span {span['begin']}→{span['end']} is not a full calendar year; "
+                "RunPeriod auto-aligned (partial-year AMY)."
+            )
+            prepped_idf = aligned
+    except Exception as exc:  # noqa: BLE001 — never block baseline on span probe
+        run_period_meta = {"patch": "run_period", "error": str(exc)}
     baseline_idf = run_dir / "baseline.idf"
     baseline_patch_name = ep.get("baseline_idf_patch") or "fan_avail_continuous"
     patch_meta = _apply_patch(baseline_patch_name, prepped_idf, baseline_idf)
@@ -301,6 +323,8 @@ def run_easy_button(
     after_ecm1_annual: dict | None = None
     after_ecm2_annual: dict | None = None
     patch_log = [monthly_meta, patch_meta]
+    if run_period_meta:
+        patch_log.insert(1, run_period_meta)
 
     for m in measures:
         mid = m["measure_id"]

--- a/vibe_code_apps_20/wattlab/energyplus/docker.py
+++ b/vibe_code_apps_20/wattlab/energyplus/docker.py
@@ -142,8 +142,10 @@ def run_energyplus(
     if readvars:
         cmd.append("-r")
     cmd.append(f"/work/in/{idf.name}")
-    # Put idf+epw copies next to a shared mount if they differ in parents.
-    stage = work / "_stage_in"
+    # Sibling stage dir — NOT nested under output_dir. Nested mounts break
+    # ReadVars (-r): EnergyPlus cannot write /work/in/*.rvi when /work/in is a
+    # child of the /work/out volume (DinD host-path resolution).
+    stage = work.parent / f"{work.name}__stage_in"
     stage.mkdir(parents=True, exist_ok=True)
     staged_idf = stage / idf.name
     staged_epw = stage / epw.name

--- a/vibe_code_apps_20/wattlab/studio/eui_compare.py
+++ b/vibe_code_apps_20/wattlab/studio/eui_compare.py
@@ -1,0 +1,159 @@
+"""EUI index helpers — bills vs peer bands vs EnergyPlus model (Studio)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from wattlab.benchmarks.eui import compare_eui, lookup
+from wattlab.config import PROTOTYPE_AREA_FT2_NOMINAL
+
+
+def _annual_from_report(report: dict[str, Any] | None) -> dict[str, Any]:
+    if not report:
+        return {}
+    for key in ("baseline_annual", "annual"):
+        block = report.get(key)
+        if isinstance(block, dict) and block:
+            return block
+    records = report.get("result_records") or report.get("records") or []
+    for rr in records:
+        if rr.get("measure_id") in (None, "", "baseline"):
+            ann = rr.get("annual") or {}
+            if ann:
+                return ann
+    if records:
+        return dict((records[0] or {}).get("annual") or {})
+    return {}
+
+
+def load_model_eui_from_run(run_dir: Path | None) -> dict[str, Any]:
+    """Pull model site EUI + scale stamps from a published ``runs/<id>/`` tree."""
+    out: dict[str, Any] = {}
+    if run_dir is None or not Path(run_dir).is_dir():
+        return out
+    root = Path(run_dir)
+    for name in ("report.json", "wattlab_report.json", "campaign_stamp.json"):
+        p = root / name
+        if not p.is_file():
+            continue
+        try:
+            report = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        ann = _annual_from_report(report)
+        eui = ann.get("site_eui_kbtu_ft2_year")
+        if eui is None:
+            eui = report.get("site_eui_kbtu_ft2_year") or report.get("site_eui_kbtu_ft2")
+        if eui is not None:
+            out["model_eui_kbtu_ft2"] = float(eui)
+        out["building_area_m2"] = ann.get("building_area_m2") or report.get("building_area_m2")
+        out["prototype_area_scale"] = report.get("prototype_area_scale")
+        out["target_floor_area_ft2"] = report.get("target_floor_area_ft2")
+        out["area_honesty"] = report.get("area_honesty")
+        out["weather_mode"] = (
+            (report.get("weather_suitability") or {}).get("mode")
+            or report.get("weather_mode")
+        )
+        out["run_id"] = report.get("run_id") or root.name
+        if out.get("model_eui_kbtu_ft2") is not None:
+            return out
+    return out
+
+
+def build_eui_index(
+    *,
+    bill_eui_kbtu_ft2: float | None,
+    property_type: str,
+    model_eui_kbtu_ft2: float | None = None,
+    prototype_area_scale: float | None = None,
+    target_floor_area_ft2: float | None = None,
+    model_label: str = "EnergyPlus model",
+) -> dict[str, Any]:
+    """Compare bill / peer / model EUIs for Studio tables + charts.
+
+    Model EUI from 5Zone is on **prototype** area (~10k ft²). Absolute kWh must
+    not be compared to site bills without ``prototype_area_scale``; EUI
+    (intensity) can still be plotted beside peers as a screening index.
+    """
+    ptype = property_type or "office"
+    bm = lookup(ptype)
+    p20 = float(bm.get("p20") or float(bm["p50"]) * 0.65)
+    p50 = float(bm["p50"])
+    p80 = float(bm.get("p80") or float(bm["p50"]) * 1.35)
+    rows: list[dict[str, Any]] = []
+    if bill_eui_kbtu_ft2 is not None:
+        bill_cmp = compare_eui(float(bill_eui_kbtu_ft2), ptype)
+        rows.append(
+            {
+                "series": "Bills (site)",
+                "site_eui_kbtu_ft2": bill_cmp["site_eui_kbtu_ft2"],
+                "band": bill_cmp["band"],
+                "vs_median_pct": bill_cmp["vs_median_pct"],
+                "note": "Measured / allocated campus bills",
+            }
+        )
+    rows.append(
+        {
+            "series": "Peer p20",
+            "site_eui_kbtu_ft2": p20,
+            "band": "peer",
+            "vs_median_pct": None,
+            "note": bm.get("source") or "benchmark registry",
+        }
+    )
+    rows.append(
+        {
+            "series": "Peer p50 (typical)",
+            "site_eui_kbtu_ft2": p50,
+            "band": "peer",
+            "vs_median_pct": 0.0,
+            "note": bm.get("benchmark_name") or bm.get("source"),
+        }
+    )
+    rows.append(
+        {
+            "series": "Peer p80",
+            "site_eui_kbtu_ft2": p80,
+            "band": "peer",
+            "vs_median_pct": None,
+            "note": bm.get("source") or "benchmark registry",
+        }
+    )
+    if model_eui_kbtu_ft2 is not None:
+        model_cmp = compare_eui(float(model_eui_kbtu_ft2), ptype)
+        scale = float(prototype_area_scale) if prototype_area_scale else None
+        note = (
+            f"{model_label} on prototype footprint (~{PROTOTYPE_AREA_FT2_NOMINAL:,.0f} ft²)"
+        )
+        if target_floor_area_ft2:
+            note += f"; target site {float(target_floor_area_ft2):,.0f} ft²"
+        if scale and scale > 1.05:
+            note += f"; scale≈{scale:.2f}× — do not treat raw kWh as site total"
+        rows.append(
+            {
+                "series": "Model (prototype EUI)",
+                "site_eui_kbtu_ft2": model_cmp["site_eui_kbtu_ft2"],
+                "band": model_cmp["band"],
+                "vs_median_pct": model_cmp["vs_median_pct"],
+                "note": note,
+            }
+        )
+    return {
+        "property_type": bm.get("property_type") or ptype,
+        "property_type_matched": bm.get("property_type_matched"),
+        "peer_p20": p20,
+        "peer_p50": p50,
+        "peer_p80": p80,
+        "benchmark_name": bm.get("benchmark_name"),
+        "source": bm.get("source"),
+        "bill_eui_kbtu_ft2": (
+            round(float(bill_eui_kbtu_ft2), 1) if bill_eui_kbtu_ft2 is not None else None
+        ),
+        "model_eui_kbtu_ft2": (
+            round(float(model_eui_kbtu_ft2), 1) if model_eui_kbtu_ft2 is not None else None
+        ),
+        "prototype_area_scale": prototype_area_scale,
+        "rows": rows,
+    }

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
@@ -131,13 +131,23 @@ def render(*, campus: Campus | None = None) -> None:
     a3.metric("Gas", f"{summary['campus']['mcf']:,.0f} Mcf")
     a4.metric("Window", f"{w['start']} → {w['end']}")
 
-    # Peer strip
+    # Peer strip — explicit typical / band metrics (spreadsheet-style)
     st.subheader("Site EUI vs peers (same property type)")
+    st.caption(
+        "Peer p20 / p50 (typical) / p80 from public EPA Portfolio Manager / CBECS-style "
+        "registry (kBtu/ft²-yr). Twin page adds EnergyPlus model EUI beside these bands."
+    )
     rows = []
     for b in summary["buildings"]:
         cmp = compare_eui(b["site_eui_kbtu_ft2"], b["property_type"])
         rows.append({**b, **{f"peer_{k}": cmp[k] for k in ("p20", "p50", "p80", "band", "vs_median_pct")}})
     dfb = pd.DataFrame(rows)
+    b0 = rows[0]
+    p1, p2, p3, p4 = st.columns(4)
+    p1.metric("Bill site EUI", f"{b0['site_eui_kbtu_ft2']} kBtu/ft²")
+    p2.metric("Peer typical (p50)", f"{b0['peer_p50']} kBtu/ft²")
+    p3.metric("Peer p20–p80", f"{b0['peer_p20']} – {b0['peer_p80']}")
+    p4.metric("vs median", f"{b0['peer_vs_median_pct']:+.1f}% · {b0['peer_band']}")
     st.dataframe(
         dfb[
             [
@@ -146,7 +156,9 @@ def render(*, campus: Campus | None = None) -> None:
                 "kwh",
                 "mcf",
                 "site_eui_kbtu_ft2",
+                "peer_p20",
                 "peer_p50",
+                "peer_p80",
                 "peer_band",
                 "peer_vs_median_pct",
             ]
@@ -174,7 +186,7 @@ def render(*, campus: Campus | None = None) -> None:
         yaxis=dict(visible=False), xaxis_title="Site EUI (kBtu/ft²-yr)",
         showlegend=False,
     )
-    st.plotly_chart(fig_peer, width="stretch")
+    st.plotly_chart(fig_peer, width="stretch", key="fuel_peer_eui_chart")
 
     # Monthly tables + gap-aware charts
     st.subheader("Monthly fuel (gaps shown as blanks)")
@@ -194,7 +206,7 @@ def render(*, campus: Campus | None = None) -> None:
             title=f"{fuel.title()} — connectgaps=False",
             yaxis_title=unit,
         )
-        st.plotly_chart(fig, width="stretch")
+        st.plotly_chart(fig, width="stretch", key=f"fuel_monthly_{fuel}_chart")
 
     # Heatmaps
     st.subheader("Intensity & demand calendars")
@@ -205,6 +217,7 @@ def render(*, campus: Campus | None = None) -> None:
             st.plotly_chart(
                 px.imshow(mat, aspect="auto", color_continuous_scale="YlOrRd", title="Elec kBtu/ft²"),
                 width="stretch",
+                key="fuel_heat_elec",
             )
     with h2:
         mat = intensity_heatmap_frame(campus, fuel="gas")
@@ -212,6 +225,7 @@ def render(*, campus: Campus | None = None) -> None:
             st.plotly_chart(
                 px.imshow(mat, aspect="auto", color_continuous_scale="Blues", title="Gas kBtu/ft²"),
                 width="stretch",
+                key="fuel_heat_gas",
             )
     with h3:
         mat = demand_heatmap_frame(campus)
@@ -219,6 +233,7 @@ def render(*, campus: Campus | None = None) -> None:
             st.plotly_chart(
                 px.imshow(mat, aspect="auto", color_continuous_scale="Viridis", title="Demand kW"),
                 width="stretch",
+                key="fuel_heat_demand",
             )
         else:
             st.caption("No demand_kw column in electric bills.")

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -22,6 +22,7 @@ from wattlab.studio.ep_viz import (
     read_run_progress,
     zone_mean_by_role,
 )
+from wattlab.studio.eui_compare import build_eui_index, load_model_eui_from_run
 from wattlab.studio.workspace import reports_dir, runs_dir
 
 
@@ -31,6 +32,127 @@ def _bundle() -> Any:
 
 def _profile() -> dict[str, Any] | None:
     return st.session_state.get("studio_profile")
+
+
+def _render_eui_index(
+    *,
+    profile: dict[str, Any] | None = None,
+    run_dir: Path | None = None,
+    chart_key: str = "twin_eui_index",
+) -> None:
+    """Bills vs peer typical EUI vs EnergyPlus model — always visible when data exists."""
+    import plotly.graph_objects as go
+
+    st.subheader("EUI index — bills vs peers vs model")
+    st.caption(
+        "Peer bands from public EPA/CBECS-style registry (kBtu/ft²-yr). "
+        "Model EUI is on the prototype footprint unless scaled — see note."
+    )
+    bill_eui = None
+    ptype = "office"
+    bench = st.session_state.get("studio_benchmark_summary") or {}
+    if bench.get("campus"):
+        bill_eui = bench["campus"].get("site_eui_kbtu_ft2")
+    campus = st.session_state.get("studio_campus")
+    if campus is not None and campus.buildings:
+        ptype = campus.buildings[0].property_type or ptype
+        if bill_eui is None:
+            try:
+                from wattlab.benchmarks import annual_summary
+
+                summary = annual_summary(campus)
+                bill_eui = summary["campus"]["site_eui_kbtu_ft2"]
+                st.session_state["studio_benchmark_summary"] = summary
+            except Exception:
+                pass
+    if profile:
+        ptype = profile.get("building_type") or ptype
+
+    model = load_model_eui_from_run(run_dir)
+    report = st.session_state.get("studio_report") or {}
+    model_eui = model.get("model_eui_kbtu_ft2")
+    scale = model.get("prototype_area_scale") or report.get("prototype_area_scale")
+    target = model.get("target_floor_area_ft2") or report.get("target_floor_area_ft2")
+    if model_eui is None:
+        ann = (report.get("baseline_annual") or report.get("annual") or {})
+        if ann.get("site_eui_kbtu_ft2_year") is not None:
+            model_eui = float(ann["site_eui_kbtu_ft2_year"])
+        else:
+            for rr in report.get("result_records") or report.get("records") or []:
+                a = (rr or {}).get("annual") or {}
+                if a.get("site_eui_kbtu_ft2_year") is not None:
+                    model_eui = float(a["site_eui_kbtu_ft2_year"])
+                    break
+
+    if bill_eui is None and model_eui is None:
+        st.info(
+            "Load Fuel campus bills and/or publish a Twin run with report.json to see "
+            "bill EUI vs peer p20/p50/p80 vs model."
+        )
+        return
+
+    idx = build_eui_index(
+        bill_eui_kbtu_ft2=float(bill_eui) if bill_eui is not None else None,
+        property_type=str(ptype),
+        model_eui_kbtu_ft2=float(model_eui) if model_eui is not None else None,
+        prototype_area_scale=float(scale) if scale is not None else None,
+        target_floor_area_ft2=float(target) if target is not None else None,
+        model_label=str(model.get("run_id") or report.get("run_id") or "EnergyPlus"),
+    )
+    m1, m2, m3, m4 = st.columns(4)
+    m1.metric("Bills site EUI", f"{idx['bill_eui_kbtu_ft2']} kBtu/ft²" if idx["bill_eui_kbtu_ft2"] is not None else "—")
+    m2.metric("Peer typical (p50)", f"{idx['peer_p50']} kBtu/ft²")
+    m3.metric(
+        "Model EUI (prototype)",
+        f"{idx['model_eui_kbtu_ft2']} kBtu/ft²" if idx["model_eui_kbtu_ft2"] is not None else "—",
+    )
+    m4.metric("Peer band", f"p20={idx['peer_p20']} · p80={idx['peer_p80']}")
+
+    df = pd.DataFrame(idx["rows"])
+    st.dataframe(df, width="stretch", hide_index=True)
+
+    fig = go.Figure()
+    fig.add_shape(
+        type="rect",
+        x0=idx["peer_p20"],
+        x1=idx["peer_p80"],
+        y0=-0.5,
+        y1=0.5,
+        fillcolor="rgba(44,160,44,0.18)",
+        line_width=0,
+    )
+    fig.add_vline(x=idx["peer_p50"], line_dash="dash", line_color="#2ca02c")
+    colors = {"Bills (site)": "#1f77b4", "Model (prototype EUI)": "#d62728"}
+    for _, r in df.iterrows():
+        series = str(r["series"])
+        if series.startswith("Peer"):
+            continue
+        fig.add_scatter(
+            x=[r["site_eui_kbtu_ft2"]],
+            y=[0],
+            mode="markers+text",
+            marker=dict(symbol="diamond", size=16, color=colors.get(series, "#333")),
+            text=[series],
+            textposition="top center",
+            name=series,
+        )
+    fig.update_layout(
+        height=200,
+        margin=dict(l=10, r=10, t=20, b=10),
+        yaxis=dict(visible=False),
+        xaxis_title="Site EUI (kBtu/ft²-yr)",
+        showlegend=False,
+        title=f"{idx.get('benchmark_name') or idx['property_type']} peers",
+    )
+    st.plotly_chart(fig, width="stretch", key=chart_key)
+    if scale and float(scale) > 1.05:
+        st.warning(
+            f"prototype_area_scale ≈ {float(scale):.2f}× — model intensity (EUI) is comparable; "
+            "absolute modeled kWh is NOT site totals until geometry is scaled."
+        )
+    honesty = model.get("area_honesty") or report.get("area_honesty")
+    if honesty:
+        st.caption(honesty)
 
 
 def _fixture_eplusout() -> Path | None:
@@ -183,15 +305,21 @@ def render() -> None:
             st.warning("Dump still missing: " + ", ".join(g["field"] for g in missing))
 
     profile = _profile()
+    active_preview = _resolve_active_run()
+    _render_eui_index(
+        profile=profile,
+        run_dir=active_preview,
+        chart_key="twin_eui_index_active",
+    )
+
     if not profile:
         st.info(
             "Resolve a profile above (or have an AI agent write answers.json → wattlab twin). "
             "Agent prompt: vibe20_agent_spec/AGENT_TESTER_PROMPT.md"
         )
         # Still show any published 08 panes so agent work is visible before profile
-        active_early = _resolve_active_run()
-        if active_early is not None:
-            _render_08_panes(active_early)
+        if active_preview is not None:
+            _render_08_panes(active_preview)
         return
 
     with st.expander("Resolved profile", expanded=False):
@@ -380,7 +508,18 @@ def render() -> None:
     if not hist:
         st.caption("No prior runs in workspace runs/.")
     else:
-        st.dataframe(pd.DataFrame(hist), width="stretch", hide_index=True)
+        enriched = []
+        for h in hist:
+            row = dict(h)
+            model = load_model_eui_from_run(Path(str(h["dir"])) if h.get("dir") else None)
+            if model.get("model_eui_kbtu_ft2") is not None:
+                row["model_eui_kbtu_ft2"] = model["model_eui_kbtu_ft2"]
+            if model.get("prototype_area_scale") is not None:
+                row["prototype_area_scale"] = model["prototype_area_scale"]
+            if model.get("weather_mode"):
+                row["weather_mode"] = model["weather_mode"]
+            enriched.append(row)
+        st.dataframe(pd.DataFrame(enriched), width="stretch", hide_index=True)
         pick = st.selectbox(
             "Inspect iteration",
             options=[h.get("dir") for h in hist if h.get("dir")],
@@ -389,3 +528,10 @@ def render() -> None:
         if pick and st.button("Show 08 panes for selection", key="twin_show_iter"):
             st.session_state["studio_active_run"] = pick
             st.rerun()
+        if pick and Path(str(pick)).is_dir():
+            st.markdown(f"**EUI index for** `{Path(str(pick)).name}`")
+            _render_eui_index(
+                profile=profile,
+                run_dir=Path(str(pick)),
+                chart_key=f"twin_eui_index_hist_{Path(str(pick)).name}",
+            )

--- a/vibe_code_apps_20/wattlab/weather/epw.py
+++ b/vibe_code_apps_20/wattlab/weather/epw.py
@@ -332,6 +332,85 @@ def build_amy_epw(
     return metadata
 
 
+def epw_data_period(epw_path: Path | str) -> dict[str, Any] | None:
+    """Return begin/end dates covered by an EPW (DATA PERIODS + data rows).
+
+    Used to auto-align IDF ``RunPeriod`` when AMY weather is partial-year
+    (default annual RunPeriod + short EPW → EnergyPlus fatal EOF).
+    """
+    from datetime import date
+
+    path = Path(epw_path)
+    if not path.is_file():
+        return None
+    begin: date | None = None
+    end: date | None = None
+    header_begin: date | None = None
+    header_end: date | None = None
+    first_row: date | None = None
+    last_row: date | None = None
+
+    def _md(token: str, year: int | None = None) -> date | None:
+        parts = token.replace(" ", "").split("/")
+        if len(parts) != 2:
+            return None
+        try:
+            m, d = int(parts[0]), int(parts[1])
+            y = year or 2000
+            return date(y, m, d)
+        except ValueError:
+            return None
+
+    with path.open(encoding="utf-8", errors="replace") as fh:
+        for i, raw in enumerate(fh):
+            line = raw.strip()
+            if i < 8 and line.upper().startswith("DATA PERIODS"):
+                fields = [f.strip() for f in line.split(",")]
+                # DATA PERIODS,n,n,name,dow,start,end
+                if len(fields) >= 7:
+                    header_begin = _md(fields[5])
+                    header_end = _md(fields[6])
+                continue
+            if i < 8:
+                continue
+            # Data row: year,month,day,hour,...
+            parts = line.split(",")
+            if len(parts) < 4:
+                continue
+            try:
+                y, m, d = int(parts[0]), int(parts[1]), int(parts[2])
+                row_d = date(y, m, d)
+            except ValueError:
+                continue
+            if first_row is None:
+                first_row = row_d
+            last_row = row_d
+
+    begin = first_row or header_begin
+    end = last_row or header_end
+    if begin is None or end is None:
+        return None
+    full_year = begin.month == 1 and begin.day == 1 and end.month == 12 and end.day == 31
+    # Same calendar span without requiring Jan1–Dec31 when years differ in TMY
+    if header_begin and header_end:
+        full_year = full_year or (
+            header_begin.month == 1
+            and header_begin.day == 1
+            and header_end.month == 12
+            and header_end.day == 31
+            and (last_row is None or (last_row - first_row).days >= 360)
+        )
+    return {
+        "begin": begin.isoformat(),
+        "end": end.isoformat(),
+        "begin_date": begin,
+        "end_date": end,
+        "full_calendar_year": bool(full_year),
+        "n_days": (end - begin).days + 1,
+        "source": str(path),
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description="Build AMY EPW from weather CSV")
     p.add_argument("weather_csv", type=Path)


### PR DESCRIPTION
## Summary
- Fix critical nested `_stage_in` DinD mount (sibling `out__stage_in`) so `-r` / eplusout.csv works from Studio
- Fuel + Twin: bill EUI vs peer typical (p50) / p20–p80 vs EnergyPlus model EUI + scale honesty
- Auto-align IDF RunPeriod to partial-year AMY EPW span
- Keep user city label (`troy`) with climate catalog note (detroit)

## Test plan
- [x] pytest dind/city + studio AppTest + smoke_studio
- [ ] CI vibe20-ghcr green → merge → pull on bensbench (leave Studio recreate after pull)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EUI comparison metrics and visualizations to Fuel Dashboard and Twin calibration views.
  * Added support for displaying model EUI, peer benchmarks, scaling details, and comparison notes.
  * Added EPW period detection for full- and partial-year weather files.
  * Improved city display to preserve user-provided wording while retaining climate catalog details.

* **Bug Fixes**
  * Improved baseline simulations using partial-year weather files.
  * Fixed EnergyPlus staging behavior to support reliable file generation.
  * Added clearer handling for unknown or remapped cities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->