### PR TITLE
fix(vibe20): W2b/W3b, peak demand kW, multi-floor Twin, agent docker docs

### DIFF
--- a/vibe_code_apps_19/README.md
+++ b/vibe_code_apps_19/README.md
@@ -31,6 +31,7 @@ Suggested human→agent message:
 - **WattLab dump v3** (Export tab) — AI-agent handoff zip for vibe20: profiles `summary` (default) / `diagnostic` / `forensic`, shared `telemetry/`, mechanical series + coverage, FDD summary/findings, expanded sensor stats + provenance, `model_seed.json`, and `MANIFEST.json` (`wattlab_dump_v3`)
 - Headless agent API + CLI; session download/restore for Cloud-friendly handoff
 - **Docker / GHCR** image for self-host demos (**Vibe 19 only** — this work does not publish Vibe 20)
+- **Shared agent workspace with vibe20:** dump zips into a host volume both containers mount; agents use `docker exec` (no git clone). See vibe20 [`AGENT_DOCKER_WORKSPACE.md`](../vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md)
 
 ## Quick start (local)
 

--- a/vibe_code_apps_20/tests/test_dind_readvars_city.py
+++ b/vibe_code_apps_20/tests/test_dind_readvars_city.py
@@ -199,6 +199,135 @@ def test_nameplate_to_capacity_factors() -> None:
     assert meta.get("cooling_factor")
 
 
+def test_nameplate_area_scale_liberty_style() -> None:
+    """140k ft² + 200 t → ~14.3 t effective on ~10k prototype (≈0.14× factor)."""
+    from wattlab.config import PROTOTYPE_AREA_FT2_NOMINAL
+    from wattlab.energyplus.sizing import nameplate_to_capacity_factors
+
+    inv = {
+        "systems": [
+            {
+                "system": "VAV SYS 1",
+                "load_type": "Cooling",
+                "user_design_capacity_w": 351685.0,  # ~100 ton autosized
+            }
+        ],
+        "components": [],
+        "tables": {},
+    }
+    scale = 140_000.0 / PROTOTYPE_AREA_FT2_NOMINAL
+    factors, meta = nameplate_to_capacity_factors(
+        inv, cooling_tons=200.0, prototype_area_scale=scale
+    )
+    # 14.3 t effective on ~100 t autosize → factor ~0.14 < 0.25 → refused
+    assert meta.get("nameplate_area_scaled") is True
+    assert abs(meta["cooling_tons_effective"] - (200.0 / scale)) < 0.01
+    assert abs(meta["cooling_tons_effective"] - 14.26) < 0.5
+    assert factors == {}
+    assert meta.get("hard_size_refused") is True
+    # Use a smaller autosize so scaled nameplate stays in band:
+    inv_small = {
+        "systems": [
+            {
+                "system": "VAV SYS 1",
+                "load_type": "Cooling",
+                "user_design_capacity_w": 35168.5,  # ~10 ton
+            }
+        ],
+        "components": [],
+        "tables": {},
+    }
+    factors2, meta2 = nameplate_to_capacity_factors(
+        inv_small, cooling_tons=200.0, prototype_area_scale=scale
+    )
+    assert meta2.get("nameplate_area_scaled") is True
+    assert abs(meta2["cooling_tons_effective"] - 14.26) < 0.5
+    assert "cooling_plant" in factors2
+    assert abs(factors2["cooling_plant"] - 1.426) < 0.1
+    assert meta2.get("hard_size_refused") is False
+
+
+def test_nameplate_hard_size_refused_extreme() -> None:
+    from wattlab.energyplus.sizing import nameplate_to_capacity_factors
+
+    inv = {
+        "systems": [
+            {
+                "system": "VAV SYS 1",
+                "load_type": "Cooling",
+                "user_design_capacity_w": 35168.5,  # ~10 ton
+            }
+        ],
+        "components": [],
+        "tables": {},
+    }
+    # No area scale: 200 t on 10 t → factor 20× → refuse
+    factors, meta = nameplate_to_capacity_factors(inv, cooling_tons=200.0)
+    assert factors == {}
+    assert meta.get("hard_size_refused") is True
+    assert meta.get("refused_factors")
+
+
+def test_peak_demand_kw_from_tbl_and_savings(tmp_path: Path) -> None:
+    from wattlab.energyplus.results import (
+        parse_eplustbl_csv,
+        peak_demand_kw_from_eplusout_csv,
+        savings_by_measure,
+    )
+
+    tbl = tmp_path / "eplustbl.csv"
+    tbl.write_text(
+        "\n".join(
+            [
+                "Report,Annual Building Utility Performance Summary",
+                ",Total Site Energy,100.0,50.0",
+                ",Total Building Area,927.2",
+                ",Total End Uses,80.0,20.0",
+                ",Electricity:Facility,80.0",
+                "Report,Demand End Use Components Summary",
+                ",Total End Uses,125000.0",
+                ",Electricity:Facility,125000.0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    parsed = parse_eplustbl_csv(tbl)
+    assert parsed.get("peak_demand_kw") == 125.0
+
+    csv_path = tmp_path / "eplusout.csv"
+    csv_path.write_text(
+        "Date/Time,Electricity:Facility [J](Hourly)\n"
+        "01/01  01:00:00,360000000\n"
+        "01/01  02:00:00,720000000\n",
+        encoding="utf-8",
+    )
+    assert peak_demand_kw_from_eplusout_csv(csv_path) == 200.0
+
+    rows = savings_by_measure(
+        [
+            {
+                "measure_id": None,
+                "annual": {
+                    "electricity_kwh_year": 1000.0,
+                    "peak_demand_kw": 125.0,
+                    "utility_cost_usd_year": 120.0,
+                },
+            },
+            {
+                "measure_id": "led",
+                "annual": {
+                    "electricity_kwh_year": 900.0,
+                    "peak_demand_kw": 110.0,
+                    "utility_cost_usd_year": 108.0,
+                },
+            },
+        ]
+    )
+    assert rows[0]["peak_demand_kw"] == 125.0
+    assert rows[1]["vs_baseline"]["peak_demand_kw_delta"] == 15.0
+
+
 
 def test_run_energyplus_can_disable_readvars(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -258,6 +387,40 @@ def test_epw_data_period_partial(tmp_path: Path) -> None:
     assert span["full_calendar_year"] is False
     assert span["begin"] == "2026-03-16"
     assert span["end"] == "2026-07-16"
+    assert span.get("ok") is True
+    assert span.get("end_clipped_from_partial_day") is False
+
+
+def test_epw_data_period_clips_trailing_partial_day(tmp_path: Path) -> None:
+    """BUG-W2b: last row hour 10 must not set RunPeriod end to that calendar day."""
+    from wattlab.weather.epw import epw_data_period
+
+    pad = ",".join(["0"] * 30)
+    epw = tmp_path / "partial_hour.epw"
+    lines = [
+        "LOCATION,Test,MI,USA,AMY,0,42.5,-83.1,-5.0,200.0",
+        "DESIGN CONDITIONS,0",
+        "TYPICAL/EXTREME PERIODS,0",
+        "GROUND TEMPERATURES,0",
+        "HOLIDAYS/DAYLIGHT SAVINGS,No,0,0,0",
+        "COMMENTS 1,",
+        "COMMENTS 2,",
+        "DATA PERIODS,1,1,Data,Monday, 7/15, 7/17",
+        f"2026,7,15,1,0,{pad}",
+        f"2026,7,15,24,0,{pad}",
+        f"2026,7,16,1,0,{pad}",
+        f"2026,7,16,24,0,{pad}",
+        f"2026,7,17,1,0,{pad}",
+        f"2026,7,17,10,0,{pad}",
+    ]
+    epw.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    span = epw_data_period(epw)
+    assert span is not None
+    assert span["begin"] == "2026-07-15"
+    assert span["end"] == "2026-07-16"
+    assert span["last_row_hour"] == 10
+    assert span["end_clipped_from_partial_day"] is True
+    assert span.get("ok") is True
 
 
 def test_build_eui_index_bills_peers_model() -> None:

--- a/vibe_code_apps_20/tests/test_ep_viz.py
+++ b/vibe_code_apps_20/tests/test_ep_viz.py
@@ -35,6 +35,16 @@ def test_floor_plan_and_oa_from_fixture():
     assert oa is not None
 
 
+def test_multifloor_office_schematic_smoke():
+    from wattlab.studio.ep_viz import MULTIFLOOR_HONESTY, multifloor_office_figure
+
+    roles = {"north": 22.0, "south": 23.0, "east": 21.5, "west": 22.5, "center": 22.0}
+    fig = multifloor_office_figure(roles, n_floors=6)
+    assert fig is not None
+    assert "6-story" in (fig.layout.title.text or "")
+    assert "Schematic massing" in MULTIFLOOR_HONESTY
+
+
 def test_demo_replay_install(tmp_path: Path):
     dest = tmp_path / "demo_replay"
     install_demo_replay(dest, FIXTURE)

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -158,8 +158,14 @@ publish_run_for_studio(Path("…/wattlab_<run_id>"), run_id="<run_id>")
 **Regression (this image):** Twin → **Run EnergyPlus (Docker)** once from Studio
 itself (not only host CLI). Expect `eplusout.csv` without chmod workarounds.
 Out dirs are world-writable + E+ `--user 1000:1000` (BUG-W1). Partial AMY
-auto-clips RunPeriod via `simulate()` (BUG-W2). Optional Twin **cooling_tons /
-fan_hp** → hard-size freeze after autosize (BUG-W3). Entry: `/app/studio.py`.
+auto-clips RunPeriod via `simulate()` (BUG-W2). **BUG-W2b:** EPW end is the last
+**full** day (max hour ≥ 23) — trailing partial hours (e.g. 10:00) must not set
+RunPeriod end. Optional Twin **cooling_tons / fan_hp** → area-aware hard-size
+(`1/prototype_area_scale` when scale > 1.5); factors outside `[0.25, 4.0]` refuse
+freeze → `sizing_scenario=hard_size_refused` (BUG-W3b). Results show **peak_demand_kw**
+alongside kWh. Multi-floor profiles (`floors` ≥ 2) get stacked schematic plates
+(not site CAD). Agent ops: [`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)
+(`docker exec` + shared volume — no git clone). Entry: `/app/studio.py`.
 
 ## TURNKEY CHECKLIST
 
@@ -171,12 +177,16 @@ fan_hp** → hard-size freeze after autosize (BUG-W3). Entry: `/app/studio.py`.
 5. Dry-run plan once (optional warm-up).
 6. **Studio-native** Docker E+ once → `eplusout.csv` (DinD sibling-mount gate).
 7. **Live campaign:** ≥3 Docker E+ sims (≥6–10 if sparse), each published, each confirmed in Twin UI.
-8. Partial-year AMY: RunPeriod auto-aligned (or document fatal if not).
+8. Partial-year AMY: RunPeriod ends on last **full** EPW day (W2b); not trailing hour-10 day.
 9. MCP inspect at least once if `full_mcp_available`.
 10. G14 / crosscheck logged per run when bills exist — or honest period/scale mismatch.
 11. Area honesty / `prototype_area_scale` called out (5Zone ≠ site ft²).
-12. ECMs page exercised; capital gate noted.
-13. Write `reports/CALIBRATE_SESSION.md` + `BUG_REPORT.md`.
+12. Hard-size: area-scaled nameplate or `hard_size_refused` banner when factors absurd (W3b).
+13. Peak demand kW visible on Twin results / ECM when eplustbl or eplusout has it.
+14. Multi-floor profile (≥2): stacked schematic + honesty caption (not site CAD).
+15. ECMs page exercised; capital gate noted.
+16. Write `reports/CALIBRATE_SESSION.md` + `BUG_REPORT.md`.
+17. Agent path via shared volume / `docker exec` (see `docs/AGENT_DOCKER_WORKSPACE.md`).
 
 ## PASS / FAIL
 
@@ -189,6 +199,10 @@ fan_hp** → hard-size freeze after autosize (BUG-W3). Entry: `/app/studio.py`.
 | **Twin calibrate** | **≥3 live** `energyplus-mcp-dev` sims in `runs/`, each with eplusout; human saw updates; G14 attempted **or** honest mismatch logged when bills exist |
 | E+ MCP | ≥1 inspect/validate if MCP available; else document `simulate_only` |
 | Honesty | No calibrated ROI without G14 + area + weather stamps |
+| W2b full-day AMY | RunPeriod end = last complete EPW day (not partial trailing hours) |
+| W3b hard-size | Area-scaled nameplate or refused + NEEDS_INPUT banner |
+| Demand kW | `peak_demand_kw` on results when meters/tbl present |
+| Multi-floor viz | floors≥2 → stacked schematic + honesty caption |
 
 One live sim is **not** enough. Really try the loop — baseline + hypotheses —
 with the human engineer.

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -1,0 +1,80 @@
+# Agent Docker workspace (vibe19 + vibe20)
+
+Agents use the **running containers** and a **shared host volume** — not a git
+clone of this repo on the agent machine. Studio (browser) is the human viewer;
+CLI/`docker exec` is the agent surface for this cycle.
+
+> Future: same workspace contract may gain a thin HTTP wrapper. Until then,
+> `docker exec` + shared volumes are the equal vibe19/20 ops path.
+
+## Shared volume layout
+
+On the host (bensbench-style):
+
+```text
+$WATTLAB_HOST_WORKSPACE/          # e.g. $HOME/wattlab_workspace
+  uploads/                        # WattLab dump zips from vibe19
+  runs/                           # published Twin iterations (eplusout.csv, reports)
+  reports/                        # CALIBRATE_SESSION.md, capital plans, …
+  .artifacts/                     # DinD EnergyPlus stage/out (container-managed)
+```
+
+Containers typically mount:
+
+| Container | Host path | Container path | Notes |
+|-----------|-----------|----------------|-------|
+| `vibe19`  | `$HOME/wattlab_workspace` | `/data` (or app workspace) | Export dump zip here |
+| `vibe20`  | `$HOME/wattlab_workspace` | `/data` | `WATTLAB_STUDIO_WORKSPACE=/data` |
+| both      | `/var/run/docker.sock` | same | DinD EnergyPlus (`energyplus-mcp-dev`) |
+
+vibe20 also needs `WATTLAB_HOST_WORKSPACE` set to the **host** path (sibling
+mounts for DinD) and preferably `ENERGYPLUS_DOCKER_USER=1000:1000`.
+
+## Agent flow (no git)
+
+```text
+docker exec vibe19 … agent_api / agent_afdd
+        │
+        ▼  WattLab dump zip
+shared wattlab_workspace/uploads/
+        │
+        ▼
+docker exec vibe20 wattlab twin | easy-button | calibrate
+        │
+        ▼  Docker sock → energyplus-mcp-dev
+runs/<id>/eplusout.csv + wattlab_report.json
+        │
+        ▼
+Human opens Studio Twin (browser) — Refresh agent runs
+```
+
+### Examples
+
+```bash
+# 1) vibe19 — produce dump into shared uploads (exact CLI depends on image entrypoints)
+docker exec vibe19 python -m openfdd_vibe ...   # or agent_api / agent_afdd docs in vibe19
+
+# 2) vibe20 — easy-button / twin from a profile under /data
+docker exec vibe20 wattlab easy-button --building /data/uploads/.../building_profile.json
+
+# 3) Confirm publish
+docker exec vibe20 ls -la /data/runs
+```
+
+EnergyPlus itself runs in `energyplus-mcp-dev` via the mounted docker socket
+(DinD). Do **not** expect host `pyenergyplus` or a live Flask mid-run server.
+
+## Equal look-and-feel (ops)
+
+| Concern | vibe19 | vibe20 |
+|---------|--------|--------|
+| Workspace | shared volume | same shared volume |
+| Agent entry | `docker exec` + agent API/AFDD | `docker exec` + `wattlab` CLI |
+| Human UI | Streamlit | Streamlit Studio Twin |
+| Secrets / code | image + volume | image + volume (no clone) |
+
+Cross-links:
+
+- vibe19 README — Docker/GHCR + dump handoff
+- [`AGENT_TESTER_PROMPT.md`](../AGENT_TESTER_PROMPT.md) — browser gates (W2b/W3b, demand kW, multi-floor)
+- [`TWIN_LOOP.md`](TWIN_LOOP.md) — calibrate iteration contract

--- a/vibe_code_apps_20/wattlab/easy_button.py
+++ b/vibe_code_apps_20/wattlab/easy_button.py
@@ -317,6 +317,12 @@ def run_easy_button(
         )
 
         inv = parse_sizing_inventory(base_out)
+        area_ft2 = float(
+            profile.get("conditioned_floor_area_ft2") or profile.get("floor_area_ft2") or 0
+        )
+        area_scale = (
+            area_ft2 / PROTOTYPE_AREA_FT2_NOMINAL if area_ft2 > 0 else None
+        )
         factors, factor_meta = nameplate_to_capacity_factors(
             inv,
             cooling_tons=(
@@ -327,9 +333,22 @@ def run_easy_button(
             fan_hp=(
                 float(hard_size["fan_hp"]) if hard_size.get("fan_hp") is not None else None
             ),
+            prototype_area_scale=area_scale,
         )
         patch_log.append({"patch": "hard_size_factors", **factor_meta, "factors": factors})
-        if factors:
+        if factor_meta.get("hard_size_refused"):
+            sizing_scenario = "hard_size_refused"
+            patch_log.append(
+                {
+                    "patch": "hard_size",
+                    "ok": False,
+                    "needs_input": True,
+                    "note": factor_meta.get("refuse_reason")
+                    or "Hard-size factors out of band; kept autosize (NEEDS_INPUT).",
+                    "refused_factors": factor_meta.get("refused_factors"),
+                }
+            )
+        elif factors:
             hard_idf = run_dir / "baseline_hard_size.idf"
             freeze_meta = freeze_autosized_values(
                 baseline_idf, hard_idf, inv, capacity_factors=factors
@@ -355,6 +374,8 @@ def run_easy_button(
     baseline_flags = ["uncalibrated", "conceptual_screening", "openfdd_wattlab"]
     if sizing_scenario == "hard_size":
         baseline_flags.append("hard_size_nameplate")
+    elif sizing_scenario == "hard_size_refused":
+        baseline_flags.append("hard_size_refused_needs_input")
     baseline_record = build_result_record(
         run_id=f"{run_id}_baseline",
         measure_id=None,

--- a/vibe_code_apps_20/wattlab/energyplus/mcp.py
+++ b/vibe_code_apps_20/wattlab/energyplus/mcp.py
@@ -198,6 +198,17 @@ def align_idf_to_epw(
     span = epw_data_period(epw)
     if not span:
         return {"patch": "run_period", "applied": False, "reason": "epw_span_unknown", "out": str(idf)}
+    if span.get("partial_day_only") or span.get("ok") is False or not span.get("end"):
+        return {
+            "patch": "run_period",
+            "applied": False,
+            "reason": span.get("reason") or "partial_day_only",
+            "epw_begin": span.get("begin"),
+            "epw_end": span.get("end"),
+            "last_row_hour": span.get("last_row_hour"),
+            "end_clipped_from_partial_day": span.get("end_clipped_from_partial_day"),
+            "out": str(idf),
+        }
     if span.get("full_calendar_year"):
         return {
             "patch": "run_period",
@@ -220,6 +231,8 @@ def align_idf_to_epw(
     meta["epw_begin"] = begin
     meta["epw_end"] = end
     meta["n_days"] = span.get("n_days")
+    meta["last_row_hour"] = span.get("last_row_hour")
+    meta["end_clipped_from_partial_day"] = span.get("end_clipped_from_partial_day")
     return meta
 
 

--- a/vibe_code_apps_20/wattlab/energyplus/results.py
+++ b/vibe_code_apps_20/wattlab/energyplus/results.py
@@ -38,6 +38,7 @@ def _annual_fields(
     gas_gj: float | None,
     area_m2: float | None,
     source_file: Path,
+    peak_demand_kw: float | None = None,
 ) -> dict[str, Any]:
     out: dict[str, Any] = {
         "total_site_energy_gj": site_gj,
@@ -57,6 +58,8 @@ def _annual_fields(
     elif site_gj is not None and area_m2 and area_m2 > 0:
         mj_m2 = (site_gj * 1000.0) / area_m2
         out["site_eui_kbtu_ft2_year"] = round(mj_m2 * MJ_PER_M2_TO_KBTU_PER_FT2, 2)
+    if peak_demand_kw is not None:
+        out["peak_demand_kw"] = round(float(peak_demand_kw), 3)
     return out
 
 
@@ -101,6 +104,7 @@ def parse_eplustbl_csv(path: Path) -> dict[str, Any]:
     if facility_gj is not None and (elec_gj is None or elec_gj > facility_gj * 50):
         elec_gj = facility_gj
 
+    peak_kw = _peak_demand_kw_from_tbl_text(text)
 
     return _annual_fields(
         site_gj=site_gj,
@@ -109,7 +113,93 @@ def parse_eplustbl_csv(path: Path) -> dict[str, Any]:
         gas_gj=gas_gj,
         area_m2=area_m2,
         source_file=path,
+        peak_demand_kw=peak_kw,
     )
+
+
+def _peak_demand_kw_from_tbl_text(text: str) -> float | None:
+    """Best-effort peak kW from eplustbl CSV/HTML text (Demand End Use tables)."""
+    peak_w: float | None = None
+    in_demand = False
+    for raw in text.splitlines():
+        up = raw.upper()
+        if "DEMAND END USE" in up or "ELECTRICITY PEAK DEMAND" in up:
+            in_demand = True
+            continue
+        if in_demand and ("ANNUAL BUILDING" in up or "BUILDING ENERGY PERFORMANCE" in up):
+            in_demand = False
+        parts = [p.strip() for p in raw.split(",")]
+        if len(parts) < 3:
+            continue
+        label = parts[1]
+        val = _parse_float(parts[2])
+        if val is None:
+            continue
+        # Demand tables report Watts; energy tables report GJ (~hundreds).
+        if label in {"Total End Uses", "Electricity:Facility", "Cooling", "Interior Lighting"}:
+            if in_demand and val > 1000:  # W-scale
+                if peak_w is None or (label == "Total End Uses" and val > peak_w):
+                    if label == "Total End Uses":
+                        peak_w = val
+                    elif peak_w is None and label == "Electricity:Facility":
+                        peak_w = val
+        if "PEAK DEMAND" in label.upper() and val > 0:
+            # Already kW in some report styles, W in others
+            if val > 5000:
+                peak_w = val
+            else:
+                return round(val, 3)
+    if peak_w is not None:
+        return round(peak_w / 1000.0, 3)
+    return None
+
+
+def peak_demand_kw_from_eplusout_csv(path: Path) -> float | None:
+    """Max Electricity:Facility rate from hourly eplusout.csv (J or W columns)."""
+    if not path.is_file():
+        return None
+    try:
+        with path.open(encoding="utf-8", errors="replace", newline="") as fh:
+            reader = csv.reader(fh)
+            header = next(reader, None)
+            if not header:
+                return None
+            col_idx: int | None = None
+            col_is_joules = False
+            for i, name in enumerate(header):
+                low = name.lower()
+                if "electricity:facility" not in low:
+                    continue
+                if "[j]" in low or "joule" in low:
+                    col_idx = i
+                    col_is_joules = True
+                    break
+                if "[w]" in low or "watt" in low:
+                    col_idx = i
+                    col_is_joules = False
+                    break
+                col_idx = i
+            if col_idx is None:
+                return None
+            peak = 0.0
+            found = False
+            for row in reader:
+                if col_idx >= len(row):
+                    continue
+                v = _parse_float(row[col_idx])
+                if v is None:
+                    continue
+                found = True
+                if col_is_joules:
+                    # Hourly energy J → average kW over the hour
+                    kw = v / 3_600_000.0
+                else:
+                    kw = v / 1000.0 if v > 500 else v
+                if kw > peak:
+                    peak = kw
+            return round(peak, 3) if found and peak > 0 else None
+    except OSError:
+        return None
 
 
 def parse_eplustbl_htm(path: Path) -> dict[str, Any]:
@@ -396,6 +486,23 @@ def annual_from_output_dir(
         # the meter stream, which monthly Output:Meter requests always feed.
         monthly = parse_monthly_from_mtr(output_dir / "eplusout.mtr")
     parsed["monthly"] = monthly
+    if parsed.get("peak_demand_kw") is None:
+        peak = peak_demand_kw_from_eplusout_csv(output_dir / "eplusout.csv")
+        if peak is not None:
+            parsed["peak_demand_kw"] = peak
+            parsed.setdefault("peak_demand_source", "eplusout.csv")
+        elif csv_path.is_file():
+            # Re-scan tbl text if parse path used HTML only earlier
+            pass
+        else:
+            peak = _peak_demand_kw_from_tbl_text(
+                (htm_path.read_text(encoding="utf-8", errors="replace") if htm_path.is_file() else "")
+            )
+            if peak is not None:
+                parsed["peak_demand_kw"] = peak
+                parsed["peak_demand_source"] = "eplustbl.htm"
+    elif "peak_demand_source" not in parsed:
+        parsed["peak_demand_source"] = "eplustbl"
     return parsed
 
 
@@ -432,6 +539,7 @@ def savings_by_measure(result_records: list[dict[str, Any]]) -> list[dict[str, A
             "natural_gas_therm_year": ann.get("natural_gas_therm_year"),
             "site_eui_kbtu_ft2_year": ann.get("site_eui_kbtu_ft2_year"),
             "utility_cost_usd_year": ann.get("utility_cost_usd_year"),
+            "peak_demand_kw": ann.get("peak_demand_kw"),
             "vs_baseline": {
                 "kwh_saved": _delta(
                     baseline.get("electricity_kwh_year"), ann.get("electricity_kwh_year")
@@ -448,6 +556,9 @@ def savings_by_measure(result_records: list[dict[str, Any]]) -> list[dict[str, A
                     baseline.get("site_eui_kbtu_ft2_year"),
                     ann.get("site_eui_kbtu_ft2_year"),
                 ),
+                "peak_demand_kw_delta": _delta(
+                    baseline.get("peak_demand_kw"), ann.get("peak_demand_kw")
+                ),
                 "kwh_pct": _pct(
                     baseline.get("electricity_kwh_year"), ann.get("electricity_kwh_year")
                 ),
@@ -461,6 +572,9 @@ def savings_by_measure(result_records: list[dict[str, Any]]) -> list[dict[str, A
                 ),
                 "cost_saved_usd": _delta(
                     prev.get("utility_cost_usd_year"), ann.get("utility_cost_usd_year")
+                ),
+                "peak_demand_kw_delta": _delta(
+                    prev.get("peak_demand_kw"), ann.get("peak_demand_kw")
                 ),
                 "kwh_pct": _pct(
                     prev.get("electricity_kwh_year"), ann.get("electricity_kwh_year")
@@ -495,6 +609,7 @@ def build_result_record(
             "site_eui_kbtu_ft2_year": annual.get("site_eui_kbtu_ft2_year"),
             "utility_cost_usd_year": annual.get("utility_cost_usd_year"),
             "total_site_energy_gj": annual.get("total_site_energy_gj"),
+            "peak_demand_kw": annual.get("peak_demand_kw"),
             # Needed downstream to area-normalize prototype savings vs the
             # real building (crosscheck.prototype_area_scale).
             "building_area_m2": annual.get("building_area_m2"),

--- a/vibe_code_apps_20/wattlab/energyplus/sizing.py
+++ b/vibe_code_apps_20/wattlab/energyplus/sizing.py
@@ -342,37 +342,71 @@ def _autosized_fan_power_w(inventory: Mapping[str, Any]) -> float | None:
     return total if found and total > 0 else None
 
 
+# Acceptable hard-size factor band vs autosized inventory (outside → refuse freeze).
+HARD_SIZE_FACTOR_MIN = 0.25
+HARD_SIZE_FACTOR_MAX = 4.0
+# When site/target area ≫ prototype, scale nameplate down before factoring.
+AREA_SCALE_NAMEPLATE_THRESHOLD = 1.5
+
+
 def nameplate_to_capacity_factors(
     inventory: Mapping[str, Any],
     *,
     cooling_tons: float | None = None,
     fan_hp: float | None = None,
+    prototype_area_scale: float | None = None,
 ) -> tuple[dict[str, float], dict[str, Any]]:
     """Map FM nameplate (tons / fan hp) → capacity_factors vs autosized inventory.
 
+    When ``prototype_area_scale`` > 1.5, nameplate is scaled by ``1/scale`` so a
+    site 200 t / 140k ft² building does not apply ~20× factors to a ~10k ft²
+    5Zone prototype.
+
     Returns ``(factors, meta)``. Empty factors when inventory lacks comparable
-    autosized values — caller should stamp NEEDS_INPUT / observe-only.
+    autosized values, or when any factor falls outside ``[0.25, 4.0]``
+    (``hard_size_refused``) — caller should keep autosize and stamp NEEDS_INPUT.
     """
     meta: dict[str, Any] = {
         "cooling_tons_nameplate": cooling_tons,
         "fan_hp_nameplate": fan_hp,
+        "prototype_area_scale": prototype_area_scale,
+        "hard_size_refused": False,
     }
+    scale = float(prototype_area_scale) if prototype_area_scale else None
+    cool_eff = float(cooling_tons) if cooling_tons is not None else None
+    fan_eff = float(fan_hp) if fan_hp is not None else None
+    if scale is not None and scale > AREA_SCALE_NAMEPLATE_THRESHOLD:
+        meta["nameplate_area_scaled"] = True
+        meta["area_scale_applied"] = scale
+        if cool_eff is not None and cool_eff > 0:
+            cool_eff = cool_eff / scale
+            meta["cooling_tons_effective"] = round(cool_eff, 4)
+        if fan_eff is not None and fan_eff > 0:
+            fan_eff = fan_eff / scale
+            meta["fan_hp_effective"] = round(fan_eff, 4)
+    else:
+        meta["nameplate_area_scaled"] = False
+        if cool_eff is not None:
+            meta["cooling_tons_effective"] = cool_eff
+        if fan_eff is not None:
+            meta["fan_hp_effective"] = fan_eff
+
     factors: dict[str, float] = {}
-    if cooling_tons is not None and float(cooling_tons) > 0:
+    if cool_eff is not None and cool_eff > 0:
         auto_w = _autosized_cooling_w(inventory)
         meta["autosized_cooling_w"] = auto_w
         if auto_w and auto_w > 0:
-            target_w = float(cooling_tons) * _TON_W
+            target_w = cool_eff * _TON_W
             factors["cooling_plant"] = target_w / auto_w
             factors["cooling_coils"] = factors["cooling_plant"]
             meta["cooling_factor"] = factors["cooling_plant"]
         else:
             meta["cooling_factor_error"] = "no_autosized_cooling_in_inventory"
-    if fan_hp is not None and float(fan_hp) > 0:
+    if fan_eff is not None and fan_eff > 0:
         auto_w = _autosized_fan_power_w(inventory)
         meta["autosized_fan_w"] = auto_w
         if auto_w and auto_w > 0:
-            target_w = float(fan_hp) * _HP_W
+            target_w = fan_eff * _HP_W
             ratio = target_w / auto_w
             factors["fan_power"] = ratio
             factors["fan_pressure"] = ratio
@@ -380,4 +414,20 @@ def nameplate_to_capacity_factors(
         else:
             # No fan power in inventory — leave note; do not invent.
             meta["fan_factor_error"] = "no_autosized_fan_power_in_inventory"
+
+    if factors:
+        out_of_band = {
+            k: v
+            for k, v in factors.items()
+            if v < HARD_SIZE_FACTOR_MIN or v > HARD_SIZE_FACTOR_MAX
+        }
+        if out_of_band:
+            meta["hard_size_refused"] = True
+            meta["refused_factors"] = dict(factors)
+            meta["out_of_band_factors"] = out_of_band
+            meta["refuse_reason"] = (
+                f"capacity factors outside [{HARD_SIZE_FACTOR_MIN}, {HARD_SIZE_FACTOR_MAX}]; "
+                "kept autosize — provide site geometry or Ideal Loads (NEEDS_INPUT)"
+            )
+            return {}, meta
     return factors, meta

--- a/vibe_code_apps_20/wattlab/studio/ep_viz.py
+++ b/vibe_code_apps_20/wattlab/studio/ep_viz.py
@@ -124,6 +124,78 @@ def floor_plan_figure(role_temps: dict[str, float]):
     return fig
 
 
+def multifloor_office_figure(
+    role_temps: dict[str, float],
+    *,
+    n_floors: int,
+    highlight_floor: int | None = None,
+):
+    """Stacked floor-plate schematic for multi-story office screening.
+
+    Each plate reuses the classic 5Zone compass vertices; temps are mapped from
+    the single-story prototype CSV (honesty: not site CAD / not true multi-floor IDF).
+    """
+    import plotly.graph_objects as go
+
+    n = max(2, int(n_floors))
+    fig = go.Figure()
+    gap = 0.35
+    plate_h = 3.0
+    show_floors = list(range(1, n + 1))
+    if n > 8 and highlight_floor is not None:
+        # Optional selector: show all but emphasize one; still draw all for ≤8
+        pass
+    for fi, floor in enumerate(show_floors):
+        y_off = fi * (plate_h + gap)
+        emph = highlight_floor is None or floor == int(highlight_floor)
+        for role, vertices in ZONE_VERTICES.items():
+            temp = role_temps.get(role)
+            fill = rgb_from_temperature(temp) if temp is not None else "rgb(200,200,200)"
+            if not emph:
+                fill = "rgba(180,180,180,0.35)"
+            xs = [v[0] for v in vertices] + [vertices[0][0]]
+            ys = [v[1] + y_off for v in vertices] + [vertices[0][1] + y_off]
+            label = f"F{floor} {role}"
+            if temp is not None and emph:
+                label = f"F{floor} {role}: {temp:.1f} C"
+            fig.add_trace(
+                go.Scatter(
+                    x=xs,
+                    y=ys,
+                    fill="toself",
+                    fillcolor=fill,
+                    line={"color": "#222" if emph else "#999", "width": 1},
+                    mode="lines",
+                    name=label,
+                    hoverinfo="name",
+                    showlegend=(floor == show_floors[-1]),
+                )
+            )
+        # Floor label
+        fig.add_annotation(
+            x=-0.4,
+            y=y_off + plate_h / 2,
+            text=f"F{floor}",
+            showarrow=False,
+            font={"size": 11},
+        )
+    fig.update_layout(
+        title=f"Schematic massing — {n}-story office (prototype zones per plate)",
+        xaxis={"visible": False, "scaleanchor": "y"},
+        yaxis={"visible": False},
+        showlegend=True,
+        height=min(900, 200 + n * 90),
+        margin={"l": 40, "r": 20, "t": 50, "b": 20},
+    )
+    return fig
+
+
+MULTIFLOOR_HONESTY = (
+    "Schematic massing for N-story office screening — not site CAD; "
+    "prototype 5Zone roles mapped to each plate until a multi-floor IDF exists."
+)
+
+
 def outdoor_figure(outdoor: pd.DataFrame):
     """OA drybulb over sim timesteps (08 right-hand chart)."""
     import plotly.graph_objects as go

--- a/vibe_code_apps_20/wattlab/studio/eui_compare.py
+++ b/vibe_code_apps_20/wattlab/studio/eui_compare.py
@@ -56,6 +56,8 @@ def load_model_eui_from_run(run_dir: Path | None) -> dict[str, Any]:
             (report.get("weather_suitability") or {}).get("mode")
             or report.get("weather_mode")
         )
+        if ann.get("peak_demand_kw") is not None:
+            out["peak_demand_kw"] = ann.get("peak_demand_kw")
         out["run_id"] = report.get("run_id") or root.name
         if out.get("model_eui_kbtu_ft2") is not None:
             return out

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -108,6 +108,23 @@ def render() -> None:
             if mid in ep_by:
                 row["kwh_saved"] = float(ep_by[mid].get("kwh_saved") or row.get("kwh_saved") or 0)
                 row["therms_saved"] = float(ep_by[mid].get("therms_saved") or row.get("therms_saved") or 0)
+                if ep_by[mid].get("peak_demand_kw_delta") is not None:
+                    row["peak_demand_kw_delta"] = ep_by[mid]["peak_demand_kw_delta"]
+
+    # Show demand columns from report when present
+    demand_preview = []
+    for s in report.get("savings_by_measure") or []:
+        if s.get("peak_demand_kw") is not None:
+            demand_preview.append(
+                {
+                    "measure_id": s.get("measure_id"),
+                    "peak_demand_kw": s.get("peak_demand_kw"),
+                    "vs_baseline_kw": (s.get("vs_baseline") or {}).get("peak_demand_kw_delta"),
+                }
+            )
+    if demand_preview:
+        st.markdown("**Peak demand (kW)** from EnergyPlus results")
+        st.dataframe(pd.DataFrame(demand_preview), width="stretch", hide_index=True)
 
     plan = capital_plan(econ_rows)
     st.session_state["studio_capital_plan"] = plan

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -14,9 +14,11 @@ from wattlab.defaults import resolve_profile
 from wattlab.energyplus.timeseries import find_eplusout_csv, load_sim_timeseries
 from wattlab.seed import gap_report
 from wattlab.studio.ep_viz import (
+    MULTIFLOOR_HONESTY,
     floor_plan_figure,
     install_demo_replay,
     list_iteration_runs,
+    multifloor_office_figure,
     outdoor_figure,
     publish_run_for_studio,
     read_run_progress,
@@ -179,7 +181,7 @@ def _resolve_active_run() -> Path | None:
     return None
 
 
-def _render_08_panes(run_dir: Path) -> None:
+def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
     st.subheader("EnergyPlus visualizer (APIHelper 08 — browser)")
     st.caption(
         "Populated by any AI agent (or Studio buttons) writing `runs/<id>/` "
@@ -214,11 +216,40 @@ def _render_08_panes(run_dir: Path) -> None:
     if ts2 is not None:
         roles = zone_mean_by_role(ts2)
         if roles:
-            st.plotly_chart(
-                floor_plan_figure(roles),
-                width="stretch",
-                key=f"twin_floor_{run_dir.name}",
-            )
+            floors = int(n_floors or 1)
+            profile = _profile() or {}
+            if floors < 2:
+                floors = int(
+                    profile.get("number_of_floors")
+                    or profile.get("floors")
+                    or st.session_state.get("twin_floors")
+                    or 1
+                )
+            btype = str(profile.get("building_type") or profile.get("property_type") or "").lower()
+            use_multi = floors >= 2 or ("office" in btype and floors >= 2)
+            if use_multi and floors >= 2:
+                highlight = None
+                if floors > 8:
+                    highlight = int(
+                        st.selectbox(
+                            "Highlight floor",
+                            options=list(range(1, floors + 1)),
+                            index=floors - 1,
+                            key=f"twin_floor_sel_{run_dir.name}",
+                        )
+                    )
+                st.plotly_chart(
+                    multifloor_office_figure(roles, n_floors=floors, highlight_floor=highlight),
+                    width="stretch",
+                    key=f"twin_multifloor_{run_dir.name}",
+                )
+                st.caption(MULTIFLOOR_HONESTY.replace("N-story", f"{floors}-story"))
+            else:
+                st.plotly_chart(
+                    floor_plan_figure(roles),
+                    width="stretch",
+                    key=f"twin_floor_{run_dir.name}",
+                )
         means = ts2.zone_mean_temps()
         if not means.empty:
             st.dataframe(means, width="stretch", hide_index=True)
@@ -346,7 +377,10 @@ def render() -> None:
     st.markdown("**Hard-size constrain (optional FM nameplate)**")
     st.caption(
         "Sparse ladder step 3: after autosize, freeze plant/fans toward FM tons/hp "
-        "(conceptual). Leave blank to keep autosize-only."
+        "(conceptual). When target floor area ≫ prototype (~10k ft²), nameplate is "
+        "scaled by 1/prototype_area_scale before factoring. Factors outside "
+        "[0.25, 4.0] refuse freeze (NEEDS_INPUT — site geometry or Ideal Loads). "
+        "Leave blank to keep autosize-only."
     )
     hs1, hs2 = st.columns(2)
     cooling_tons = hs1.number_input(
@@ -355,7 +389,7 @@ def render() -> None:
         value=0.0,
         step=10.0,
         key="twin_cooling_tons",
-        help="e.g. 200 for 2×100 ton chillers",
+        help="e.g. 200 for 2×100 ton chillers — scaled down when site ≫ prototype",
     )
     fan_hp = hs2.number_input(
         "supply_fan_hp (nameplate)",
@@ -363,7 +397,7 @@ def render() -> None:
         value=0.0,
         step=5.0,
         key="twin_fan_hp",
-        help="e.g. 75 hp",
+        help="e.g. 75 hp — scaled with area when site ≫ prototype",
     )
 
     measure_set = st.session_state.get("studio_measure_set") or profile.get("measure_set") or "best"
@@ -472,9 +506,32 @@ def render() -> None:
                 f"(target {report.get('target_floor_area_ft2')} ft² / "
                 f"prototype ~{report.get('prototype_area_ft2_nominal')} ft²)"
             )
+        sizing = report.get("sizing_scenario")
+        if sizing == "hard_size_refused":
+            refuse_note = None
+            for p in report.get("patches") or []:
+                if p.get("patch") == "hard_size" and p.get("needs_input"):
+                    refuse_note = p.get("note")
+                    break
+                if p.get("hard_size_refused"):
+                    refuse_note = p.get("refuse_reason")
+                    break
+            st.error(
+                "Hard-size **refused** (NEEDS_INPUT): capacity factors outside "
+                "[0.25, 4.0] after area scaling — kept autosize. "
+                f"{refuse_note or 'Provide site geometry or Ideal Loads.'}"
+            )
+        elif sizing == "hard_size":
+            st.info("Hard-size freeze applied (area-aware nameplate factors).")
         savings = report.get("savings_by_measure") or []
         if savings:
             st.dataframe(pd.json_normalize(savings), width="stretch", hide_index=True)
+            peak_rows = [s for s in savings if s.get("peak_demand_kw") is not None]
+            if peak_rows:
+                st.caption(
+                    "Peak demand (kW) shown alongside energy — from eplustbl Demand "
+                    "tables or max hourly Electricity:Facility when present."
+                )
         cross = report.get("crosscheck")
         if cross:
             st.subheader(f"Crosscheck: {cross.get('overall_verdict')}")
@@ -569,6 +626,8 @@ def render() -> None:
                 row["prototype_area_scale"] = model["prototype_area_scale"]
             if model.get("weather_mode"):
                 row["weather_mode"] = model["weather_mode"]
+            if model.get("peak_demand_kw") is not None:
+                row["peak_demand_kw"] = model["peak_demand_kw"]
             enriched.append(row)
         st.dataframe(pd.DataFrame(enriched), width="stretch", hide_index=True)
         pick = st.selectbox(

--- a/vibe_code_apps_20/wattlab/weather/epw.py
+++ b/vibe_code_apps_20/wattlab/weather/epw.py
@@ -337,18 +337,23 @@ def epw_data_period(epw_path: Path | str) -> dict[str, Any] | None:
 
     Used to auto-align IDF ``RunPeriod`` when AMY weather is partial-year
     (default annual RunPeriod + short EPW → EnergyPlus fatal EOF).
+
+    ``end`` is the last **complete** calendar day (max hour ≥ 23). A trailing
+    partial day (e.g. last row 10:00) is clipped so EnergyPlus does not EOF mid-day.
     """
+    from collections import defaultdict
     from datetime import date
 
     path = Path(epw_path)
     if not path.is_file():
         return None
-    begin: date | None = None
-    end: date | None = None
     header_begin: date | None = None
     header_end: date | None = None
     first_row: date | None = None
     last_row: date | None = None
+    last_row_hour: int | None = None
+    hours_by_day: dict[date, set[int]] = defaultdict(set)
+    day_order: list[date] = []
 
     def _md(token: str, year: int | None = None) -> date | None:
         parts = token.replace(" ", "").split("/")
@@ -379,26 +384,83 @@ def epw_data_period(epw_path: Path | str) -> dict[str, Any] | None:
                 continue
             try:
                 y, m, d = int(parts[0]), int(parts[1]), int(parts[2])
+                hour = int(float(parts[3]))
                 row_d = date(y, m, d)
             except ValueError:
                 continue
             if first_row is None:
                 first_row = row_d
             last_row = row_d
+            last_row_hour = hour
+            if row_d not in hours_by_day:
+                day_order.append(row_d)
+            hours_by_day[row_d].add(hour)
 
     begin = first_row or header_begin
-    end = last_row or header_end
-    if begin is None or end is None:
+    if begin is None:
         return None
+
+    def _day_complete(d: date) -> bool:
+        hrs = hours_by_day.get(d) or set()
+        # EPW hours are typically 1–24 (or 0–23). Treat max≥23 as a full day
+        # (trailing partial days end ~10:00 and must not set RunPeriod end).
+        return bool(hrs) and max(hrs) >= 23
+
+    end_clipped = False
+    end: date | None = None
+    # Walk days in **file appearance order** (TMY years differ by month — do not
+    # sort by absolute calendar date or Dec 31 1981 loses to Apr 2002).
+    if day_order:
+        for d in reversed(day_order):
+            if _day_complete(d):
+                end = d
+                break
+        if end is None:
+            # No complete day — cannot safely align annual-style RunPeriod
+            return {
+                "begin": begin.isoformat(),
+                "end": None,
+                "begin_date": begin,
+                "end_date": None,
+                "full_calendar_year": False,
+                "n_days": None,
+                "source": str(path),
+                "last_row_hour": last_row_hour,
+                "end_clipped_from_partial_day": True,
+                "partial_day_only": True,
+                "ok": False,
+                "reason": "partial_day_only",
+            }
+        if last_row is not None and end != last_row:
+            end_clipped = True
+        elif (
+            last_row is not None
+            and end == last_row
+            and last_row_hour is not None
+            and last_row_hour < 23
+        ):
+            # Incomplete last day — should have selected prior complete day above
+            end_clipped = True
+    else:
+        end = last_row or header_end
+        if end is None:
+            return None
+
+    # n_days: for mixed-year TMY use month/day span via header or row count of days
+    if day_order and len(day_order) >= 360:
+        n_days = len(day_order)
+    else:
+        n_days = (end - begin).days + 1 if end >= begin else len(day_order) or None
+
     full_year = begin.month == 1 and begin.day == 1 and end.month == 12 and end.day == 31
-    # Same calendar span without requiring Jan1–Dec31 when years differ in TMY
     if header_begin and header_end:
         full_year = full_year or (
             header_begin.month == 1
             and header_begin.day == 1
             and header_end.month == 12
             and header_end.day == 31
-            and (last_row is None or (last_row - first_row).days >= 360)
+            and (n_days is not None and n_days >= 360)
+            and not end_clipped
         )
     return {
         "begin": begin.isoformat(),
@@ -406,8 +468,12 @@ def epw_data_period(epw_path: Path | str) -> dict[str, Any] | None:
         "begin_date": begin,
         "end_date": end,
         "full_calendar_year": bool(full_year),
-        "n_days": (end - begin).days + 1,
+        "n_days": n_days,
         "source": str(path),
+        "last_row_hour": last_row_hour,
+        "end_clipped_from_partial_day": end_clipped,
+        "partial_day_only": False,
+        "ok": True,
     }
 
 


### PR DESCRIPTION
## Summary
- **W2b:** Clip AMY RunPeriod end to last complete EPW day (file-order; TMY-safe); refuse partial-day-only spans
- **W3b:** Area-scale nameplate by `1/prototype_area_scale` when scale > 1.5; refuse freeze if factors outside [0.25, 4.0]
- **Demand:** Stamp `peak_demand_kw` on annual/savings; Twin + ECM UI
- **Viz:** Multi-floor stacked 5Zone schematic when floors >= 2 + honesty caption
- **Docs:** `AGENT_DOCKER_WORKSPACE.md` + tester gates; vibe19 README cross-link

## Test plan
- [x] `pytest tests/test_dind_readvars_city.py tests/test_ep_viz.py`
- [x] `scripts/smoke_studio.py`
- [ ] Merge develop → vibe20-ghcr green → recreate bensbench with WATTLAB_HOST_WORKSPACE + ENERGYPLUS_DOCKER_USER=1000:1000

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peak electricity demand (kW) to simulation results, savings comparisons, and ECM economics.
  * Added stacked multi-floor office schematics with floor highlighting and clear schematic labeling.
  * Added area-aware hard-sizing with safeguards and visible refusal messaging for out-of-range inputs.
  * Improved weather-period handling for trailing partial days and RunPeriod clipping.

* **Bug Fixes**
  * Improved peak-demand extraction across supported EnergyPlus output formats.
  * Corrected partial-day date ranges and annual-period detection.

* **Documentation**
  * Added guidance for the shared Docker workspace and expanded testing and reporting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->