### PR TITLE
fix(vibe20): DinD perms, AMY RunPeriod, hard-size nameplate

### DIFF
--- a/vibe_code_apps_20/Dockerfile
+++ b/vibe_code_apps_20/Dockerfile
@@ -1,8 +1,13 @@
-# WattLab Studio container — ESCO / capital-planning cockpit.
-# Serves studio.py (Streamlit). EnergyPlus runs need a Docker daemon, which is
-# not available inside this container — the Studio dry-run / benchmark /
-# measures / capital-plan paths are fully functional; run real E+ simulations
-# from a host checkout (`wattlab easy-button`) instead.
+# WattLab Studio container — ESCO / capital-planning cockpit (Streamlit).
+#
+# EnergyPlus: mount the host Docker socket + set WATTLAB_HOST_WORKSPACE to the
+# host path of the /data bind so Twin → Run EnergyPlus (Docker) can spawn
+# energyplus-mcp-dev (DinD). Artifacts under /data/.artifacts; sibling stage
+# mounts + world-writable out dirs + --user 1000:1000 for ReadVars CSV.
+# Without docker.sock, dry-run / Fuel / ECMs still work; agents can publish
+# runs/ from a host checkout (`wattlab easy-button`).
+#
+# Entry point: studio.py (not wattlab/studio/app.py).
 FROM python:3.12-slim
 
 ARG VIBE20_GIT_SHA=unknown
@@ -13,6 +18,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     VIBE20_DOCKER=1 \
     WATTLAB_ROOT=/app \
+    ENERGYPLUS_DOCKER_USER=1000:1000 \
     VIBE20_GIT_SHA=${VIBE20_GIT_SHA} \
     VIBE20_IMAGE_REF=${VIBE20_IMAGE_REF} \
     VIBE20_IMAGE_TAG=${VIBE20_IMAGE_TAG} \

--- a/vibe_code_apps_20/README.md
+++ b/vibe_code_apps_20/README.md
@@ -32,6 +32,8 @@ docker run -d --restart unless-stopped -p 8520:8501 \
 `WATTLAB_HOST_WORKSPACE` must be the **host** path that matches the `/data` bind
 mount so Studio Twin → Run EnergyPlus can `docker run -v` into
 `energyplus-mcp-dev` (DinD-safe). Artifacts land under `/data/.artifacts`.
+Out/stage dirs are made world-writable and E+ runs as uid **1000** (override with
+`ENERGYPLUS_DOCKER_USER=` empty to disable). Streamlit entry: **`studio.py`**.
 
 Open **http://localhost:8520** (or `http://<host-ip>:8520`). Vibe19 typically uses **8502**.
 

--- a/vibe_code_apps_20/tests/test_dind_readvars_city.py
+++ b/vibe_code_apps_20/tests/test_dind_readvars_city.py
@@ -101,6 +101,7 @@ def test_run_energyplus_passes_readvars_and_host_mounts(
     host.mkdir()
     monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(data))
     monkeypatch.setenv("WATTLAB_HOST_WORKSPACE", str(host))
+    monkeypatch.delenv("ENERGYPLUS_DOCKER_USER", raising=False)
 
     idf = data / "baseline.idf"
     epw = data / "weather.epw"
@@ -123,15 +124,80 @@ def test_run_energyplus_passes_readvars_and_host_mounts(
     assert captured, "docker run was not invoked"
     args = captured[0]
     assert "-r" in args
+    assert "--user" in args
+    assert "1000:1000" in args
     host_ws = str(host.resolve()).replace("\\", "/")
     vol_flags = [args[i + 1] for i, a in enumerate(args) if a == "-v"]
     assert vol_flags
     joined = " ".join(v.replace("\\", "/") for v in vol_flags)
-    # Sibling stage (…/out__stage_in), not nested …/out/_stage_in
     assert "out__stage_in" in joined
     assert "/out/_stage_in" not in joined
     for v in vol_flags:
         assert host_ws in v.replace("\\", "/"), (v, host_ws)
+    # Out dir must be world-writable for E+ uid 1000
+    assert (out.stat().st_mode & 0o777) == 0o777 or (out.stat().st_mode & 0o222)
+
+
+def test_ensure_ep_writable_chmod(tmp_path: Path) -> None:
+    from wattlab.energyplus.docker import ensure_ep_writable
+
+    p = tmp_path / "sim"
+    ensure_ep_writable(p)
+    assert p.is_dir()
+    mode = p.stat().st_mode & 0o777
+    assert mode == 0o777 or (mode & 0o002)  # world-writable bit
+
+
+def test_align_idf_to_epw_partial(tmp_path: Path) -> None:
+    from wattlab.energyplus.mcp import align_idf_to_epw
+
+    idf = tmp_path / "b.idf"
+    idf.write_text(
+        "RunPeriod,\n  Annual,\n  1,\n  1,\n  2026,\n  12,\n  31,\n  2026,\n  Yes;\n",
+        encoding="utf-8",
+    )
+    epw = tmp_path / "partial.epw"
+    lines = [
+        "LOCATION,Test,MI,USA,AMY,0,42.5,-83.1,-5.0,200.0",
+        "DESIGN CONDITIONS,0",
+        "TYPICAL/EXTREME PERIODS,0",
+        "GROUND TEMPERATURES,0",
+        "HOLIDAYS/DAYLIGHT SAVINGS,No,0,0,0",
+        "COMMENTS 1,",
+        "COMMENTS 2,",
+        "DATA PERIODS,1,1,Data,Monday, 3/16, 7/16",
+        "2026,3,16,1,0," + ",".join(["0"] * 30),
+        "2026,7,16,24,0," + ",".join(["0"] * 30),
+    ]
+    epw.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    out = tmp_path / "aligned.idf"
+    meta = align_idf_to_epw(idf, epw, out_idf=out)
+    assert meta.get("applied") is True
+    text = out.read_text(encoding="utf-8")
+    assert "3," in text  # begin month
+    assert "16," in text  # begin day
+    assert meta["epw_begin"] == "2026-03-16"
+
+
+def test_nameplate_to_capacity_factors() -> None:
+    from wattlab.energyplus.sizing import nameplate_to_capacity_factors
+
+    inv = {
+        "systems": [
+            {
+                "system": "VAV SYS 1",
+                "load_type": "Cooling",
+                "user_design_capacity_w": 351685.0,  # ~100 ton
+            }
+        ],
+        "components": [],
+        "tables": {},
+    }
+    factors, meta = nameplate_to_capacity_factors(inv, cooling_tons=200.0)
+    assert "cooling_plant" in factors
+    assert abs(factors["cooling_plant"] - 2.0) < 0.05
+    assert meta.get("cooling_factor")
+
 
 
 def test_run_energyplus_can_disable_readvars(

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -156,9 +156,10 @@ publish_run_for_studio(Path("…/wattlab_<run_id>"), run_id="<run_id>")
 - Empty 08 panes = missing publish / `-r` / DinD — check env + sibling stage mounts.
 
 **Regression (this image):** Twin → **Run EnergyPlus (Docker)** once from Studio
-itself (not only host CLI). Expect `eplusout.csv` under `/data/.artifacts/…`
-and a published `runs/<id>/` after success. Nested `_stage_in` under out was the
-prior bug — sibling `…/sim__stage_in` should work.
+itself (not only host CLI). Expect `eplusout.csv` without chmod workarounds.
+Out dirs are world-writable + E+ `--user 1000:1000` (BUG-W1). Partial AMY
+auto-clips RunPeriod via `simulate()` (BUG-W2). Optional Twin **cooling_tons /
+fan_hp** → hard-size freeze after autosize (BUG-W3). Entry: `/app/studio.py`.
 
 ## TURNKEY CHECKLIST
 

--- a/vibe_code_apps_20/wattlab/easy_button.py
+++ b/vibe_code_apps_20/wattlab/easy_button.py
@@ -300,19 +300,68 @@ def run_easy_button(
     baseline_idf = run_dir / "baseline.idf"
     baseline_patch_name = ep.get("baseline_idf_patch") or "fan_avail_continuous"
     patch_meta = _apply_patch(baseline_patch_name, prepped_idf, baseline_idf)
+    patch_log: list[dict[str, Any]] = [monthly_meta, patch_meta]
+    if run_period_meta:
+        patch_log.insert(1, run_period_meta)
     base_out = run_dir / "sim_baseline"
     sim_meta = simulate(baseline_idf, epw, base_out)
+    sizing_scenario = "autosize"
+    hard_size = (ep.get("hard_size") or profile.get("hard_size") or {})
+    if isinstance(hard_size, dict) and (
+        hard_size.get("cooling_tons") is not None or hard_size.get("fan_hp") is not None
+    ):
+        from wattlab.energyplus.sizing import (
+            freeze_autosized_values,
+            nameplate_to_capacity_factors,
+            parse_sizing_inventory,
+        )
+
+        inv = parse_sizing_inventory(base_out)
+        factors, factor_meta = nameplate_to_capacity_factors(
+            inv,
+            cooling_tons=(
+                float(hard_size["cooling_tons"])
+                if hard_size.get("cooling_tons") is not None
+                else None
+            ),
+            fan_hp=(
+                float(hard_size["fan_hp"]) if hard_size.get("fan_hp") is not None else None
+            ),
+        )
+        patch_log.append({"patch": "hard_size_factors", **factor_meta, "factors": factors})
+        if factors:
+            hard_idf = run_dir / "baseline_hard_size.idf"
+            freeze_meta = freeze_autosized_values(
+                baseline_idf, hard_idf, inv, capacity_factors=factors
+            )
+            patch_log.append(freeze_meta)
+            baseline_idf = hard_idf
+            base_out = run_dir / "sim_baseline_hard"
+            sim_meta = simulate(baseline_idf, epw, base_out)
+            sizing_scenario = "hard_size"
+        else:
+            sizing_scenario = "autosize_observe_hard_size_unavailable"
+            patch_log.append(
+                {
+                    "patch": "hard_size",
+                    "ok": False,
+                    "note": "Nameplate provided but autosized inventory lacked comparable fields; kept autosize.",
+                }
+            )
     annual = annual_from_output_dir(
         base_out, elec_rate_usd_per_kwh=elec_rate, gas_rate_usd_per_therm=gas_rate
     )
     records: list[dict] = []
+    baseline_flags = ["uncalibrated", "conceptual_screening", "openfdd_wattlab"]
+    if sizing_scenario == "hard_size":
+        baseline_flags.append("hard_size_nameplate")
     baseline_record = build_result_record(
         run_id=f"{run_id}_baseline",
         measure_id=None,
         idf_path=baseline_idf,
         annual=annual,
         artifacts=[str(base_out / "eplustbl.htm"), str(baseline_idf)],
-        extra_flags=["uncalibrated", "conceptual_screening", "openfdd_wattlab"],
+        extra_flags=baseline_flags,
     )
     records.append(baseline_record)
     (run_dir / "result_record_baseline.json").write_text(
@@ -322,9 +371,6 @@ def run_easy_button(
     current_idf = baseline_idf
     after_ecm1_annual: dict | None = None
     after_ecm2_annual: dict | None = None
-    patch_log = [monthly_meta, patch_meta]
-    if run_period_meta:
-        patch_log.insert(1, run_period_meta)
 
     for m in measures:
         mid = m["measure_id"]
@@ -437,6 +483,8 @@ def run_easy_button(
             "the IDF — compare EUI / use prototype_area_scale for screening only; "
             "do not claim calibrated building savings without a scaled or site-specific model."
         ),
+        "sizing_scenario": sizing_scenario,
+        "hard_size": hard_size if isinstance(hard_size, dict) and hard_size else None,
         "epw": str(epw),
         "epw_note": epw_note,
         "weather_suitability": wx,

--- a/vibe_code_apps_20/wattlab/energyplus/docker.py
+++ b/vibe_code_apps_20/wattlab/energyplus/docker.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
 
 from wattlab.config import DOCKER_IMAGE, ENERGYPLUS_MCP, ROOT
+
+# energyplus-mcp-dev image runs as vscode (uid 1000). Studio DinD often creates
+# bind-mounted dirs as root 755 → E+ cannot write eplusout.* under /work/out.
+_DEFAULT_EP_USER = "1000:1000"
 
 
 class DockerUnavailable(RuntimeError):
@@ -83,6 +88,35 @@ def _win_mount(path: Path) -> str:
     return str(path.resolve()).replace("\\", "/")
 
 
+def ensure_ep_writable(path: Path) -> Path:
+    """Create ``path`` world-writable so E+ container uid 1000 can write outputs.
+
+    Studio often runs as root and creates 755 dirs; energyplus-mcp-dev is uid 1000.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path, 0o777)
+    except OSError:
+        pass
+    return path
+
+
+def _chmod_loose(path: Path, mode: int = 0o666) -> None:
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass
+
+
+def energyplus_docker_user() -> str | None:
+    """User for ``docker run --user``. Default 1000:1000; set empty to disable."""
+    raw = os.environ.get("ENERGYPLUS_DOCKER_USER")
+    if raw is None:
+        return _DEFAULT_EP_USER
+    raw = raw.strip()
+    return raw or None
+
+
 def run_in_container(
     cmd: list[str],
     *,
@@ -96,6 +130,9 @@ def run_in_container(
     ensure_image(build=False)
     tag = image or DOCKER_IMAGE
     args = [docker_bin(), "run", "--rm"]
+    user = energyplus_docker_user()
+    if user:
+        args.extend(["--user", user])
     default_mounts: list[tuple[Path, str]] = [(ROOT, "/workspace/app")]
     if ENERGYPLUS_MCP.is_dir():
         default_mounts.append((ENERGYPLUS_MCP, "/workspace/EnergyPlus-MCP"))
@@ -125,10 +162,14 @@ def run_energyplus(
     ``eplusout.csv`` for Twin APIHelper-08 timeseries panes.
     Mount sources are translated via ``host_path_for_docker`` when Studio runs
     with docker.sock + ``WATTLAB_HOST_WORKSPACE``.
+
+    Output/stage dirs are chmod'd world-writable and the container runs as
+    ``ENERGYPLUS_DOCKER_USER`` (default ``1000:1000``) so DinD from a root
+    Studio process can write under ``/work/out``.
     """
     from wattlab.config import host_path_for_docker
 
-    output_dir.mkdir(parents=True, exist_ok=True)
+    ensure_ep_writable(output_dir)
     idf = idf.resolve()
     epw = epw.resolve()
     work = output_dir.resolve()
@@ -146,27 +187,36 @@ def run_energyplus(
     # ReadVars (-r): EnergyPlus cannot write /work/in/*.rvi when /work/in is a
     # child of the /work/out volume (DinD host-path resolution).
     stage = work.parent / f"{work.name}__stage_in"
-    stage.mkdir(parents=True, exist_ok=True)
+    ensure_ep_writable(stage)
     staged_idf = stage / idf.name
     staged_epw = stage / epw.name
     if staged_idf.resolve() != idf:
         shutil.copy2(idf, staged_idf)
     if staged_epw.resolve() != epw:
         shutil.copy2(epw, staged_epw)
+    _chmod_loose(staged_idf)
+    _chmod_loose(staged_epw)
     host_stage = host_path_for_docker(stage)
     host_work = host_path_for_docker(work)
     args = [
         docker_bin(),
         "run",
         "--rm",
-        "-v",
-        f"{_win_mount(host_stage)}:/work/in",
-        "-v",
-        f"{_win_mount(host_work)}:/work/out",
-        "-w",
-        "/work/out",
-        DOCKER_IMAGE,
-        *cmd,
     ]
+    user = energyplus_docker_user()
+    if user:
+        args.extend(["--user", user])
+    args.extend(
+        [
+            "-v",
+            f"{_win_mount(host_stage)}:/work/in",
+            "-v",
+            f"{_win_mount(host_work)}:/work/out",
+            "-w",
+            "/work/out",
+            DOCKER_IMAGE,
+            *cmd,
+        ]
+    )
     ensure_image(build=False)
     return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)

--- a/vibe_code_apps_20/wattlab/energyplus/mcp.py
+++ b/vibe_code_apps_20/wattlab/energyplus/mcp.py
@@ -180,22 +180,92 @@ def get_server_status_via_docker(*, check_mcp_import: bool = False) -> dict[str,
     return status
 
 
+def align_idf_to_epw(
+    idf: Path,
+    epw: Path,
+    out_idf: Path | None = None,
+) -> dict[str, Any]:
+    """Clip IDF RunPeriod to EPW data coverage (partial-year AMY safe).
+
+    Returns metadata; ``out`` is the IDF path to simulate (may equal ``idf``
+    when weather is a full calendar year and no clip is needed).
+    """
+    from wattlab.energyplus.patches import apply_run_period
+    from wattlab.weather.epw import epw_data_period
+
+    idf = Path(idf)
+    epw = Path(epw)
+    span = epw_data_period(epw)
+    if not span:
+        return {"patch": "run_period", "applied": False, "reason": "epw_span_unknown", "out": str(idf)}
+    if span.get("full_calendar_year"):
+        return {
+            "patch": "run_period",
+            "applied": False,
+            "reason": "full_calendar_year",
+            "epw_begin": span["begin"],
+            "epw_end": span["end"],
+            "out": str(idf),
+        }
+    dest = Path(out_idf) if out_idf is not None else idf.with_name(f"{idf.stem}_epw_aligned.idf")
+    # Prefer exact data-row dates (not header month/day without year).
+    begin = span["begin"]
+    end = span["end"]
+    meta = apply_run_period(idf, dest, begin=begin, end=end)
+    meta["applied"] = True
+    meta["reason"] = (
+        f"EPW data period {begin}→{end} is not a full calendar year; "
+        "RunPeriod auto-clipped (partial-year AMY)."
+    )
+    meta["epw_begin"] = begin
+    meta["epw_end"] = end
+    meta["n_days"] = span.get("n_days")
+    return meta
+
+
 def simulate(
     idf: Path,
     epw: Path,
     output_dir: Path,
     *,
     timeout: int | None = 3600,
+    align_run_period: bool = True,
 ) -> dict[str, Any]:
-    """Run EnergyPlus simulation (parity with MCP run_energyplus_simulation)."""
-    proc = run_energyplus(idf, epw, output_dir, timeout=timeout)
-    return {
+    """Run EnergyPlus simulation (parity with MCP run_energyplus_simulation).
+
+    When ``align_run_period`` is True (default), partial-year EPWs auto-clip
+    the IDF RunPeriod before Docker invoke — avoids FATAL GetNextEnvironment.
+    """
+    idf = Path(idf)
+    epw = Path(epw)
+    output_dir = Path(output_dir)
+    align_meta: dict[str, Any] | None = None
+    idf_run = idf
+    if align_run_period:
+        try:
+            aligned_path = output_dir.parent / f"{output_dir.name}__epw_aligned.idf"
+            # ensure parent exists for aligned idf (writable)
+            from wattlab.energyplus.docker import ensure_ep_writable
+
+            ensure_ep_writable(output_dir.parent)
+            align_meta = align_idf_to_epw(idf, epw, out_idf=aligned_path)
+            if align_meta.get("applied"):
+                idf_run = Path(align_meta["out"])
+        except Exception as exc:  # noqa: BLE001
+            align_meta = {"patch": "run_period", "applied": False, "error": str(exc)}
+
+    proc = run_energyplus(idf_run, epw, output_dir, timeout=timeout)
+    out: dict[str, Any] = {
         "returncode": proc.returncode,
         "stdout_tail": (proc.stdout or "")[-2000:],
         "stderr_tail": (proc.stderr or "")[-2000:],
         "output_dir": str(output_dir),
         "ok": proc.returncode == 0,
+        "idf_simulated": str(idf_run),
     }
+    if align_meta is not None:
+        out["run_period_align"] = align_meta
+    return out
 
 
 def copy_prototype(src: Path, dest: Path) -> Path:

--- a/vibe_code_apps_20/wattlab/energyplus/sizing.py
+++ b/vibe_code_apps_20/wattlab/energyplus/sizing.py
@@ -277,3 +277,107 @@ def freeze_autosized_values(
         "screening_only",
     ]
     return meta
+
+
+# 1 refrigeration ton ≈ 3516.85 W; 1 mechanical hp ≈ 745.7 W
+_TON_W = 3516.8528420667
+_HP_W = 745.7
+
+
+def _autosized_cooling_w(inventory: Mapping[str, Any]) -> float | None:
+    """Best-effort total cooling plant capacity from sizing inventory (W)."""
+    total = 0.0
+    found = False
+    for sys in inventory.get("systems") or []:
+        load = str(sys.get("load_type") or "").lower()
+        cap = sys.get("user_design_capacity_w")
+        if cap is not None and ("cool" in load or "cooling" in load or not load):
+            total += float(cap)
+            found = True
+    for comp in inventory.get("components") or []:
+        desc = str(comp.get("description") or "").lower()
+        otype = str(comp.get("object_type") or "").lower()
+        val = comp.get("value")
+        if val is None:
+            continue
+        if "chiller" in otype and ("nominal capacity" in desc or "capacity" in desc):
+            total += float(val)
+            found = True
+        elif "cooling" in desc and "capacity" in desc and "coil" not in otype:
+            total += float(val)
+            found = True
+    plant = (inventory.get("tables") or {}).get("central_plant") or []
+    for row in plant:
+        for key, val in row.items():
+            if key == "name" or not isinstance(val, (int, float)):
+                continue
+            kl = key.lower()
+            if "capacity" in kl or "nominal" in kl:
+                total += float(val)
+                found = True
+    return total if found and total > 0 else None
+
+
+def _autosized_fan_power_w(inventory: Mapping[str, Any]) -> float | None:
+    fans = (inventory.get("tables") or {}).get("fans") or []
+    total = 0.0
+    found = False
+    for row in fans:
+        for key, val in row.items():
+            if not isinstance(val, (int, float)):
+                continue
+            kl = key.lower()
+            if "power" in kl or "rated electric" in kl:
+                total += float(val)
+                found = True
+    for comp in inventory.get("components") or []:
+        otype = str(comp.get("object_type") or "").lower()
+        desc = str(comp.get("description") or "").lower()
+        val = comp.get("value")
+        if val is None:
+            continue
+        if "fan" in otype and ("power" in desc or "max power" in desc):
+            total += float(val)
+            found = True
+    return total if found and total > 0 else None
+
+
+def nameplate_to_capacity_factors(
+    inventory: Mapping[str, Any],
+    *,
+    cooling_tons: float | None = None,
+    fan_hp: float | None = None,
+) -> tuple[dict[str, float], dict[str, Any]]:
+    """Map FM nameplate (tons / fan hp) → capacity_factors vs autosized inventory.
+
+    Returns ``(factors, meta)``. Empty factors when inventory lacks comparable
+    autosized values — caller should stamp NEEDS_INPUT / observe-only.
+    """
+    meta: dict[str, Any] = {
+        "cooling_tons_nameplate": cooling_tons,
+        "fan_hp_nameplate": fan_hp,
+    }
+    factors: dict[str, float] = {}
+    if cooling_tons is not None and float(cooling_tons) > 0:
+        auto_w = _autosized_cooling_w(inventory)
+        meta["autosized_cooling_w"] = auto_w
+        if auto_w and auto_w > 0:
+            target_w = float(cooling_tons) * _TON_W
+            factors["cooling_plant"] = target_w / auto_w
+            factors["cooling_coils"] = factors["cooling_plant"]
+            meta["cooling_factor"] = factors["cooling_plant"]
+        else:
+            meta["cooling_factor_error"] = "no_autosized_cooling_in_inventory"
+    if fan_hp is not None and float(fan_hp) > 0:
+        auto_w = _autosized_fan_power_w(inventory)
+        meta["autosized_fan_w"] = auto_w
+        if auto_w and auto_w > 0:
+            target_w = float(fan_hp) * _HP_W
+            ratio = target_w / auto_w
+            factors["fan_power"] = ratio
+            factors["fan_pressure"] = ratio
+            meta["fan_factor"] = ratio
+        else:
+            # No fan power in inventory — leave note; do not invent.
+            meta["fan_factor_error"] = "no_autosized_fan_power_in_inventory"
+    return factors, meta

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -325,12 +325,63 @@ def render() -> None:
     with st.expander("Resolved profile", expanded=False):
         st.json(profile)
 
+    try:
+        from wattlab.energyplus.mcp import capability_status
+
+        cap = capability_status(probe_docker=True)
+        mode = cap.get("mode") or "?"
+        if mode == "simulate_only":
+            st.info(
+                f"EnergyPlus capability: **{mode}** — Docker sims OK; LBNL MCP inspect "
+                "tools need a host vendor clone (`full_mcp_available`). "
+                f"{cap.get('note') or ''}"
+            )
+        elif mode == "full_mcp_available":
+            st.success(f"EnergyPlus capability: **{mode}**")
+        else:
+            st.warning(f"EnergyPlus capability: **{mode}** — {cap.get('note') or ''}")
+    except Exception as exc:
+        st.caption(f"capability_status unavailable: {exc}")
+
+    st.markdown("**Hard-size constrain (optional FM nameplate)**")
+    st.caption(
+        "Sparse ladder step 3: after autosize, freeze plant/fans toward FM tons/hp "
+        "(conceptual). Leave blank to keep autosize-only."
+    )
+    hs1, hs2 = st.columns(2)
+    cooling_tons = hs1.number_input(
+        "cooling_tons (nameplate)",
+        min_value=0.0,
+        value=0.0,
+        step=10.0,
+        key="twin_cooling_tons",
+        help="e.g. 200 for 2×100 ton chillers",
+    )
+    fan_hp = hs2.number_input(
+        "supply_fan_hp (nameplate)",
+        min_value=0.0,
+        value=0.0,
+        step=5.0,
+        key="twin_fan_hp",
+        help="e.g. 75 hp",
+    )
+
     measure_set = st.session_state.get("studio_measure_set") or profile.get("measure_set") or "best"
     proxies = st.session_state.get("studio_proxies") or {}
     run_profile = dict(profile)
     run_profile["measure_set"] = measure_set
     if proxies:
         run_profile["proxy_savings"] = proxies
+    hard_size: dict[str, float] = {}
+    if cooling_tons and float(cooling_tons) > 0:
+        hard_size["cooling_tons"] = float(cooling_tons)
+    if fan_hp and float(fan_hp) > 0:
+        hard_size["fan_hp"] = float(fan_hp)
+    if hard_size:
+        ep = dict(run_profile.get("energyplus") or {})
+        ep["hard_size"] = hard_size
+        run_profile["energyplus"] = ep
+        run_profile["hard_size"] = hard_size
 
     try:
         from wattlab.energyplus.docker import docker_info_ok, image_present


### PR DESCRIPTION
## Summary
- **BUG-W1:** world-writable EP out/stage + `ENERGYPLUS_DOCKER_USER=1000:1000` so Studio DinD can write eplusout.*
- **BUG-W2:** `simulate()` / `align_idf_to_epw` auto-clips RunPeriod to EPW data rows
- **BUG-W3:** Twin cooling_tons / fan_hp → inventory-based capacity freeze after autosize
- **BUG-W4/W5/W6:** Dockerfile + capability banner + studio.py entry noted

## Test plan
- [x] pytest + smoke_studio
- [ ] CI vibe20-ghcr → merge → pull/recreate on bensbench; Studio DinD smoke without chmod