### PR TITLE
feat(vibe20): G14 campaign, DinD CLI, client deliverables

### DIFF
--- a/vibe_code_apps_20/Dockerfile
+++ b/vibe_code_apps_20/Dockerfile
@@ -2,12 +2,15 @@
 #
 # EnergyPlus: mount the host Docker socket + set WATTLAB_HOST_WORKSPACE to the
 # host path of the /data bind so Twin → Run EnergyPlus (Docker) can spawn
-# energyplus-mcp-dev (DinD). Artifacts under /data/.artifacts; sibling stage
+# energyplus-mcp-dev (DinD). The image includes the Docker *client* binary
+# (sock alone is not enough). Artifacts under /data/.artifacts; sibling stage
 # mounts + world-writable out dirs + --user 1000:1000 for ReadVars CSV.
 # Without docker.sock, dry-run / Fuel / ECMs still work; agents can publish
-# runs/ from a host checkout (`wattlab easy-button`).
+# runs/ from ``docker exec vibe20 wattlab …`` (prefer that over host pip -e).
 #
 # Entry point: studio.py (not wattlab/studio/app.py).
+FROM docker:27-cli AS dockercli
+
 FROM python:3.12-slim
 
 ARG VIBE20_GIT_SHA=unknown
@@ -32,6 +35,9 @@ LABEL org.opencontainers.image.title="vibe20" \
       org.opencontainers.image.ref.name="${VIBE20_IMAGE_REF}:${VIBE20_IMAGE_TAG}"
 
 WORKDIR /app
+
+# DinD client — host still provides the daemon via /var/run/docker.sock
+COPY --from=dockercli /usr/local/bin/docker /usr/local/bin/docker
 
 COPY . .
 RUN pip install --no-cache-dir ".[studio]"

--- a/vibe_code_apps_20/scripts/smoke_studio.py
+++ b/vibe_code_apps_20/scripts/smoke_studio.py
@@ -77,6 +77,11 @@ def main() -> int:
     at.button(key="twin_dry_run").click().run()
     if at.exception:
         return _fail(at, "Twin(dry-run)")
+    # Client deliverable package (no live E+ required)
+    at.button(key="twin_build_deliverable").click().run()
+    if at.exception:
+        return _fail(at, "Twin(deliverable)")
+    print("OK: Twin deliverable build (no Streamlit exceptions)")
 
     at.radio(key="studio_page").set_value("ECMs").run()
     at.button(key="ecm_build_measures").click().run()

--- a/vibe_code_apps_20/tests/test_deliverables_campaign.py
+++ b/vibe_code_apps_20/tests/test_deliverables_campaign.py
@@ -1,0 +1,86 @@
+"""Tests for calibrate campaign helpers + client deliverables."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wattlab.calibrate import scale_monthly_energy
+from wattlab.calibrate_campaign import data_window_from_bill_months
+from wattlab.deliverables import (
+    build_executive_markdown,
+    build_results_workbook_bytes,
+    package_deliverables,
+)
+
+
+def test_data_window_from_bill_months():
+    w = data_window_from_bill_months(["2024-03", "2024-01", "2024-12"])
+    assert w["start"] == "2024-01-01"
+    assert w["end"] == "2024-12-31"
+    assert w["bill_months_first"] == "2024-01"
+    assert w["bill_months_last"] == "2024-12"
+
+
+def test_scale_monthly_energy():
+    rows = [{"month": 1, "electricity_kwh": 100.0, "natural_gas_therm": 10.0}]
+    out = scale_monthly_energy(rows, area_scale=14.0)
+    assert out[0]["electricity_kwh"] == 1400.0
+    assert out[0]["electricity_kwh_unscaled"] == 100.0
+    assert out[0]["natural_gas_therm"] == 140.0
+
+
+def test_deliverable_package(tmp_path: Path):
+    scorecard = {
+        "run_id": "test_run",
+        "status": "CONCEPTUAL_ONLY",
+        "overall": "fail",
+        "prototype_area_scale": 14.0,
+        "sizing_scenario": "autosize",
+        "weather_suitability": {"mode": "ACTUAL_YEAR_CALIBRATION", "reason": "AMY"},
+        "annual": {
+            "electricity_kwh_year": 1000.0,
+            "site_eui_kbtu_ft2_year": 20.0,
+            "peak_demand_kw": 15.0,
+            "monthly": [{"month": 1, "electricity_kwh": 80.0}],
+        },
+        "utility_bills": {
+            "pass_fail": "fail",
+            "months_compared": 1,
+            "stats_electricity": {"nmbe_pct": 12.0, "cvrmse_pct": 20.0},
+            "per_month": [
+                {
+                    "month": "2024-01",
+                    "observed_kwh": 100.0,
+                    "simulated_kwh": 80.0,
+                    "delta_kwh": -20.0,
+                }
+            ],
+        },
+    }
+    md = build_executive_markdown(scorecard=scorecard, profile={"display_name": "Test Bldg"})
+    assert "Executive summary" in md
+    assert "G14" in md or "Guideline 14" in md or "pass/fail" in md.lower()
+
+    xlsx = build_results_workbook_bytes(scorecard=scorecard)
+    assert xlsx[:2] == b"PK"  # zip/xlsx magic
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "cal_ready.idf").write_text("Version,26.1;\n", encoding="utf-8")
+    (run_dir / "amy.epw").write_text("LOCATION,Test\n", encoding="utf-8")
+    (run_dir / "eplustbl.htm").write_text("<html>ok</html>", encoding="utf-8")
+
+    out = tmp_path / "deliverable_test_run"
+    meta = package_deliverables(
+        out_dir=out,
+        run_dir=run_dir,
+        scorecard=scorecard,
+        profile={"display_name": "Test Bldg", "building_type": "office"},
+    )
+    assert meta["ok"] is True
+    assert Path(meta["report_md"]).is_file()
+    assert Path(meta["workbook_xlsx"]).is_file()
+    assert Path(meta["zip_path"]).is_file()
+    assert (out / "03_Models" / "Baseline" / "Building_Baseline.idf").is_file()
+    assert (out / "03_Models" / "Baseline" / "Weather.epw").is_file()
+    assert (out / "04_Outputs" / "Baseline" / "eplustbl.htm").is_file()

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -8,6 +8,10 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 
 **Sparse-building physics ladder (TMY→constrain→AMY→FDD):** [`docs/SPARSE_BUILDING_PLAYBOOK.md`](docs/SPARSE_BUILDING_PLAYBOOK.md)
 
+**Docker exec + shared volume (no git clone):** [`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)
+
+**G14 calibrate campaign + client report/xlsx/zip:** [`docs/CALIBRATE_AND_DELIVERABLES.md`](docs/CALIBRATE_AND_DELIVERABLES.md)
+
 **App:** ESCO / energy-engineering toolkit — vibe19 FDD dumps in, calibrated EnergyPlus twins + benchmarked capital plans out. Where vibe19 is about **finding faults**, vibe20 is about **pricing the fixes credibly**: ESCO spreadsheet bin-method calculators, EnergyPlus crosschecks, public benchmarks, and ROI guardrails.
 
 **Stack honesty:** EnergyPlus = physics engine; EnergyPlus-MCP = inspect/modify/sim wrench (~35 tools); WattLab + assumption skills = defaults ledger, peers → bins → E+, G14. MCP is not a calibration coach — see [`skills/wattlab-energyplus-mcp/SKILL.md`](skills/wattlab-energyplus-mcp/SKILL.md) and [`skills/wattlab-assumptions/SKILL.md`](skills/wattlab-assumptions/SKILL.md).
@@ -31,7 +35,9 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
     is Phase 2 using the vibe19 Haystack map shape.
 8. **Costs are range + basis + vintage + confidence** — `retrofit_costs_public.json` rows carry `unit_basis` (building_ft2 vs glazing_ft2 …), `currency_year`, `confidence`. Historical LBNL medians are reference bands, **never** current-year bids. Windows math on glazing area, chillers on building area — never mix.
 9. **EUI units are kBtu/ft²-year (site)** — conversions: 1 kWh = 3,412 Btu; 1 Mcf gas = 1.037 MMBtu; 1 therm = 100 kBtu. Peer bands from `benchmarks_public.json` (EPA PM medians, CBECS 70.6 fallback).
-10. **Docker-only EnergyPlus** — pinned image via `wattlab.energyplus.docker`; run manifests (`run_manifest.json`) record model/weather SHA + image on every run. Docker tests skip when the image is missing — that's fine.
+10. **Docker-only EnergyPlus** — pinned image via `wattlab.energyplus.docker`; run manifests (`run_manifest.json`) record model/weather SHA + image on every run. Docker tests skip when the image is missing — that's fine. Studio image includes a **Docker CLI client**; mount `/var/run/docker.sock` + set `WATTLAB_HOST_WORKSPACE` + prefer `ENERGYPLUS_DOCKER_USER=1000:1000`. Prefer **`docker exec vibe20 wattlab …`** over host `pip install -e` (host drift bug).
+10b. **G14 calibrate campaign** — `wattlab calibrate-campaign --bundle … --bills … --lat --lon` derives AMY window from bill months, scores G14, publishes Twin + optional client zip. Details: [`docs/CALIBRATE_AND_DELIVERABLES.md`](docs/CALIBRATE_AND_DELIVERABLES.md). No calibrated ROI without pass + stamps.
+10c. **Client deliverables** — Twin **Build client package** (also ECM) → markdown report + xlsx workbook + model zip (`01_Report`…`06_Documentation`). Humans must not need raw E+ trees to read conclusions.
 11. **Dry-run first** — `run_easy_button(profile, dry_run=True)` and the Studio "Dry-run plan" path must always work without Docker. Never make a feature Docker-mandatory when a plan/preview is possible.
 12. **Weather** — AMY EPW from `weather_observed.csv` / Open-Meteo (`wattlab.weather.epw`); Weather-Man OAT bin tables (5°F × 3 shifts + MCWB) in `wattlab.weather.bins` (built-in NOAA Washington DC table + `from_hourly`). Calibration weather and degree-day benchmarking are separate use cases — don't conflate.
 13. **The vibe19 dump is the seed** — start with `wattlab twin <dump.zip>` (or `wattlab.seed.load_bundle` + `gap_report`). Read `MANIFEST.json` first. Required human fields: `building_type`, `city`, `floor_area_ft2` (plus `lat`/`lon` for AMY calibrate). **Never invent office/Madison/Chicago** for a real dump. Prefer `fdd_findings.csv` over `fdd_summary.csv`. See [`DATA_CONTRACT.md`](DATA_CONTRACT.md) and the **Tomorrow demo** section in [`../AGENTS.md`](../AGENTS.md).
@@ -94,15 +100,17 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 3. **[`DATA_CONTRACT.md`](DATA_CONTRACT.md)** — dump, campus, Excel derive, workspace runs/
 4. **[`docs/TWIN_LOOP.md`](docs/TWIN_LOOP.md)** — human + agent iterate protocol
 5. **[`docs/SPARSE_BUILDING_PLAYBOOK.md`](docs/SPARSE_BUILDING_PLAYBOOK.md)** — TMY→AMY→FDD when little is known (~6–10 sims)
-6. **[`AGENT_TESTER_PROMPT.md`](AGENT_TESTER_PROMPT.md)** — QA / calibrate on a bench (any agent)
-7. **[`docs/ESCO_CALCULATORS.md`](docs/ESCO_CALCULATORS.md)** — when touching `wattlab/bench/esco.py` or weather bins
-8. **[`docs/BENCHMARK_GOVERNANCE.md`](docs/BENCHMARK_GOVERNANCE.md)** — when touching benchmarks/guardrails/meters
-9. **`skills/wattlab-assumptions/SKILL.md`** — defaults hierarchy / Ideal Loads vs explicit HVAC
-10. **`skills/wattlab-energyplus-mcp/SKILL.md`** — MCP inspect/sim; DinD + ReadVars
-11. **`skills/wattlab-esco-bins/SKILL.md`** — run/extend the bin-method calculators
-12. **`skills/wattlab-benchmarking/SKILL.md`** — bills → EUI → peer bands → gate
-13. **`skills/wattlab-studio/SKILL.md`** — 4 Studio pages, workspace, smoke
-14. `.agents/` personas/workflows/checklists + `.agents/skills/*` as needed
+6. **[`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)** — `docker exec` vibe19/20 + shared `/data` (canonical agent surface)
+7. **[`docs/CALIBRATE_AND_DELIVERABLES.md`](docs/CALIBRATE_AND_DELIVERABLES.md)** — bill→AMY→G14 + client package downloads
+8. **[`AGENT_TESTER_PROMPT.md`](AGENT_TESTER_PROMPT.md)** — QA / calibrate on a bench (any agent)
+9. **[`docs/ESCO_CALCULATORS.md`](docs/ESCO_CALCULATORS.md)** — when touching `wattlab/bench/esco.py` or weather bins
+10. **[`docs/BENCHMARK_GOVERNANCE.md`](docs/BENCHMARK_GOVERNANCE.md)** — when touching benchmarks/guardrails/meters
+11. **`skills/wattlab-assumptions/SKILL.md`** — defaults hierarchy / Ideal Loads vs explicit HVAC
+12. **`skills/wattlab-energyplus-mcp/SKILL.md`** — MCP inspect/sim; DinD + ReadVars
+13. **`skills/wattlab-esco-bins/SKILL.md`** — run/extend the bin-method calculators
+14. **`skills/wattlab-benchmarking/SKILL.md`** — bills → EUI → peer bands → gate
+15. **`skills/wattlab-studio/SKILL.md`** — 4 Studio pages, workspace, smoke, deliverables
+16. `.agents/` personas/workflows/checklists + `.agents/skills/*` as needed
 
 ---
 
@@ -121,15 +129,18 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 | `wattlab/finance.py` | Capital-plan rollup |
 | `wattlab/crosscheck.py` | E+ vs proxy + G14 |
 | `wattlab/easy_button.py` | Baseline + progressive measures (`--dry-run`) |
-| `wattlab/calibrate.py` | Overlap-window calibration |
+| `wattlab/calibrate.py` | Overlap-window calibration + Studio publish |
+| `wattlab/calibrate_campaign.py` | Bills → AMY window → G14 → Twin + deliverable |
+| `wattlab/deliverables.py` | Client report.md / xlsx / model zip |
 | `wattlab/bridge.py` | vibe19 faults → measures |
-| `wattlab/energyplus/` | Docker, results, timeseries, IDF patches |
+| `wattlab/energyplus/` | Docker (CLI in image), results (`peak_demand_kw`), timeseries, IDF patches |
 | `wattlab/measures/` + `wattlab/ecm/` | Catalog / packages |
 | `wattlab/existing_building/` | Hypothesis Lab orchestration (CLI; not a Studio page) |
-| `wattlab/cli.py` | `wattlab` CLI |
-| `vibe20_agent_spec/` | Agent handbook, contracts, tester prompt, skills |
-| `studio.py` | WattLab Studio (Ingest / … / Benchmark / Fuel Weather / … / Capital plan) |
-| `scripts/smoke_studio.py` | AppTest smoke walk (all pages + fixture campus + Fuel Weather) |
+| `wattlab/cli.py` | `wattlab` CLI (`calibrate-campaign`, …) |
+| `studio.py` | WattLab Studio — Uploads / Fuel / Twin·calibrate / ECMs |
+| `scripts/smoke_studio.py` | AppTest smoke (all pages + Twin deliverable button) |
+| `vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + docker exec |
+| `vibe20_agent_spec/docs/CALIBRATE_AND_DELIVERABLES.md` | G14 campaign + client package |
 | `scripts/agent_twin_demo.py` | Full twin-loop rehearsal on practice campus (real Docker E+ baseline + ECMs) |
 | `scripts/school_30yr_rehearsal.py` | Synthetic K-12 30-year hydronic/electrification rehearsal |
 | `examples/school_30yr/` | Fictional school profile and synthetic 2025 bills |

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -90,14 +90,16 @@ docker run -d --restart unless-stopped -p 8520:8501 \
   -e WATTLAB_STUDIO_WORKSPACE=/data \
   -e WATTLAB_HOST_WORKSPACE="$HOME/wattlab_workspace" \
   -e WATTLAB_ROOT=/app \
+  -e ENERGYPLUS_DOCKER_USER=1000:1000 \
   --name vibe20 ghcr.io/bbartling/vibe20:latest
 curl -sf http://127.0.0.1:8520/_stcore/health
 ```
 
+Tip image includes the **Docker CLI** (no host `docker` binary bind-mount).
 `WATTLAB_HOST_WORKSPACE` = host path for the `/data` bind (required for Twin →
-Docker E+ / DinD). Artifacts land under `/data/.artifacts`. Sims use `-r` so
-`eplusout.csv` appears for Twin panes. Stage mounts are **siblings** of the
-output dir (`…/sim__stage_in` + `…/sim`), never nested `_stage_in` under out.
+Docker E+ / DinD). Prefer agents: `docker exec vibe20 wattlab …`
+([`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)).
+G14 + client package: [`docs/CALIBRATE_AND_DELIVERABLES.md`](docs/CALIBRATE_AND_DELIVERABLES.md).
 
 ## SETUP — EnergyPlus + EnergyPlus-MCP
 

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -165,7 +165,10 @@ RunPeriod end. Optional Twin **cooling_tons / fan_hp** → area-aware hard-size
 freeze → `sizing_scenario=hard_size_refused` (BUG-W3b). Results show **peak_demand_kw**
 alongside kWh. Multi-floor profiles (`floors` ≥ 2) get stacked schematic plates
 (not site CAD). Agent ops: [`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)
-(`docker exec` + shared volume — no git clone). Entry: `/app/studio.py`.
+(`docker exec` + shared volume — no git clone). **DinD:** image includes Docker
+CLI (sock alone insufficient). **G14 path:** `wattlab calibrate-campaign`
+(bill months → AMY window → scorecard → Twin publish). Twin **Build client package**
+downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 
 ## TURNKEY CHECKLIST
 
@@ -187,6 +190,8 @@ alongside kWh. Multi-floor profiles (`floors` ≥ 2) get stacked schematic plate
 15. ECMs page exercised; capital gate noted.
 16. Write `reports/CALIBRATE_SESSION.md` + `BUG_REPORT.md`.
 17. Agent path via shared volume / `docker exec` (see `docs/AGENT_DOCKER_WORKSPACE.md`).
+18. **calibrate-campaign** (or Twin scorecard) with bill-aligned AMY — G14 stats shown or honest fail.
+19. Twin **Build client package** → preview report + download md/xlsx/zip without Streamlit exceptions.
 
 ## PASS / FAIL
 
@@ -203,6 +208,9 @@ alongside kWh. Multi-floor profiles (`floors` ≥ 2) get stacked schematic plate
 | W3b hard-size | Area-scaled nameplate or refused + NEEDS_INPUT banner |
 | Demand kW | `peak_demand_kw` on results when meters/tbl present |
 | Multi-floor viz | floors≥2 → stacked schematic + honesty caption |
+| DinD CLI | `capability_status().docker_available` true with sock only (CLI in image) |
+| G14 campaign | bill-window AMY + scorecard NMBE/CV(RMSE) or honest fail |
+| Client package | Twin builds report + xlsx + zip; downloads work |
 
 One live sim is **not** enough. Really try the loop — baseline + hypotheses —
 with the human engineer.

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -30,6 +30,33 @@ Containers typically mount:
 vibe20 also needs `WATTLAB_HOST_WORKSPACE` set to the **host** path (sibling
 mounts for DinD) and preferably `ENERGYPLUS_DOCKER_USER=1000:1000`.
 
+The vibe20 image ships a **Docker CLI client** (sock alone is not enough). Prefer:
+
+```bash
+docker run … \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e WATTLAB_HOST_WORKSPACE="$HOME/wattlab_workspace" \
+  -e ENERGYPLUS_DOCKER_USER=1000:1000 \
+  ghcr.io/bbartling/vibe20:latest
+```
+
+Do **not** rely on host `pip install -e` wattlab — prefer `docker exec vibe20 wattlab …`
+so agents match the Studio image (avoids host package drift).
+
+## G14 calibrate campaign (bill months → Twin)
+
+```bash
+docker exec -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace vibe20 \
+  wattlab calibrate-campaign \
+  --bundle /data/uploads/dump/wattlab_dump_BUILDING_100.zip \
+  --bills /data/uploads/energy/utility_bills.csv \
+  --lat 42.6 --lon -83.15 \
+  --cooling-tons 200 --fan-hp 75
+```
+
+Publishes `runs/calibrate_*` with scorecard + optional client zip under `.artifacts/deliverable_*`.
+In Studio Twin: **Build client package** → download report / xlsx / zip.
+
 ## Agent flow (no git)
 
 ```text

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/CALIBRATE_AND_DELIVERABLES.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/CALIBRATE_AND_DELIVERABLES.md
@@ -1,0 +1,82 @@
+# Calibrate campaign + client deliverables
+
+Turnkey path from **bill-aligned AMY** to **ASHRAE G14 scorecard** and a
+**client handoff package**. Prefer `docker exec vibe20` (image tip) over host
+`pip install -e` — see [`AGENT_DOCKER_WORKSPACE.md`](AGENT_DOCKER_WORKSPACE.md).
+
+## When “calibrated” is allowed
+
+Only after monthly utility compare passes G14 (NMBE ±5%, CV(RMSE) ≤15%) with
+honest stamps. Chicago TMY screening is **not** calibration.
+
+Required stamps on every run:
+
+| Stamp | Meaning |
+| --- | --- |
+| `weather_suitability.mode` | `ACTUAL_YEAR_CALIBRATION` (AMY) vs TMY / substitute |
+| `prototype_area_scale` | target ft² / ~10k prototype — never scale kWh×N and call it the building without disclosure |
+| `sizing_scenario` | `autosize` / `hard_size` / `hard_size_refused` |
+| `g14_scale.mode` | `area_scaled_prototype` when absolute kWh G14 multiplies model by scale |
+
+## CLI — `wattlab calibrate-campaign`
+
+```bash
+docker exec -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace vibe20 \
+  wattlab calibrate-campaign \
+  --bundle /data/uploads/dump/wattlab_dump_BUILDING_100.zip \
+  --bills /data/uploads/energy/utility_bills.csv \
+  --lat 42.6 --lon -83.15 \
+  --cooling-tons 200 --fan-hp 75   # optional; area-aware W3b
+```
+
+What it does:
+
+1. Derives `data_window` from bill `YYYY-MM` months (first→last).
+2. Fetches Open-Meteo AMY when `weather_observed.csv` is missing (needs lat/lon).
+3. Runs `run_calibration` with monthly meters, W2b full-day EPW clip via `simulate`,
+   optional hard-size (W3b refuse band).
+4. Scores dual-fuel monthly G14; may apply `prototype_area_scale` to modeled kWh
+   (stamped — not site CAD).
+5. Publishes `runs/calibrate_<id>/` + `calibration_scorecard.json` +
+   `campaign_stamp.json`.
+6. Builds client package under `.artifacts/deliverable_calibrate_*`.
+
+Dry-run: `--dry-run` prints the plan without Docker.
+
+Also: `wattlab calibrate --bundle …` for an already-seeded dump with
+`data_window` + `weather_observed.csv`.
+
+## Twin UI — what humans see
+
+1. **Modeled vs actual fuel** — monthly table + chart; NMBE / CV(RMSE) / pass-fail metrics when a scorecard is present (path or autoload from active run).
+2. **Client deliverables** — **Build client package**:
+   - Report preview (markdown)
+   - Downloads: `.md` · `.xlsx` · full `.zip`
+3. Zip layout:
+
+```text
+01_Report/Energy_Modeling_Report.md
+02_Results/Energy_Model_Results.xlsx + calibration_scorecard.json
+03_Models/Baseline/Building_Baseline.idf + Weather.epw + README.md
+04_Outputs/Baseline/eplustbl.* eplusout.err …
+06_Documentation/package_stamp.json + Assumption_Register.csv
+```
+
+ECM page can build the same zip from `studio_report` (screening package).
+
+## Ladder reminder (sparse sites)
+
+Do **not** jump straight to G14. Follow
+[`SPARSE_BUILDING_PLAYBOOK.md`](SPARSE_BUILDING_PLAYBOOK.md): TMY screening →
+constrain plant → schedules → **then** AMY + `calibrate-campaign`. Expect
+~8–15 published sims when unknowns are high.
+
+## Bugs / honesty (recent)
+
+| Id | Behavior |
+| --- | --- |
+| W2b | EPW RunPeriod end = last **full** day (max hour ≥ 23) |
+| W3b | Nameplate ÷ `prototype_area_scale` when scale > 1.5; refuse freeze outside [0.25, 4.0] |
+| Troy | User label `troy` → climate catalog detroit (not silent Madison) |
+| DinD | Image includes Docker **CLI**; sock alone is not enough |
+| Host drift | Prefer `docker exec vibe20 wattlab …` |

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/SPARSE_BUILDING_PLAYBOOK.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/SPARSE_BUILDING_PLAYBOOK.md
@@ -43,8 +43,17 @@ sizing scenario on every report.
 | 3 | Same TMY | Constrain to reported plant/fans | Unmet hours / saturation = undersized or bad envelope signal | — |
 | 4 | Still TMY | One schedule hypothesis (observed AHU vs design) | Biggest free lever when BAS exists | — |
 | 5 | AMY / actual (dump weather or Open-Meteo) | Keep constrained (or re-autosize once) | Align calendar to bills | period_mismatch |
+| 5b | **`wattlab calibrate-campaign`** | Same | Bill-month window → G14 scorecard → Twin publish + client zip | G14 fail → keep iterating or ESCO exit |
 | 6–8 | AMY | One FDD knob per run (SAT, SP reset, OA/econ, lockout…) | Move monthly shape toward bills | crosscheck `investigate` |
 | 9+ | AMY | Fine multipliers (LPD, people, infil) only after HVAC story holds | Chase G14 | Or declare conceptual-only |
+
+Step 5b details: [`CALIBRATE_AND_DELIVERABLES.md`](CALIBRATE_AND_DELIVERABLES.md).
+Ops surface: [`AGENT_DOCKER_WORKSPACE.md`](AGENT_DOCKER_WORKSPACE.md).
+
+**Hard-size (W3b):** when FM tons/hp known and `prototype_area_scale` > 1.5,
+nameplate is scaled by `1/scale` before factors; factors outside `[0.25, 4.0]`
+→ `hard_size_refused` (keep autosize, NEEDS_INPUT). **W2b:** AMY RunPeriod ends
+on the last complete EPW day (not a trailing partial hour).
 
 ### Ideal Loads vs explicit HVAC
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -78,6 +78,21 @@ hypothesis → AMY with bill-aligned window → one FDD knob per run. QA floor �
 live sims; sparse sites often need **6–10**. Stamp `prototype_area_scale` —
 5Zone ≈ 10k ft² is not the site.
 
+**AMY + G14 turnkey** (after TMY screening + plant honesty):
+
+```bash
+wattlab calibrate-campaign --bundle dump.zip --bills utility_bills.csv --lat … --lon …
+```
+
+See [`CALIBRATE_AND_DELIVERABLES.md`](CALIBRATE_AND_DELIVERABLES.md). Twin UI:
+scorecard metrics + **Build client package** (report / xlsx / zip).
+
+DinD: image includes Docker CLI; set `WATTLAB_HOST_WORKSPACE` + sock.
+Prefer `docker exec vibe20` — [`AGENT_DOCKER_WORKSPACE.md`](AGENT_DOCKER_WORKSPACE.md).
+
+**W2b:** last full EPW day. **W3b:** area-aware hard-size / refuse band.
+**peak_demand_kw** on results. Multi-floor (`floors`≥2) stacked schematic.
+
 Baseline first. With bills (`reports/utility_bills.csv` or dump bills), G14
 monthly NMBE ±5% / CV(RMSE) ≤15% before calibrated savings claims — only when
 months overlap and scale is honest.

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-assumptions/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-assumptions/SKILL.md
@@ -37,7 +37,13 @@ Full ladder: [`../../docs/SPARSE_BUILDING_PLAYBOOK.md`](../../docs/SPARSE_BUILDI
 | Schedules | Occupancy / lighting / equipment / HVAC avail |
 | Baseline | LPD, EPD, people density, ventilation, infil, setpoints |
 | Measures | One hypothesis per `runs/<id>/` |
-| Results | Monthly vs bills, unmet hours, area scale, weather mode |
+| Results | Monthly vs bills, unmet hours, area scale, weather mode, peak kW, G14 |
+
+After TMY screening: `wattlab calibrate-campaign` (bill months → AMY → G14) —
+[`../../docs/CALIBRATE_AND_DELIVERABLES.md`](../../docs/CALIBRATE_AND_DELIVERABLES.md).
+
+Hard-size nameplate: scale by `1/prototype_area_scale` when scale > 1.5; refuse
+outside [0.25, 4.0]. City `troy` → detroit catalog (user label preserved).
 
 ## Ideal Loads vs explicit system
 

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-energyplus-mcp/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-energyplus-mcp/SKILL.md
@@ -48,11 +48,17 @@ checkout often has `full_mcp_available`.
 
 When Studio runs in Docker with host docker.sock:
 
+- Image tip includes a **Docker CLI** binary — sock alone is insufficient.
 - Stage artifacts under `WATTLAB_STUDIO_WORKSPACE/.artifacts` (not `/app` only).
 - Set `WATTLAB_HOST_WORKSPACE` to the host side of the `/data` bind so volume
   sources resolve on the daemon host.
-- Set `WATTLAB_ROOT=/app` so prototypes resolve under `/app/examples/…`, not
-  site-packages.
+- Set `WATTLAB_ROOT=/app` so prototypes resolve under `/app/examples/…`.
+- Prefer `ENERGYPLUS_DOCKER_USER=1000:1000` for writable out dirs / ReadVars.
+- Prefer `docker exec vibe20 wattlab …` over host editable installs
+  ([`docs/AGENT_DOCKER_WORKSPACE.md`](../../docs/AGENT_DOCKER_WORKSPACE.md)).
+
+AMY RunPeriod: `simulate(align_run_period=True)` clips to last **full** EPW day
+(W2b). Calibrate path: [`docs/CALIBRATE_AND_DELIVERABLES.md`](../../docs/CALIBRATE_AND_DELIVERABLES.md).
 
 ## What MCP does not cover (yet)
 

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
@@ -30,8 +30,8 @@ Pages: `wattlab/studio/pages/{uploads,fuel_dashboard,twin_calibrate,ecms}.py`.
 | --- | --- | --- |
 | Uploads | dump v3 + energy package (campus / Excel / Haystack); workspace listing | `studio_bundle`, `studio_energy`, `studio_campus`, `studio_utility_bills_path` |
 | Fuel dashboard | monthly fuel, peers, HDD/CDD, gap-aware charts | `studio_campus` / `fuel_weather_*` |
-| Twin / calibrate | profile, dry-run, Docker E+, 08 panes (progress/OA/floor plan), modeled vs bills, iteration history | `studio_profile`, `studio_plan`, `studio_report`, `studio_active_run` |
-| ECMs | catalog Easy Buttons + capital guardrails | `studio_measures`, `studio_proxies`, `studio_capital_plan`, `studio_guardrail_gate` |
+| Twin / calibrate | profile, dry-run, Docker E+, 08 panes (progress/OA/floor or multi-floor schematic), EUI index, G14 scorecard, **client package** downloads, iteration history | `studio_profile`, `studio_plan`, `studio_report`, `studio_active_run`, `studio_deliverable` |
+| ECMs | catalog Easy Buttons + capital guardrails + optional client zip from report | `studio_measures`, `studio_proxies`, `studio_capital_plan`, `studio_guardrail_gate` |
 
 Navigation: `st.sidebar.radio(key="studio_page")` with only those four entries
 in `studio.py` `PAGES`.
@@ -53,9 +53,20 @@ geometry convention, not a site id). Demo replay from
 `tests/fixtures/eplusout/eplusout.csv` when Docker E+ image missing.
 
 Docker sock: `-v /var/run/docker.sock:/var/run/docker.sock` plus
-`WATTLAB_HOST_WORKSPACE=<host path of /data bind>` and `WATTLAB_ROOT=/app` so
-Twin → EnergyPlus DinD mounts resolve and prototypes are not under site-packages.
+`WATTLAB_HOST_WORKSPACE=<host path of /data bind>`, `WATTLAB_ROOT=/app`, and
+`ENERGYPLUS_DOCKER_USER=1000:1000`. The **image includes the Docker CLI**
+(sock alone is not enough — no host `/usr/bin/docker` bind required on tip).
+Prefer agent work via `docker exec vibe20 wattlab …`
+([`docs/AGENT_DOCKER_WORKSPACE.md`](../../docs/AGENT_DOCKER_WORKSPACE.md)).
+
 Artifacts: `/data/.artifacts`. Sims default to ReadVars (`-r`) for `eplusout.csv`.
+
+**Client deliverables (Twin):** Build client package → report preview + download
+`.md` / `.xlsx` / `.zip` (`wattlab.deliverables`). See
+[`docs/CALIBRATE_AND_DELIVERABLES.md`](../../docs/CALIBRATE_AND_DELIVERABLES.md).
+
+**G14:** scorecard NMBE/CV(RMSE) on Twin when `calibration_scorecard.json` is
+present; campaign CLI `wattlab calibrate-campaign`.
 
 ## Conventions (do not regress)
 
@@ -70,9 +81,11 @@ Artifacts: `/data/.artifacts`. Sims default to ReadVars (`-r`) for `eplusout.csv
 
 ```text
 python scripts/smoke_studio.py
-python -m pytest tests/test_studio_app.py tests/test_excel_campus.py tests/test_ep_viz.py -q
+python -m pytest tests/test_studio_app.py tests/test_excel_campus.py tests/test_ep_viz.py tests/test_deliverables_campaign.py -q
 # live: http://localhost:8520/_stcore/health → ok
 ```
+
+Smoke must exercise Twin **Build client package** with 0 Streamlit exceptions.
 
 Tester / calibrate loop prompt: `vibe20_agent_spec/AGENT_TESTER_PROMPT.md`
 (live `energyplus-mcp-dev` + optional EnergyPlus-MCP required for Twin calibrate PASS).

--- a/vibe_code_apps_20/wattlab/calibrate.py
+++ b/vibe_code_apps_20/wattlab/calibrate.py
@@ -40,6 +40,27 @@ NMBE_PASS = 5.0
 CVRMSE_PASS = 15.0
 
 
+def scale_monthly_energy(
+    monthly: list[dict[str, Any]],
+    *,
+    area_scale: float | None,
+) -> list[dict[str, Any]]:
+    """Scale prototype monthly kWh/therms toward site for G14 absolute compare."""
+    if not area_scale or area_scale <= 0:
+        return list(monthly or [])
+    out: list[dict[str, Any]] = []
+    for row in monthly or []:
+        r = dict(row)
+        if r.get("electricity_kwh") is not None:
+            r["electricity_kwh_unscaled"] = r["electricity_kwh"]
+            r["electricity_kwh"] = round(float(r["electricity_kwh"]) * area_scale, 2)
+        if r.get("natural_gas_therm") is not None:
+            r["natural_gas_therm_unscaled"] = r["natural_gas_therm"]
+            r["natural_gas_therm"] = round(float(r["natural_gas_therm"]) * area_scale, 2)
+        out.append(r)
+    return out
+
+
 def _read_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8-sig"))
 
@@ -639,6 +660,9 @@ def run_calibration(
     lon: float | None = None,
     validation_months: int = 0,
     validation_start: int | None = None,
+    area_scale_for_g14: float | None = None,
+    publish_studio: bool = True,
+    hard_size: dict[str, float] | None = None,
 ) -> dict[str, Any]:
     bundle = Path(bundle_dir)
     # Accept WattLab dump zip as well as extracted folders
@@ -775,12 +799,60 @@ def run_calibration(
     apply_fan_avail_continuous(proto, idf1)
     idf2 = run_dir / "cal_runperiod.idf"
     rp_meta = apply_run_period(idf1, idf2, begin=begin, end=end)
-    idf3 = run_dir / "cal_ready.idf"
+    idf3 = run_dir / "cal_hourly.idf"
     out_meta = apply_hourly_outputs(idf2, idf3)
+    from wattlab.energyplus.patches.hourly_outputs import apply_monthly_energy_tables
 
+    idf4 = run_dir / "cal_ready.idf"
+    monthly_meta = apply_monthly_energy_tables(idf3, idf4)
+    sim_idf = idf4
+
+    # Optional area-aware hard-size after a first autosize pass is handled below
+    # when hard_size is set (freeze requires inventory from a completed sim).
     sim_dir = run_dir / "sim_calibrate"
     sim_dir.mkdir(parents=True, exist_ok=True)
-    sim_result = simulate(idf3, epw_path, sim_dir)
+    sim_result = simulate(sim_idf, epw_path, sim_dir)
+    sizing_scenario = "autosize"
+    if hard_size and isinstance(hard_size, dict) and (
+        hard_size.get("cooling_tons") is not None or hard_size.get("fan_hp") is not None
+    ):
+        from wattlab.config import PROTOTYPE_AREA_FT2_NOMINAL
+        from wattlab.energyplus.sizing import (
+            freeze_autosized_values,
+            nameplate_to_capacity_factors,
+            parse_sizing_inventory,
+        )
+
+        inv = parse_sizing_inventory(sim_dir)
+        area_ft2 = float(
+            seed.get("conditioned_floor_area_ft2") or seed.get("floor_area_ft2") or 0
+        )
+        scale = area_ft2 / PROTOTYPE_AREA_FT2_NOMINAL if area_ft2 > 0 else None
+        factors, factor_meta = nameplate_to_capacity_factors(
+            inv,
+            cooling_tons=(
+                float(hard_size["cooling_tons"])
+                if hard_size.get("cooling_tons") is not None
+                else None
+            ),
+            fan_hp=(
+                float(hard_size["fan_hp"]) if hard_size.get("fan_hp") is not None else None
+            ),
+            prototype_area_scale=scale,
+        )
+        if factor_meta.get("hard_size_refused"):
+            sizing_scenario = "hard_size_refused"
+        elif factors:
+            hard_idf = run_dir / "cal_hard_size.idf"
+            freeze_autosized_values(sim_idf, hard_idf, inv, capacity_factors=factors)
+            sim_dir = run_dir / "sim_calibrate_hard"
+            sim_dir.mkdir(parents=True, exist_ok=True)
+            sim_idf = hard_idf
+            sim_result = simulate(sim_idf, epw_path, sim_dir)
+            sizing_scenario = "hard_size"
+        else:
+            sizing_scenario = "autosize_observe_hard_size_unavailable"
+
     annual = annual_from_output_dir(sim_dir)
 
     hourly = parse_eplusout_hourly(sim_dir)
@@ -821,6 +893,23 @@ def run_calibration(
     )
     data_window = seed.get("data_window") if isinstance(seed.get("data_window"), dict) else None
 
+    monthly_for_g14 = list(annual.get("monthly") or [])
+    g14_scale_meta: dict[str, Any] = {"area_scale_applied": None, "mode": "prototype_raw"}
+    if area_scale_for_g14 is not None and float(area_scale_for_g14) > 0:
+        from wattlab.calibrate import scale_monthly_energy
+
+        monthly_for_g14 = scale_monthly_energy(
+            monthly_for_g14, area_scale=float(area_scale_for_g14)
+        )
+        g14_scale_meta = {
+            "area_scale_applied": round(float(area_scale_for_g14), 4),
+            "mode": "area_scaled_prototype",
+            "note": (
+                "Simulated monthly kWh/therms multiplied by prototype_area_scale "
+                "for absolute G14 vs site bills. Unscaled 5Zone geometry — not site CAD."
+            ),
+        }
+
     bills_cmp: dict[str, Any]
     validation_cmp: dict[str, Any] | None = None
     if not bills:
@@ -831,17 +920,20 @@ def run_calibration(
         }
     elif holdout_meta.get("applied"):
         bills_cmp = compare_bills_to_monthly(
-            cal_bills, annual.get("monthly") or [], data_window=data_window
+            cal_bills, monthly_for_g14, data_window=data_window
         )
         bills_cmp["split"] = "calibration"
         validation_cmp = compare_bills_to_monthly(
-            val_bills, annual.get("monthly") or [], data_window=data_window
+            val_bills, monthly_for_g14, data_window=data_window
         )
         validation_cmp["split"] = "validation"
     else:
         bills_cmp = compare_bills_to_monthly(
-            bills, annual.get("monthly") or [], data_window=data_window
+            bills, monthly_for_g14, data_window=data_window
         )
+    bills_cmp["g14_scale"] = g14_scale_meta
+    if validation_cmp is not None:
+        validation_cmp["g14_scale"] = g14_scale_meta
 
     if bills and bills_cmp.get("pass_fail") in {"pass", "fail"}:
         overall = bills_cmp["pass_fail"]
@@ -863,11 +955,13 @@ def run_calibration(
     )
 
     finished_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    patch_names = ["fan_avail_continuous", "run_period", "hourly_outputs"]
+    patch_names = ["fan_avail_continuous", "run_period", "hourly_outputs", "monthly_energy_tables"]
+    if sizing_scenario.startswith("hard_size"):
+        patch_names.append(sizing_scenario)
     manifest = build_run_manifest(
         run_id=run_id,
         run_dir=run_dir,
-        idf_path=idf3,
+        idf_path=sim_idf,
         epw_path=epw_path,
         patches=[{"name": n} for n in patch_names],
         weather_suitability=wx,
@@ -878,6 +972,7 @@ def run_calibration(
             "product": "OpenFDD WattLab Calibration",
             "prototype_sha256": file_sha256(proto) if proto.is_file() else None,
             "calibration_status": status,
+            "sizing_scenario": sizing_scenario,
         },
     )
     write_run_manifest(run_dir, manifest)
@@ -889,9 +984,16 @@ def run_calibration(
         "status": status,
         "data_window": window,
         "weather_suitability": wx,
+        "sizing_scenario": sizing_scenario,
+        "hard_size": hard_size,
+        "g14_scale": g14_scale_meta,
+        "prototype_area_scale": (
+            float(area_scale_for_g14) if area_scale_for_g14 else None
+        ),
         "epw": epw_meta,
         "run_period": rp_meta,
         "hourly_outputs": out_meta,
+        "monthly_energy_tables": monthly_meta,
         "alignment": alignment,
         "holdout": holdout_meta,
         "run_manifest": {
@@ -907,8 +1009,10 @@ def run_calibration(
         "annual": {
             "electricity_kwh_year": annual.get("electricity_kwh_year"),
             "site_eui_kbtu_ft2_year": annual.get("site_eui_kbtu_ft2_year"),
+            "peak_demand_kw": annual.get("peak_demand_kw"),
             "status": annual.get("status"),
             "monthly": annual.get("monthly") or [],
+            "building_area_m2": annual.get("building_area_m2"),
         },
         "signatures": {
             "fan": fan_cmp,
@@ -924,6 +1028,72 @@ def run_calibration(
     out_json = run_dir / "calibration_scorecard.json"
     out_json.write_text(json.dumps(scorecard, indent=2, default=str), encoding="utf-8")
     scorecard["scorecard_path"] = str(out_json)
+
+    if publish_studio:
+        try:
+            from wattlab.studio.ep_viz import publish_run_for_studio
+
+            published = publish_run_for_studio(
+                run_dir,
+                run_id=f"calibrate_{run_id}",
+                report={
+                    **scorecard,
+                    "result_records": [
+                        {
+                            "measure_id": None,
+                            "annual": scorecard.get("annual") or {},
+                            "monthly": (scorecard.get("annual") or {}).get("monthly") or [],
+                        }
+                    ],
+                },
+            )
+            # Stamp for Twin EUI / scorecard autoload
+            stamp = {
+                "run_id": run_id,
+                "calibration_status": status,
+                "overall": overall,
+                "pass_fail": bills_cmp.get("pass_fail"),
+                "weather_mode": (wx or {}).get("mode"),
+                "prototype_area_scale": scorecard.get("prototype_area_scale"),
+                "sizing_scenario": sizing_scenario,
+                "g14_scale": g14_scale_meta,
+                "scorecard_path": str(out_json),
+            }
+            (published / "campaign_stamp.json").write_text(
+                json.dumps(stamp, indent=2), encoding="utf-8"
+            )
+            shutil_copy = getattr(__import__("shutil"), "copy2")
+            if out_json.is_file():
+                shutil_copy(out_json, published / "calibration_scorecard.json")
+            scorecard["studio_run_dir"] = str(published)
+            try:
+                from wattlab.deliverables import package_deliverables
+                from wattlab.config import ARTIFACTS
+
+                deliv_dir = ARTIFACTS / f"deliverable_calibrate_{run_id}"
+                deliv = package_deliverables(
+                    out_dir=deliv_dir,
+                    run_dir=run_dir,
+                    scorecard=scorecard,
+                    report={
+                        "run_id": run_id,
+                        "prototype_area_scale": scorecard.get("prototype_area_scale"),
+                        "weather_suitability": wx,
+                        "sizing_scenario": sizing_scenario,
+                        "area_honesty": (
+                            "Area-scaled G14 uses prototype geometry × scale — not site CAD."
+                        ),
+                    },
+                    profile=profile,
+                )
+                scorecard["deliverable"] = deliv
+                if deliv.get("zip_path"):
+                    shutil_copy(deliv["zip_path"], Path(published) / Path(deliv["zip_path"]).name)
+            except Exception as exc:  # noqa: BLE001
+                scorecard["deliverable_error"] = str(exc)
+        except Exception as exc:  # noqa: BLE001
+            scorecard["studio_publish_error"] = str(exc)
+
     return scorecard
 
 

--- a/vibe_code_apps_20/wattlab/calibrate_campaign.py
+++ b/vibe_code_apps_20/wattlab/calibrate_campaign.py
@@ -1,0 +1,251 @@
+"""Turnkey AMY + ASHRAE G14 calibrate campaign (bill months → score → Twin publish).
+
+Does not invent site geometry. Requires human fields (building_type, city,
+floor_area_ft2, lat/lon) and monthly ``utility_bills.csv`` aligned to the AMY window.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from wattlab.config import PROTOTYPE_AREA_FT2_NOMINAL
+
+
+def _load_bills_csv(path: Path) -> list[dict[str, Any]]:
+    import csv
+
+    rows: list[dict[str, Any]] = []
+    with Path(path).open(encoding="utf-8", newline="") as fh:
+        for r in csv.DictReader(fh):
+            month = str(r.get("month") or r.get("period") or "")[:7]
+            if not month:
+                continue
+            entry: dict[str, Any] = {"month": month, "period": month}
+            if r.get("kwh") not in (None, ""):
+                entry["kwh"] = float(r["kwh"])
+            if r.get("therms") not in (None, ""):
+                entry["therms"] = float(r["therms"])
+            rows.append(entry)
+    return rows
+
+
+def data_window_from_bill_months(months: list[str]) -> dict[str, str]:
+    """Inclusive UTC window covering first→last ``YYYY-MM`` bill months."""
+    keys = sorted({str(m)[:7] for m in months if m and len(str(m)) >= 7})
+    if not keys:
+        raise ValueError("NEEDS_INPUT: no bill months to derive data_window")
+    y0, m0 = int(keys[0][:4]), int(keys[0][5:7])
+    y1, m1 = int(keys[-1][:4]), int(keys[-1][5:7])
+    start = date(y0, m0, 1)
+    # End = last day of end month
+    if m1 == 12:
+        end = date(y1 + 1, 1, 1)
+    else:
+        end = date(y1, m1 + 1, 1)
+    from datetime import timedelta
+
+    end = end - timedelta(days=1)
+    return {
+        "start_utc": f"{start.isoformat()}T00:00:00Z",
+        "end_utc": f"{end.isoformat()}T23:59:59Z",
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "bill_months_first": keys[0],
+        "bill_months_last": keys[-1],
+        "n_bill_months": str(len(keys)),
+    }
+
+
+def scale_monthly_energy(
+    monthly: list[dict[str, Any]],
+    *,
+    area_scale: float | None,
+) -> list[dict[str, Any]]:
+    """Scale prototype monthly kWh/therms toward site for G14 absolute compare."""
+    from wattlab.calibrate import scale_monthly_energy as _scale
+
+    return _scale(monthly, area_scale=area_scale)
+
+
+def run_calibrate_campaign(
+    *,
+    bundle: Path,
+    bills_csv: Path | None = None,
+    lat: float | None = None,
+    lon: float | None = None,
+    seed_path: Path | None = None,
+    dry_run: bool = False,
+    validation_months: int = 0,
+    allow_area_scaled_g14: bool = True,
+    hard_size: dict[str, float] | None = None,
+    fetch_open_meteo_if_missing: bool = True,
+) -> dict[str, Any]:
+    """Bills → data_window → AMY (if needed) → ``run_calibration`` → Twin publish."""
+    from wattlab.calibrate import load_utility_bills, run_calibration, _read_json
+    from wattlab.twin import maybe_build_amy_from_open_meteo
+
+    bundle = Path(bundle)
+    work = bundle
+    if bundle.is_file() and bundle.suffix.lower() == ".zip":
+        from wattlab.seed import load_bundle
+
+        loaded = load_bundle(bundle)
+        for name in ("model_seed.json", "weather_observed.csv", "operating_signatures.csv"):
+            p = loaded.files.get(name)
+            if p is not None:
+                work = Path(p).parent
+                break
+
+    seed_file = Path(seed_path) if seed_path else work / "model_seed.json"
+    if not seed_file.is_file():
+        raise FileNotFoundError(f"model_seed.json not found: {seed_file}")
+    seed = _read_json(seed_file)
+
+    # Prefer explicit bills CSV; else dump utility_bills
+    bills: list[dict[str, Any]] = []
+    if bills_csv is not None and Path(bills_csv).is_file():
+        bills = _load_bills_csv(Path(bills_csv))
+        dest = work / "utility_bills.csv"
+        if Path(bills_csv).resolve() != dest.resolve():
+            shutil.copy2(bills_csv, dest)
+    else:
+        bills = load_utility_bills(work, seed)
+
+    if not bills:
+        raise ValueError(
+            "NEEDS_INPUT: monthly utility_bills.csv required for G14 campaign "
+            "(wattlab seed import-bills … or --bills)"
+        )
+
+    months = [str(b.get("month") or b.get("period") or "")[:7] for b in bills]
+    window = data_window_from_bill_months(months)
+    seed = dict(seed)
+    seed["data_window"] = {**(seed.get("data_window") or {}), **window}
+    if lat is not None:
+        seed["lat"] = float(lat)
+    if lon is not None:
+        seed["lon"] = float(lon)
+    # Persist updated seed for calibrate
+    campaign_seed = work / "model_seed_campaign.json"
+    campaign_seed.write_text(json.dumps(seed, indent=2), encoding="utf-8")
+
+    area_ft2 = float(seed.get("conditioned_floor_area_ft2") or seed.get("floor_area_ft2") or 0)
+    area_scale_nominal = (
+        area_ft2 / PROTOTYPE_AREA_FT2_NOMINAL if area_ft2 > 0 else None
+    )
+
+    plan: dict[str, Any] = {
+        "product": "OpenFDD WattLab Calibrate Campaign",
+        "bundle": str(work),
+        "data_window": window,
+        "n_bills": len(bills),
+        "prototype_area_ft2_nominal": PROTOTYPE_AREA_FT2_NOMINAL,
+        "target_floor_area_ft2": area_ft2 or None,
+        "prototype_area_scale": area_scale_nominal,
+        "allow_area_scaled_g14": allow_area_scaled_g14,
+        "hard_size": hard_size,
+        "honesty": (
+            "G14 uses AMY weather aligned to bill months. Absolute kWh compare applies "
+            "prototype_area_scale when allow_area_scaled_g14 — this is screening math on "
+            "unscaled 5Zone geometry, not a site CAD model. Do not claim calibrated ROI "
+            "until G14 passes with honest stamps (or document failure → ESCO proxies)."
+        ),
+    }
+    if dry_run:
+        plan["dry_run"] = True
+        return plan
+
+    has_wx = (work / "weather_observed.csv").is_file()
+    amy_meta = None
+    if fetch_open_meteo_if_missing and not has_wx:
+        amy_meta = maybe_build_amy_from_open_meteo(
+            seed, work, has_observed_weather=False
+        )
+        if amy_meta is None:
+            raise ValueError(
+                "NEEDS_INPUT: weather_observed.csv missing and Open-Meteo AMY could not "
+                "be built (need lat/lon + data_window)"
+            )
+        plan["open_meteo"] = amy_meta
+
+    scorecard = run_calibration(
+        work,
+        seed_path=campaign_seed,
+        dry_run=False,
+        lat=float(seed["lat"]) if seed.get("lat") is not None else None,
+        lon=float(seed["lon"]) if seed.get("lon") is not None else None,
+        validation_months=validation_months,
+        area_scale_for_g14=(
+            area_scale_nominal if allow_area_scaled_g14 else None
+        ),
+        publish_studio=True,
+        hard_size=hard_size,
+    )
+    plan["scorecard"] = {
+        "run_id": scorecard.get("run_id"),
+        "status": scorecard.get("status"),
+        "overall": scorecard.get("overall"),
+        "pass_fail": (scorecard.get("utility_bills") or {}).get("pass_fail"),
+        "scorecard_path": scorecard.get("scorecard_path"),
+        "studio_run_dir": scorecard.get("studio_run_dir"),
+    }
+    plan["calibration_status"] = scorecard.get("status")
+    plan["ok"] = True
+    return plan
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="AMY + G14 calibrate campaign (bill months → Twin publish)"
+    )
+    p.add_argument("--bundle", type=Path, required=True, help="WattLab dump dir or zip")
+    p.add_argument("--bills", type=Path, default=None, help="utility_bills.csv (YYYY-MM)")
+    p.add_argument("--lat", type=float, default=None)
+    p.add_argument("--lon", type=float, default=None)
+    p.add_argument("--seed", type=Path, default=None)
+    p.add_argument("--validation-months", type=int, default=0)
+    p.add_argument(
+        "--no-area-scaled-g14",
+        action="store_true",
+        help="Compare raw prototype kWh to site bills (almost always wrong for large sites)",
+    )
+    p.add_argument("--cooling-tons", type=float, default=None)
+    p.add_argument("--fan-hp", type=float, default=None)
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args(argv)
+
+    hard: dict[str, float] | None = None
+    if args.cooling_tons or args.fan_hp:
+        hard = {}
+        if args.cooling_tons:
+            hard["cooling_tons"] = float(args.cooling_tons)
+        if args.fan_hp:
+            hard["fan_hp"] = float(args.fan_hp)
+
+    try:
+        result = run_calibrate_campaign(
+            bundle=args.bundle,
+            bills_csv=args.bills,
+            lat=args.lat,
+            lon=args.lon,
+            seed_path=args.seed,
+            dry_run=args.dry_run,
+            validation_months=args.validation_months,
+            allow_area_scaled_g14=not args.no_area_scaled_g14,
+            hard_size=hard,
+        )
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vibe_code_apps_20/wattlab/cli.py
+++ b/vibe_code_apps_20/wattlab/cli.py
@@ -19,6 +19,7 @@ def _usage() -> str:
         "  defaults     Resolve a building profile from minimal inputs\n"
         "  easy-button  Baseline + measure-set EnergyPlus runs (or --dry-run plan)\n"
         "  calibrate    Calibrate prototype against a vibe19 model-seed bundle\n"
+        "  calibrate-campaign  Bills→AMY window→G14 score→Twin publish (turnkey)\n"
         "  bridge       Map a vibe19 export bundle to WattLab measures\n"
         "  epw          Build an AMY EPW from observed weather CSV\n"
         "  bench        Deterministic proxy / ESCO bin-method calculators\n"
@@ -126,6 +127,10 @@ def main(argv: list[str] | None = None) -> int:
         return int(m(rest) or 0)
     if cmd == "calibrate":
         from wattlab.calibrate import main as m
+
+        return int(m(rest) or 0)
+    if cmd in {"calibrate-campaign", "calibrate_campaign"}:
+        from wattlab.calibrate_campaign import main as m
 
         return int(m(rest) or 0)
     if cmd == "bridge":

--- a/vibe_code_apps_20/wattlab/deliverables.py
+++ b/vibe_code_apps_20/wattlab/deliverables.py
@@ -1,0 +1,488 @@
+"""Client / engineer deliverable packages from WattLab runs.
+
+Produces a curated folder + zip:
+
+  01_Report/   executive markdown
+  02_Results/  workbook (xlsx) + scorecard JSON + eplustbl when present
+  03_Models/   IDF + EPW + README (reproducibility)
+  04_Outputs/  selected native EnergyPlus files
+  06_Documentation/ assumption + change stamps
+
+Not a substitute for a signed PE report — stamps honesty / G14 / area scale.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import shutil
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _safe_read_json(path: Path | None) -> dict[str, Any]:
+    if path is None or not Path(path).is_file():
+        return {}
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _find_in_run(run_dir: Path, names: tuple[str, ...]) -> Path | None:
+    root = Path(run_dir)
+    for name in names:
+        p = root / name
+        if p.is_file():
+            return p
+        hits = list(root.rglob(name))
+        if hits:
+            return hits[0]
+    return None
+
+
+def build_executive_markdown(
+    *,
+    scorecard: dict[str, Any] | None = None,
+    report: dict[str, Any] | None = None,
+    profile: dict[str, Any] | None = None,
+) -> str:
+    """Readable engineering report (markdown) — client layer."""
+    sc = scorecard or {}
+    rp = report or {}
+    pr = profile or {}
+    bills = sc.get("utility_bills") or {}
+    ann = sc.get("annual") or {}
+    if not ann and rp.get("result_records"):
+        ann = (rp["result_records"][0] or {}).get("annual") or {}
+    wx = sc.get("weather_suitability") or rp.get("weather_suitability") or {}
+    g14 = bills.get("stats_electricity") or bills.get("stats") or {}
+    lines = [
+        "# Energy modeling report (WattLab)",
+        "",
+        f"_Generated {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}_",
+        "",
+        "## 1. Executive summary",
+        "",
+        f"- Project: **{pr.get('display_name') or rp.get('display_name') or sc.get('profile_project_id') or '—'}**",
+        f"- Calibration status: **{sc.get('status') or 'screening / not claimed'}**",
+        f"- G14 monthly pass/fail: **{bills.get('pass_fail') or 'n/a'}**",
+        f"- Weather mode: **{wx.get('mode') or '—'}** — {wx.get('reason') or ''}",
+        f"- Prototype area scale: **{sc.get('prototype_area_scale') or rp.get('prototype_area_scale') or '—'}**",
+        f"- Sizing scenario: **{sc.get('sizing_scenario') or rp.get('sizing_scenario') or 'autosize'}**",
+        f"- Peak demand (kW): **{(ann.get('peak_demand_kw') if isinstance(ann, dict) else None) or '—'}**",
+        f"- Site EUI (model, kBtu/ft²·yr): **{(ann.get('site_eui_kbtu_ft2_year') if isinstance(ann, dict) else None) or '—'}**",
+        "",
+        "> This package supports existing-building screening / calibration. "
+        "It is **not** final equipment selection, TAB, or construction documents.",
+        "",
+        "## 2. Scope and objectives",
+        "",
+        "Baseline EnergyPlus simulation with optional ASHRAE Guideline 14 monthly "
+        "gates (NMBE ±5%, CV(RMSE) ≤15%) when utility bills and AMY weather align.",
+        "",
+        "## 3. Building description (from profile / dump)",
+        "",
+        f"- Building type: {pr.get('building_type') or '—'}",
+        f"- City (user label): {pr.get('climate_city') or pr.get('city') or '—'}",
+        f"- Floor area ft²: {pr.get('floor_area_ft2') or pr.get('conditioned_floor_area_ft2') or '—'}",
+        f"- Floors: {pr.get('floors') or pr.get('number_of_floors') or '—'}",
+        "",
+        "## 4. Data sources",
+        "",
+        f"- Data window: `{json.dumps(sc.get('data_window') or {})}`",
+        f"- EPW / AMY: see `03_Models/`",
+        f"- Utility bills compared: {bills.get('months_compared', 0)} months",
+        "",
+        "## 5. Methodology and assumptions",
+        "",
+        "- Engine: EnergyPlus via Docker (`energyplus-mcp-dev`)",
+        "- Seed prototype: DOE 5ZoneAirCooled unless a custom IDF is supplied",
+        "- Absolute kWh G14 may apply `prototype_area_scale` (stamped) — "
+        "prototype geometry is **not** site CAD",
+        f"- G14 scale mode: `{json.dumps(sc.get('g14_scale') or {})}`",
+        "",
+        f"Area honesty: {rp.get('area_honesty') or sc.get('honesty') or '—'}",
+        "",
+        "## 6. Baseline results",
+        "",
+        f"- Electricity kWh/yr: {(ann.get('electricity_kwh_year') if isinstance(ann, dict) else None)}",
+        f"- Natural gas therm/yr: {(ann.get('natural_gas_therm_year') if isinstance(ann, dict) else None)}",
+        f"- Peak demand kW: {(ann.get('peak_demand_kw') if isinstance(ann, dict) else None)}",
+        "",
+        "## 7. Utility calibration (ASHRAE G14 monthly)",
+        "",
+        f"- Pass/fail: **{bills.get('pass_fail')}**",
+        f"- Electricity NMBE %: {g14.get('nmbe_pct')}",
+        f"- Electricity CV(RMSE) %: {g14.get('cvrmse_pct')}",
+        f"- Period mismatch: {bills.get('period_mismatch')}",
+        "",
+        "Do not claim “calibrated” without these statistics and disclosure of "
+        "which inputs were changed.",
+        "",
+        "## 8. Measures / savings",
+        "",
+    ]
+    savings = rp.get("savings_by_measure") or []
+    if savings:
+        lines.append("| step | measure | kWh/yr | peak kW | vs baseline kWh |")
+        lines.append("| --- | --- | ---: | ---: | ---: |")
+        for s in savings:
+            vs = s.get("vs_baseline") or {}
+            lines.append(
+                f"| {s.get('step')} | {s.get('measure_id')} | "
+                f"{s.get('electricity_kwh_year')} | {s.get('peak_demand_kw')} | "
+                f"{vs.get('kwh_saved')} |"
+            )
+    else:
+        lines.append("_No progressive ECM table in this package (baseline-only or calibrate run)._")
+    lines.extend(
+        [
+            "",
+            "## 9. Limitations",
+            "",
+            "- Unscaled prototype footprint unless a site-specific IDF is provided",
+            "- Weather may be AMY (calibration) or TMY substitute (screening only)",
+            "- Shared-meter electric splits are scenarios, not measured submeters",
+            "",
+            "## 10. Conclusions and next steps",
+            "",
+            "1. Confirm NEEDS_INPUT site facts (area, stories, plant nameplates, meter split).",
+            "2. Iterate AMY + constrained HVAC until G14 passes or document failure → ESCO proxies.",
+            "3. Do not publish calibrated ROI until G14 status is VALIDATED / CALIBRATED_NOT_VALIDATED.",
+            "",
+            "## Appendices",
+            "",
+            "- `02_Results/` — workbook + scorecard",
+            "- `03_Models/` — IDF / EPW / rerun README",
+            "- `04_Outputs/` — selected EnergyPlus tabular / err files",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_results_workbook_bytes(
+    *,
+    scorecard: dict[str, Any] | None = None,
+    report: dict[str, Any] | None = None,
+) -> bytes:
+    """Excel workbook (openpyxl) — engineering layer."""
+    from openpyxl import Workbook
+
+    sc = scorecard or {}
+    rp = report or {}
+    wb = Workbook()
+
+    # Summary
+    ws = wb.active
+    ws.title = "Summary"
+    rows = [
+        ("field", "value"),
+        ("run_id", sc.get("run_id") or rp.get("run_id")),
+        ("calibration_status", sc.get("status")),
+        ("g14_pass_fail", (sc.get("utility_bills") or {}).get("pass_fail")),
+        ("weather_mode", (sc.get("weather_suitability") or {}).get("mode")),
+        ("prototype_area_scale", sc.get("prototype_area_scale") or rp.get("prototype_area_scale")),
+        ("sizing_scenario", sc.get("sizing_scenario") or rp.get("sizing_scenario")),
+        (
+            "site_eui_kbtu_ft2_year",
+            (sc.get("annual") or {}).get("site_eui_kbtu_ft2_year"),
+        ),
+        ("peak_demand_kw", (sc.get("annual") or {}).get("peak_demand_kw")),
+        ("electricity_kwh_year", (sc.get("annual") or {}).get("electricity_kwh_year")),
+    ]
+    for r in rows:
+        ws.append(list(r))
+
+    # Calibration months
+    ws2 = wb.create_sheet("Calibration_Monthly")
+    ws2.append(
+        [
+            "month",
+            "observed_kwh",
+            "simulated_kwh",
+            "delta_kwh",
+            "observed_therms",
+            "simulated_therms",
+        ]
+    )
+    for pm in (sc.get("utility_bills") or {}).get("per_month") or []:
+        ws2.append(
+            [
+                pm.get("month"),
+                pm.get("observed_kwh"),
+                pm.get("simulated_kwh") or pm.get("modeled_kwh"),
+                pm.get("delta_kwh"),
+                pm.get("observed_therms"),
+                pm.get("simulated_therms"),
+            ]
+        )
+
+    # Model monthly
+    ws3 = wb.create_sheet("Model_Monthly")
+    ws3.append(["month", "electricity_kwh", "natural_gas_therm"])
+    monthly = (sc.get("annual") or {}).get("monthly") or []
+    if not monthly and rp.get("result_records"):
+        monthly = (rp["result_records"][0] or {}).get("monthly") or []
+    for m in monthly:
+        ws3.append(
+            [
+                m.get("month") or m.get("month_name"),
+                m.get("electricity_kwh"),
+                m.get("natural_gas_therm"),
+            ]
+        )
+
+    # Savings
+    ws4 = wb.create_sheet("Savings_By_Measure")
+    ws4.append(
+        [
+            "step",
+            "measure_id",
+            "electricity_kwh_year",
+            "peak_demand_kw",
+            "kwh_saved_vs_baseline",
+            "peak_kw_delta_vs_baseline",
+        ]
+    )
+    for s in rp.get("savings_by_measure") or []:
+        vs = s.get("vs_baseline") or {}
+        ws4.append(
+            [
+                s.get("step"),
+                s.get("measure_id"),
+                s.get("electricity_kwh_year"),
+                s.get("peak_demand_kw"),
+                vs.get("kwh_saved"),
+                vs.get("peak_demand_kw_delta"),
+            ]
+        )
+
+    # Assumptions stamp
+    ws5 = wb.create_sheet("Assumption_Register")
+    ws5.append(["input", "model_value", "source", "confidence", "notes"])
+    for row in [
+        (
+            "floor_area_ft2",
+            rp.get("target_floor_area_ft2"),
+            "profile / dump",
+            "varies",
+            "Confirm gross vs conditioned",
+        ),
+        (
+            "prototype_area_scale",
+            rp.get("prototype_area_scale") or sc.get("prototype_area_scale"),
+            "computed",
+            "high",
+            "target ft2 / ~10k prototype",
+        ),
+        (
+            "weather_mode",
+            (sc.get("weather_suitability") or rp.get("weather_suitability") or {}).get("mode"),
+            "EPW / AMY",
+            "high",
+            (sc.get("weather_suitability") or {}).get("reason"),
+        ),
+        (
+            "sizing_scenario",
+            sc.get("sizing_scenario") or rp.get("sizing_scenario"),
+            "autosize / hard-size",
+            "medium",
+            "Nameplate hard-size may be refused if factors absurd",
+        ),
+        (
+            "g14_scale_mode",
+            (sc.get("g14_scale") or {}).get("mode"),
+            "calibrate campaign",
+            "medium",
+            (sc.get("g14_scale") or {}).get("note"),
+        ),
+    ]:
+        ws5.append(list(row))
+
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def build_rerun_readme(
+    *,
+    energyplus_version: str | None = None,
+    run_id: str | None = None,
+) -> str:
+    ver = energyplus_version or "26.1.0 (energyplus-mcp-dev image)"
+    return (
+        f"# Rerun instructions\n\n"
+        f"- Run id: `{run_id or '—'}`\n"
+        f"- Simulations completed with **EnergyPlus {ver}**. "
+        "Re-run with this version unless formally migrated and retested.\n\n"
+        "## Docker (canonical)\n\n"
+        "```bash\n"
+        "docker exec vibe20 wattlab calibrate-campaign --bundle /data/uploads/... \\\n"
+        "  --bills /data/uploads/.../utility_bills.csv --lat … --lon …\n"
+        "```\n\n"
+        "Or simulate a specific IDF/EPW with the energyplus-mcp-dev image "
+        "(see AGENT_DOCKER_WORKSPACE.md).\n\n"
+        "## Contents\n\n"
+        "- `Building_Baseline.idf` — patched prototype used for this run\n"
+        "- `Weather.epw` — exact weather file\n"
+        "- Parent `02_Results/` — scorecard + workbook\n"
+    )
+
+
+def package_deliverables(
+    *,
+    out_dir: Path,
+    run_dir: Path | None = None,
+    scorecard: dict[str, Any] | None = None,
+    report: dict[str, Any] | None = None,
+    profile: dict[str, Any] | None = None,
+    zip_name: str | None = None,
+) -> dict[str, Any]:
+    """Write curated deliverable tree + zip; return paths/meta."""
+    out = Path(out_dir)
+    if out.exists():
+        shutil.rmtree(out)
+    for sub in (
+        "01_Report",
+        "02_Results",
+        "03_Models/Baseline",
+        "04_Outputs/Baseline",
+        "06_Documentation",
+    ):
+        (out / sub).mkdir(parents=True, exist_ok=True)
+
+    sc = dict(scorecard or {})
+    if not sc and run_dir:
+        sc = _safe_read_json(Path(run_dir) / "calibration_scorecard.json")
+        if not sc:
+            sc = _safe_read_json(Path(run_dir) / "wattlab_report.json")
+    rp = dict(report or {})
+    if not rp and run_dir:
+        rp = _safe_read_json(Path(run_dir) / "wattlab_report.json")
+
+    md = build_executive_markdown(scorecard=sc, report=rp, profile=profile)
+    report_path = out / "01_Report" / "Energy_Modeling_Report.md"
+    report_path.write_text(md, encoding="utf-8")
+
+    xlsx_bytes = build_results_workbook_bytes(scorecard=sc, report=rp)
+    xlsx_path = out / "02_Results" / "Energy_Model_Results.xlsx"
+    xlsx_path.write_bytes(xlsx_bytes)
+
+    sc_path = out / "02_Results" / "calibration_scorecard.json"
+    sc_path.write_text(json.dumps(sc, indent=2, default=str), encoding="utf-8")
+    if rp:
+        (out / "02_Results" / "wattlab_report.json").write_text(
+            json.dumps(rp, indent=2, default=str), encoding="utf-8"
+        )
+
+    # Monthly CSV (always available without Excel)
+    monthly_csv = out / "02_Results" / "calibration_monthly.csv"
+    with monthly_csv.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(
+            fh,
+            fieldnames=[
+                "month",
+                "observed_kwh",
+                "simulated_kwh",
+                "delta_kwh",
+                "observed_therms",
+                "simulated_therms",
+            ],
+            extrasaction="ignore",
+        )
+        w.writeheader()
+        for pm in (sc.get("utility_bills") or {}).get("per_month") or []:
+            row = dict(pm)
+            if row.get("simulated_kwh") is None and row.get("modeled_kwh") is not None:
+                row["simulated_kwh"] = row["modeled_kwh"]
+            w.writerow(row)
+
+    ep_ver = None
+    if run_dir:
+        root = Path(run_dir)
+        idf = _find_in_run(
+            root,
+            (
+                "cal_ready.idf",
+                "cal_hard_size.idf",
+                "baseline.idf",
+                "baseline_hard_size.idf",
+            ),
+        )
+        epw = _find_in_run(root, ("amy.epw",))
+        if epw is None:
+            # report may point at epw
+            epw_s = rp.get("epw") or sc.get("epw")
+            if isinstance(epw_s, dict):
+                epw_s = epw_s.get("out") or epw_s.get("path")
+            if isinstance(epw_s, str) and Path(epw_s).is_file():
+                epw = Path(epw_s)
+        if idf and idf.is_file():
+            shutil.copy2(idf, out / "03_Models" / "Baseline" / "Building_Baseline.idf")
+        if epw and epw.is_file():
+            shutil.copy2(epw, out / "03_Models" / "Baseline" / "Weather.epw")
+
+        for name in (
+            "eplustbl.htm",
+            "eplustbl.csv",
+            "eplusout.err",
+            "eplusout.end",
+            "eplusout.csv",
+            "eplusout.eio",
+        ):
+            p = _find_in_run(root, (name,))
+            if p and p.is_file():
+                shutil.copy2(p, out / "04_Outputs" / "Baseline" / name)
+
+        manifest = _safe_read_json(root / "run_manifest.json")
+        ep_ver = manifest.get("energyplus_version") or manifest.get("docker_image")
+
+    readme = build_rerun_readme(
+        energyplus_version=str(ep_ver) if ep_ver else None,
+        run_id=str(sc.get("run_id") or rp.get("run_id") or ""),
+    )
+    (out / "03_Models" / "Baseline" / "README.md").write_text(readme, encoding="utf-8")
+
+    stamp = {
+        "product": "WattLab deliverable package",
+        "created_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "calibration_status": sc.get("status"),
+        "g14_pass_fail": (sc.get("utility_bills") or {}).get("pass_fail"),
+        "weather_mode": (sc.get("weather_suitability") or {}).get("mode"),
+        "prototype_area_scale": sc.get("prototype_area_scale") or rp.get("prototype_area_scale"),
+        "intended_use": (
+            "Existing-building energy analysis and retrofit screening. "
+            "Not a substitute for detailed mechanical design."
+        ),
+    }
+    (out / "06_Documentation" / "package_stamp.json").write_text(
+        json.dumps(stamp, indent=2), encoding="utf-8"
+    )
+    (out / "06_Documentation" / "Assumption_Register.csv").write_text(
+        "input,model_value,source,confidence,notes\n"
+        f"prototype_area_scale,{stamp.get('prototype_area_scale')},computed,high,target/prototype\n"
+        f"weather_mode,{stamp.get('weather_mode')},EPW/AMY,high,\n"
+        f"g14_pass_fail,{stamp.get('g14_pass_fail')},scorecard,high,\n",
+        encoding="utf-8",
+    )
+
+    zname = zip_name or f"wattlab_deliverable_{sc.get('run_id') or 'package'}.zip"
+    zip_path = out.parent / zname
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for p in out.rglob("*"):
+            if p.is_file():
+                zf.write(p, arcname=str(p.relative_to(out.parent)))
+
+    return {
+        "ok": True,
+        "out_dir": str(out),
+        "zip_path": str(zip_path),
+        "report_md": str(report_path),
+        "workbook_xlsx": str(xlsx_path),
+        "stamp": stamp,
+    }

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -195,3 +196,43 @@ def render() -> None:
         key="ecm_dl_json",
     )
     st.caption(f"Also written to `{out}` for agents.")
+
+    st.subheader("Client energy-model package")
+    st.caption("Same Twin deliverable builder — report + workbook + model zip from the latest Studio report.")
+    if st.button("Build client package from ECM report", key="ecm_build_deliverable"):
+        from wattlab.deliverables import package_deliverables
+
+        if not report:
+            st.warning("No studio_report yet — run Twin / easy-button first.")
+        else:
+            rid = report.get("run_id") or "ecm_report"
+            dest = reports_dir() / f"deliverable_{rid}"
+            try:
+                sc = {
+                    "run_id": rid,
+                    "status": "screening",
+                    "annual": ((report.get("result_records") or [{}])[0] or {}).get("annual"),
+                    "weather_suitability": report.get("weather_suitability"),
+                    "prototype_area_scale": report.get("prototype_area_scale"),
+                    "sizing_scenario": report.get("sizing_scenario"),
+                    "utility_bills": {},
+                }
+                meta = package_deliverables(
+                    out_dir=dest,
+                    scorecard=sc,
+                    report=report,
+                    profile=profile,
+                )
+                st.session_state["studio_deliverable"] = meta
+                st.success(f"Package → {meta.get('out_dir')}")
+            except Exception as exc:
+                st.error(str(exc))
+    deliv = st.session_state.get("studio_deliverable") or {}
+    if deliv.get("zip_path") and Path(str(deliv["zip_path"])).is_file():
+        st.download_button(
+            "Download energy-model package (.zip)",
+            data=Path(str(deliv["zip_path"])).read_bytes(),
+            file_name=Path(str(deliv["zip_path"])).name,
+            mime="application/zip",
+            key="ecm_dl_deliverable_zip",
+        )

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -563,21 +563,53 @@ def render() -> None:
     )
     bills_rows: list[dict[str, Any]] = []
     monthly_model: list[dict[str, Any]] = []
+    scorecard: dict[str, Any] = {}
+
+    def _load_scorecard(sc: dict[str, Any]) -> list[dict[str, Any]]:
+        rows = list((sc.get("utility_bills") or {}).get("per_month") or [])
+        for pm in rows:
+            if pm.get("modeled_kwh") is None and pm.get("simulated_kwh") is not None:
+                pm["modeled_kwh"] = pm["simulated_kwh"]
+        return rows
+
     if scorecard_path.strip():
         sp = Path(scorecard_path.strip())
         if sp.is_file():
-            sc = json.loads(sp.read_text(encoding="utf-8"))
-            monthly_model = list((sc.get("annual") or {}).get("monthly") or [])
-            for pm in (sc.get("utility_bills") or {}).get("per_month") or []:
-                bills_rows.append(
-                    {
-                        "month": pm.get("month"),
-                        "observed_kwh": pm.get("observed_kwh"),
-                        "modeled_kwh": pm.get("modeled_kwh"),
-                        "delta_kwh": pm.get("delta_kwh"),
-                    }
+            try:
+                scorecard = json.loads(sp.read_text(encoding="utf-8"))
+                bills_rows = _load_scorecard(scorecard)
+                monthly_model = list((scorecard.get("annual") or {}).get("monthly") or [])
+                st.caption(
+                    f"G14 status={scorecard.get('status')} · pass_fail="
+                    f"{(scorecard.get('utility_bills') or {}).get('pass_fail')} · "
+                    f"scale={scorecard.get('g14_scale') or scorecard.get('prototype_area_scale')}"
                 )
-            st.caption(f"Scorecard status: {sc.get('status') or sc.get('overall')}")
+            except Exception as exc:
+                st.warning(f"scorecard read failed: {exc}")
+    else:
+        active_sc = _resolve_active_run()
+        if active_sc is not None:
+            for name in ("calibration_scorecard.json", "campaign_stamp.json"):
+                sp = Path(active_sc) / name
+                if not sp.is_file():
+                    continue
+                try:
+                    sc = json.loads(sp.read_text(encoding="utf-8"))
+                    if name == "campaign_stamp.json" and sc.get("scorecard_path"):
+                        sp2 = Path(sc["scorecard_path"])
+                        if sp2.is_file():
+                            sc = json.loads(sp2.read_text(encoding="utf-8"))
+                    scorecard = sc
+                    bills_rows = _load_scorecard(sc)
+                    monthly_model = list((sc.get("annual") or {}).get("monthly") or [])
+                    if bills_rows or sc.get("status"):
+                        st.caption(
+                            f"Autoloaded scorecard · status={sc.get('status')} · "
+                            f"pass_fail={(sc.get('utility_bills') or {}).get('pass_fail')}"
+                        )
+                    break
+                except Exception:
+                    continue
 
     if bundle is not None and not getattr(bundle, "utility_bills", pd.DataFrame()).empty:
         ub = bundle.utility_bills
@@ -593,8 +625,112 @@ def render() -> None:
         st.dataframe(bdf, width="stretch", hide_index=True)
         if "observed_kwh" in bdf.columns and "modeled_kwh" in bdf.columns:
             st.line_chart(bdf.set_index("month")[["observed_kwh", "modeled_kwh"]])
+        ubills = scorecard.get("utility_bills") or {}
+        stats = ubills.get("stats_electricity") or ubills.get("stats") or {}
+        if stats:
+            g1, g2, g3 = st.columns(3)
+            g1.metric("G14 NMBE %", f"{stats.get('nmbe_pct', '—')}")
+            g2.metric("G14 CV(RMSE) %", f"{stats.get('cvrmse_pct', '—')}")
+            g3.metric("Pass/fail", str(ubills.get("pass_fail") or "—"))
     elif monthly_model:
         st.dataframe(pd.DataFrame(monthly_model).head(24), width="stretch", hide_index=True)
+
+    st.subheader("Client deliverables")
+    st.caption(
+        "Professional handoff: executive report, results workbook, and model package "
+        "(IDF / EPW / selected EnergyPlus outputs). Screening or calibrated — stamped honestly."
+    )
+    studio_report = st.session_state.get("studio_report") or {}
+    profile = _profile() or {}
+    build_col, hint_col = st.columns([1, 2])
+    with build_col:
+        build_clicked = st.button(
+            "Build client package",
+            key="twin_build_deliverable",
+            type="primary",
+            help="Creates report.md + results.xlsx + zip under reports/",
+        )
+    with hint_col:
+        st.caption(
+            "Uses the active Twin run + calibration scorecard when present. "
+            "Agents can also run `wattlab calibrate-campaign` then refresh."
+        )
+    if build_clicked:
+        from wattlab.deliverables import package_deliverables
+
+        run_src = _resolve_active_run()
+        sc = scorecard
+        if not sc and run_src and (Path(run_src) / "calibration_scorecard.json").is_file():
+            sc = json.loads(
+                (Path(run_src) / "calibration_scorecard.json").read_text(encoding="utf-8")
+            )
+        if not sc and studio_report:
+            sc = {
+                "run_id": studio_report.get("run_id"),
+                "status": "screening",
+                "annual": ((studio_report.get("result_records") or [{}])[0] or {}).get("annual"),
+                "weather_suitability": studio_report.get("weather_suitability"),
+                "prototype_area_scale": studio_report.get("prototype_area_scale"),
+                "sizing_scenario": studio_report.get("sizing_scenario"),
+                "utility_bills": {},
+            }
+        if not sc and not studio_report and run_src is None:
+            st.warning("No scorecard or published run yet — run Twin / calibrate-campaign first.")
+        else:
+            rid = (sc or {}).get("run_id") or (Path(run_src).name if run_src else "latest")
+            dest = reports_dir() / f"deliverable_{rid}"
+            try:
+                meta = package_deliverables(
+                    out_dir=dest,
+                    run_dir=Path(run_src) if run_src else None,
+                    scorecard=sc or {},
+                    report=studio_report or None,
+                    profile=profile,
+                )
+                st.session_state["studio_deliverable"] = meta
+                st.success(f"Package ready → `{meta.get('out_dir')}`")
+            except Exception as exc:
+                st.error(f"Deliverable build failed: {exc}")
+
+    deliv = st.session_state.get("studio_deliverable") or {}
+    if deliv.get("report_md") and Path(str(deliv["report_md"])).is_file():
+        tab_report, tab_files = st.tabs(["Report preview", "Downloads"])
+        md_text = Path(str(deliv["report_md"])).read_text(encoding="utf-8")
+        with tab_report:
+            st.markdown(md_text)
+        with tab_files:
+            stamp = (deliv.get("stamp") or {})
+            if stamp:
+                st.json(stamp, expanded=False)
+            d1, d2, d3 = st.columns(3)
+            d1.download_button(
+                "Report (.md)",
+                data=md_text.encode("utf-8"),
+                file_name="Energy_Modeling_Report.md",
+                mime="text/markdown",
+                key="dl_report_md",
+            )
+            xlsx_p = deliv.get("workbook_xlsx")
+            if xlsx_p and Path(str(xlsx_p)).is_file():
+                d2.download_button(
+                    "Results workbook (.xlsx)",
+                    data=Path(str(xlsx_p)).read_bytes(),
+                    file_name="Energy_Model_Results.xlsx",
+                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    key="dl_workbook_xlsx",
+                )
+            zip_p = deliv.get("zip_path")
+            if zip_p and Path(str(zip_p)).is_file():
+                d3.download_button(
+                    "Full package (.zip)",
+                    data=Path(str(zip_p)).read_bytes(),
+                    file_name=Path(str(zip_p)).name,
+                    mime="application/zip",
+                    key="dl_deliverable_zip",
+                )
+            st.caption(
+                "Zip layout: `01_Report` · `02_Results` · `03_Models` · `04_Outputs` · `06_Documentation`"
+            )
 
     st.subheader("Iteration history (agent + Studio)")
     hist = list_iteration_runs(runs_dir(), limit=15)


### PR DESCRIPTION
## Summary
- Bake Docker CLI into vibe20 image (sock alone is not enough for Studio DinD)
- `wattlab calibrate-campaign`: bill months → data_window → AMY → G14 scorecard → Twin publish + area-scaled honesty stamps
- Client deliverables: executive markdown, results workbook, IDF/EPW zip — Twin + ECM download UI
- Docs/tester gates; prefer `docker exec vibe20` over host pip -e

## Test plan
- [x] pytest test_deliverables_campaign + related
- [x] smoke_studio.py including Twin deliverable button (0 exceptions)
- [ ] vibe20-ghcr green after merge
- [ ] bensbench recreate without host docker CLI bind-mount

Made with [Cursor](https://cursor.com)