### PR TITLE
fix(vibe20): multi-year G14, ARTIFACTS crash, bill-aligned AMY

### DIFF
--- a/vibe_code_apps_20/Dockerfile
+++ b/vibe_code_apps_20/Dockerfile
@@ -7,6 +7,7 @@
 # mounts + world-writable out dirs + --user 1000:1000 for ReadVars CSV.
 # Without docker.sock, dry-run / Fuel / ECMs still work; agents can publish
 # runs/ from ``docker exec vibe20 wattlab …`` (prefer that over host pip -e).
+# Image uses editable install (``pip install -e``) so import wattlab == /app/wattlab.
 #
 # Entry point: studio.py (not wattlab/studio/app.py).
 FROM docker:27-cli AS dockercli
@@ -40,7 +41,8 @@ WORKDIR /app
 COPY --from=dockercli /usr/local/bin/docker /usr/local/bin/docker
 
 COPY . .
-RUN pip install --no-cache-dir ".[studio]"
+# Editable install so ``import wattlab`` resolves to /app/wattlab (single tree).
+RUN pip install --no-cache-dir -e ".[studio]"
 
 EXPOSE 8501
 

--- a/vibe_code_apps_20/tests/test_deliverables_campaign.py
+++ b/vibe_code_apps_20/tests/test_deliverables_campaign.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import patch
 
 from wattlab.calibrate import scale_monthly_energy
-from wattlab.calibrate_campaign import data_window_from_bill_months
+from wattlab.calibrate_campaign import (
+    data_window_from_bill_months,
+    ensure_bill_aligned_weather,
+    run_calibrate_campaign,
+    weather_csv_covers_window,
+)
 from wattlab.deliverables import (
     build_executive_markdown,
     build_results_workbook_bytes,
@@ -19,6 +26,121 @@ def test_data_window_from_bill_months():
     assert w["end"] == "2024-12-31"
     assert w["bill_months_first"] == "2024-01"
     assert w["bill_months_last"] == "2024-12"
+
+
+def test_campaign_replaces_dump_data_window(tmp_path: Path):
+    """BUG-W-SEED-WINDOW-MERGE: bill window replaces dump; dump kept under dump_data_window."""
+    seed = {
+        "building_type": "office",
+        "city": "troy",
+        "floor_area_ft2": 140000,
+        "lat": 42.56,
+        "lon": -83.12,
+        "data_window": {
+            "start_utc": "2026-03-16T00:00:00Z",
+            "end_utc": "2026-07-17T10:00:00Z",
+            "span_hours": 2961,
+        },
+    }
+    (tmp_path / "model_seed.json").write_text(json.dumps(seed), encoding="utf-8")
+    bills = tmp_path / "utility_bills.csv"
+    rows = ["month,kwh,therms"]
+    y, m = 2024, 12
+    for _ in range(12):
+        rows.append(f"{y:04d}-{m:02d},1000,50")
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+    bills.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    plan = run_calibrate_campaign(
+        bundle=tmp_path,
+        bills_csv=bills,
+        dry_run=True,
+    )
+    assert plan["data_window"]["start"] == "2024-12-01"
+    assert plan["data_window"]["end"] == "2025-11-30"
+    assert "span_hours" not in plan["data_window"]
+    assert plan["dump_data_window"]["span_hours"] == 2961
+
+    campaign_seed = json.loads(
+        (tmp_path / "model_seed_campaign.json").read_text(encoding="utf-8")
+    )
+    assert campaign_seed["data_window"]["start"] == "2024-12-01"
+    assert "span_hours" not in campaign_seed["data_window"]
+    assert campaign_seed["dump_data_window"]["span_hours"] == 2961
+
+
+def test_weather_csv_covers_window(tmp_path: Path):
+    window = {
+        "start": "2024-12-01",
+        "end": "2025-11-30",
+        "start_utc": "2024-12-01T00:00:00Z",
+        "end_utc": "2025-11-30T23:59:59Z",
+    }
+    covering = tmp_path / "wx_ok.csv"
+    covering.write_text(
+        "timestamp_utc,web-outside-air-temp\n"
+        "2024-12-01T00:00:00Z,30\n"
+        "2025-11-30T23:00:00Z,40\n",
+        encoding="utf-8",
+    )
+    assert weather_csv_covers_window(covering, window) is True
+
+    dump_partial = tmp_path / "wx_2026.csv"
+    dump_partial.write_text(
+        "timestamp_utc,web-outside-air-temp\n"
+        "2026-03-16T00:00:00Z,50\n"
+        "2026-07-17T10:00:00Z,70\n",
+        encoding="utf-8",
+    )
+    assert weather_csv_covers_window(dump_partial, window) is False
+
+
+def test_ensure_bill_aligned_weather_stashes_off_window(tmp_path: Path):
+    """BUG-W-DUMP-WX-VS-BILLS: off-window dump weather is stashed; Open-Meteo invoked."""
+    window = data_window_from_bill_months(["2024-12", "2025-11"])
+    wx = tmp_path / "weather_observed.csv"
+    wx.write_text(
+        "timestamp_utc,web-outside-air-temp\n"
+        "2026-03-16T00:00:00Z,50\n"
+        "2026-07-17T10:00:00Z,70\n",
+        encoding="utf-8",
+    )
+    seed = {"lat": 42.56, "lon": -83.12, "data_window": window}
+
+    with patch(
+        "wattlab.twin.maybe_build_amy_from_open_meteo",
+        return_value={"ok": True, "source": "open_meteo"},
+    ) as mock_amy:
+        out = ensure_bill_aligned_weather(
+            tmp_path, seed, window, fetch_open_meteo_if_missing=True
+        )
+    assert mock_amy.called
+    assert out["weather_source"] == "open_meteo_amy"
+    assert "stashed_weather" in out
+    assert not wx.is_file()
+    assert Path(out["stashed_weather"]).is_file()
+
+
+def test_ensure_bill_aligned_weather_keeps_covering(tmp_path: Path):
+    window = data_window_from_bill_months(["2024-12", "2025-11"])
+    wx = tmp_path / "weather_observed.csv"
+    wx.write_text(
+        "timestamp_utc,web-outside-air-temp\n"
+        "2024-12-01T00:00:00Z,30\n"
+        "2025-11-30T23:00:00Z,40\n",
+        encoding="utf-8",
+    )
+    seed = {"lat": 42.56, "lon": -83.12, "data_window": window}
+    with patch("wattlab.twin.maybe_build_amy_from_open_meteo") as mock_amy:
+        out = ensure_bill_aligned_weather(
+            tmp_path, seed, window, fetch_open_meteo_if_missing=True
+        )
+    assert not mock_amy.called
+    assert out["weather_source"] == "existing_weather_observed"
+    assert wx.is_file()
 
 
 def test_scale_monthly_energy():

--- a/vibe_code_apps_20/tests/test_import_bills.py
+++ b/vibe_code_apps_20/tests/test_import_bills.py
@@ -45,6 +45,37 @@ def test_compare_bills_period_mismatch_refuses_false_g14():
     assert cmp["months_compared"] == 0
 
 
+def test_compare_bills_cross_year_window_joins_twelve_months():
+    """BUG-W-G14-YEAR: Dec'24–Nov'25 bills + bare Jan–Dec sim → 12 months."""
+    from wattlab.calibrate import month_keys_for_data_window
+
+    months = []
+    y, m = 2024, 12
+    for _ in range(12):
+        months.append(f"{y:04d}-{m:02d}")
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+    bills = [{"month": mo, "kwh": 1000.0, "therms": 100.0} for mo in months]
+    monthly = [
+        {"month": i, "electricity_kwh": 1000.0, "natural_gas_therm": 100.0}
+        for i in range(1, 13)
+    ]
+    window = {
+        "start_utc": "2024-12-01T00:00:00Z",
+        "end_utc": "2025-11-30T23:59:59Z",
+        "start": "2024-12-01",
+        "end": "2025-11-30",
+    }
+    assert month_keys_for_data_window(window) == months
+    cmp = compare_bills_to_monthly(bills, monthly, data_window=window)
+    assert cmp["months_compared"] == 12
+    assert cmp["period_mismatch"] is False
+    assert cmp["pass_fail"] == "pass"
+    assert {p["month"] for p in cmp["per_month"]} == set(months)
+
+
 def test_compare_bills_legacy_int_months_still_join():
     bills = [{"month": m, "kwh": 1000.0, "therms": 100.0} for m in range(1, 13)]
     monthly = [
@@ -54,6 +85,18 @@ def test_compare_bills_legacy_int_months_still_join():
     cmp = compare_bills_to_monthly(bills, monthly)
     assert cmp["pass_fail"] == "pass"
     assert cmp["months_compared"] == 12
+
+
+def test_run_calibration_no_artifacts_local_shadow():
+    """BUG-W-ARTIFACTS: inner ARTIFACTS import must not shadow module binding."""
+    import inspect
+
+    from wattlab import calibrate as cal_mod
+
+    src = inspect.getsource(cal_mod.run_calibration)
+    assert "from wattlab.config import ARTIFACTS" not in src
+    # Module-level ARTIFACTS remains usable (would UnboundLocalError if shadowed).
+    assert cal_mod.ARTIFACTS is not None
 
 
 def test_normalize_bill_month_key():

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -193,6 +193,9 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 16. Write `reports/CALIBRATE_SESSION.md` + `BUG_REPORT.md`.
 17. Agent path via shared volume / `docker exec` (see `docs/AGENT_DOCKER_WORKSPACE.md`).
 18. **calibrate-campaign** (or Twin scorecard) with bill-aligned AMY — G14 stats shown or honest fail.
+    Cross-year bills (e.g. Dec’24–Nov’25): scorecard `utility_bills.months_compared`
+    should match bill count (~12), not collapse to 1. Dump weather that misses the
+    bill window must be stashed / Open-Meteo rebuilt — do not silently use 2026 dump wx.
 19. Twin **Build client package** → preview report + download md/xlsx/zip without Streamlit exceptions.
 
 ## PASS / FAIL
@@ -211,7 +214,7 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 | Demand kW | `peak_demand_kw` on results when meters/tbl present |
 | Multi-floor viz | floors≥2 → stacked schematic + honesty caption |
 | DinD CLI | `capability_status().docker_available` true with sock only (CLI in image) |
-| G14 campaign | bill-window AMY + scorecard NMBE/CV(RMSE) or honest fail |
+| G14 campaign | bill-window AMY + `months_compared` ≈ bill months (cross-year OK) + NMBE/CV(RMSE) or honest fail |
 | Client package | Twin builds report + xlsx + zip; downloads work |
 
 One live sim is **not** enough. Really try the loop — baseline + hypotheses —

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/CALIBRATE_AND_DELIVERABLES.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/CALIBRATE_AND_DELIVERABLES.md
@@ -31,15 +31,22 @@ docker exec -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace vibe20 \
 
 What it does:
 
-1. Derives `data_window` from bill `YYYY-MM` months (first→last).
-2. Fetches Open-Meteo AMY when `weather_observed.csv` is missing (needs lat/lon).
+1. Derives `data_window` from bill `YYYY-MM` months (first→last) and **replaces**
+   any dump telemetry window (stale `span_hours` kept under `dump_data_window`).
+2. Fetches Open-Meteo AMY when `weather_observed.csv` is missing **or** does not
+   cover the bill window (off-window dump weather is renamed
+   `weather_observed_DUMP_STASH_*.csv`). Needs lat/lon.
 3. Runs `run_calibration` with monthly meters, W2b full-day EPW clip via `simulate`,
    optional hard-size (W3b refuse band).
-4. Scores dual-fuel monthly G14; may apply `prototype_area_scale` to modeled kWh
-   (stamped — not site CAD).
+4. Scores dual-fuel monthly G14 with **multi-year-aware** bare-month join
+   (Dec’24–Nov’25 bills → expect `months_compared` ≈ 12, not 1). May apply
+   `prototype_area_scale` to modeled kWh (stamped — not site CAD).
 5. Publishes `runs/calibrate_<id>/` + `calibration_scorecard.json` +
    `campaign_stamp.json`.
 6. Builds client package under `.artifacts/deliverable_calibrate_*`.
+
+Image tip: editable `pip install -e ".[studio]"` so `/app/wattlab` is the only
+import tree (no dual `/app` vs site-packages drift).
 
 Dry-run: `--dry-run` prints the plan without Docker.
 
@@ -80,3 +87,6 @@ constrain plant → schedules → **then** AMY + `calibrate-campaign`. Expect
 | Troy | User label `troy` → climate catalog detroit (not silent Madison) |
 | DinD | Image includes Docker **CLI**; sock alone is not enough |
 | Host drift | Prefer `docker exec vibe20 wattlab …` |
+| ARTIFACTS | No inner `ARTIFACTS` re-import in `run_calibration` (UnboundLocalError) |
+| G14 year | Cross-year bill windows join all months in `data_window` |
+| Dump wx | Off-window `weather_observed.csv` stashed before Open-Meteo |

--- a/vibe_code_apps_20/wattlab/calibrate.py
+++ b/vibe_code_apps_20/wattlab/calibrate.py
@@ -389,6 +389,73 @@ def load_utility_bills(bundle: Path, seed: dict[str, Any]) -> list[dict[str, Any
     return out
 
 
+def month_keys_for_data_window(data_window: dict[str, Any] | None) -> list[str]:
+    """Inclusive ``YYYY-MM`` keys from ``data_window`` start→end."""
+    if not data_window:
+        return []
+    start_raw = (
+        data_window.get("start_utc")
+        or data_window.get("start")
+        or data_window.get("start_date")
+    )
+    end_raw = (
+        data_window.get("end_utc")
+        or data_window.get("end")
+        or data_window.get("end_date")
+    )
+    if not isinstance(start_raw, str) or not isinstance(end_raw, str):
+        return []
+    if len(start_raw) < 7 or len(end_raw) < 7:
+        return []
+    try:
+        y0, m0 = int(start_raw[:4]), int(start_raw[5:7])
+        y1, m1 = int(end_raw[:4]), int(end_raw[5:7])
+    except (TypeError, ValueError):
+        return []
+    if not (1 <= m0 <= 12 and 1 <= m1 <= 12):
+        return []
+    keys: list[str] = []
+    y, m = y0, m0
+    # Cap at 36 months to avoid runaway loops on bad windows.
+    for _ in range(36):
+        keys.append(f"{y:04d}-{m:02d}")
+        if (y, m) >= (y1, m1):
+            break
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+    return keys
+
+
+def calendar_month_key_map(
+    window_keys: list[str],
+) -> tuple[dict[int, str], str | None]:
+    """Map calendar month 1–12 → unique ``YYYY-MM`` in the window.
+
+    Returns an empty map + reason when the same calendar month appears twice
+    (RunPeriod longer than 12 months) — refuse silent wrong joins.
+    """
+    by_m: dict[int, str] = {}
+    for key in window_keys:
+        if len(key) < 7 or key[4] != "-":
+            continue
+        try:
+            month_num = int(key[5:7])
+        except ValueError:
+            continue
+        if not 1 <= month_num <= 12:
+            continue
+        if month_num in by_m:
+            return (
+                {},
+                "data_window spans duplicate calendar months "
+                f"({by_m[month_num]} and {key}); refuse bare-month join",
+            )
+        by_m[month_num] = key
+    return by_m, None
+
+
 def compare_bills_to_monthly(
     bills: list[dict[str, Any]],
     monthly: list[dict[str, Any]],
@@ -397,12 +464,18 @@ def compare_bills_to_monthly(
 ) -> dict[str, Any]:
     """Dual-fuel monthly G14 compare (electricity kWh + gas therms when present).
 
-    Keys months as ``YYYY-MM`` when available. When bill years and simulation /
-    telemetry windows do not overlap, returns ``period_mismatch`` and does not
-    report a false G14 pass on coincidental month numbers.
+    Keys months as ``YYYY-MM`` when available. Bare E+ months (1–12) are stamped
+    from the full ``data_window`` span (multi-year aware). When bill years and
+    simulation / telemetry windows do not overlap, returns ``period_mismatch``
+    and does not report a false G14 pass on coincidental month numbers.
     """
+    window_keys = month_keys_for_data_window(data_window)
+    cal_map, cal_dup_reason = calendar_month_key_map(window_keys)
+
     sim_year: int | None = None
-    if data_window:
+    if window_keys:
+        sim_year = int(window_keys[0][:4])
+    elif data_window:
         for k in ("start_utc", "end_utc", "start", "end"):
             v = data_window.get(k)
             if isinstance(v, str) and len(v) >= 4 and v[:4].isdigit():
@@ -412,14 +485,29 @@ def compare_bills_to_monthly(
     bill_years = _bill_calendar_years(bills)
     # Infer sim year from monthly rows when present as YYYY-MM.
     for m in monthly:
-        key = normalize_bill_month_key(m.get("month") or m.get("period"), default_year=sim_year)
+        key = normalize_bill_month_key(m.get("month") or m.get("period"))
         if key and not key.startswith("0001-"):
             sim_year = int(key[:4])
             break
 
     period_mismatch = False
     mismatch_reason = ""
-    if bill_years and sim_year is not None and sim_year not in bill_years:
+    if cal_dup_reason:
+        period_mismatch = True
+        mismatch_reason = cal_dup_reason
+    elif bill_years and window_keys:
+        bill_keys = {
+            normalize_bill_month_key(b.get("month") or b.get("period"))
+            for b in bills
+        }
+        bill_keys.discard(None)
+        if bill_keys and not (bill_keys & set(window_keys)):
+            period_mismatch = True
+            mismatch_reason = (
+                f"bill months do not overlap data_window "
+                f"{window_keys[0]}…{window_keys[-1]}"
+            )
+    elif bill_years and sim_year is not None and sim_year not in bill_years:
         # Also accept adjacent-year windows that still share YYYY-MM keys below.
         period_mismatch = True
         mismatch_reason = (
@@ -429,8 +517,27 @@ def compare_bills_to_monthly(
 
     by_m: dict[str, dict[str, Any]] = {}
     for m in monthly:
-        key = normalize_bill_month_key(m.get("month") or m.get("period"), default_year=sim_year)
-        if key:
+        raw = m.get("month") or m.get("period")
+        key = normalize_bill_month_key(raw)
+        if key and not key.startswith("0001-"):
+            by_m[key] = m
+            continue
+        # Bare month 1–12: map via multi-year window when available.
+        month_num: int | None = None
+        if key and key.startswith("0001-"):
+            month_num = int(key[5:7])
+        elif isinstance(raw, (int, float)) or (
+            isinstance(raw, str) and raw.strip().isdigit()
+        ):
+            try:
+                month_num = int(float(raw))
+            except (TypeError, ValueError):
+                month_num = None
+        if month_num is not None and cal_map and month_num in cal_map:
+            by_m[cal_map[month_num]] = m
+        elif month_num is not None and sim_year is not None and not cal_map:
+            by_m[f"{sim_year}-{month_num:02d}"] = m
+        elif key:
             by_m[key] = m
 
     obs_kwh: list[float] = []
@@ -446,7 +553,7 @@ def compare_bills_to_monthly(
         # If bills are real YYYY-MM and sim is legacy 0001-MM, try month-only
         # only when years are unknown/compatible — never across mismatched years.
         row = by_m.get(key)
-        if row is None and key.startswith("0001-") is False and sim_year is None:
+        if row is None and key.startswith("0001-") is False and sim_year is None and not cal_map:
             # Sim months are bare 1–12 → 0001-MM
             row = by_m.get(f"0001-{key[5:]}")
         if row is None and key.startswith("0001-"):
@@ -531,6 +638,7 @@ def compare_bills_to_monthly(
         "period_mismatch_reason": mismatch_reason,
         "bill_years": sorted(bill_years),
         "simulation_year": sim_year,
+        "simulation_months": window_keys or None,
         "per_month": per_month,
         "thresholds": {"nmbe_pct": NMBE_PASS, "cvrmse_pct": CVRMSE_PASS},
     }
@@ -1068,7 +1176,6 @@ def run_calibration(
             scorecard["studio_run_dir"] = str(published)
             try:
                 from wattlab.deliverables import package_deliverables
-                from wattlab.config import ARTIFACTS
 
                 deliv_dir = ARTIFACTS / f"deliverable_calibrate_{run_id}"
                 deliv = package_deliverables(

--- a/vibe_code_apps_20/wattlab/calibrate_campaign.py
+++ b/vibe_code_apps_20/wattlab/calibrate_campaign.py
@@ -62,6 +62,112 @@ def data_window_from_bill_months(months: list[str]) -> dict[str, str]:
     }
 
 
+def weather_csv_covers_window(
+    wx_path: Path,
+    data_window: dict[str, Any],
+    *,
+    tolerance_hours: float = 48.0,
+) -> bool:
+    """True when ``weather_observed.csv`` timestamps cover bill ``data_window``."""
+    from wattlab.twin import _parse_window_date
+
+    start = _parse_window_date(
+        data_window.get("start_utc")
+        or data_window.get("start")
+        or data_window.get("start_date")
+    )
+    end = _parse_window_date(
+        data_window.get("end_utc")
+        or data_window.get("end")
+        or data_window.get("end_date")
+    )
+    if start is None or end is None or not Path(wx_path).is_file():
+        return False
+
+    import csv
+    from datetime import datetime, timedelta, timezone
+
+    ts_vals: list[datetime] = []
+    with Path(wx_path).open(encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        for i, row in enumerate(reader):
+            raw = (
+                row.get("timestamp_utc")
+                or row.get("timestamp")
+                or row.get("datetime")
+                or ""
+            )
+            if not raw:
+                continue
+            try:
+                ts = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            ts_vals.append(ts)
+            if i > 200_000:
+                break
+    if not ts_vals:
+        return False
+
+    wx_start = min(ts_vals).date()
+    wx_end = max(ts_vals).date()
+    tol_days = max(1, int(timedelta(hours=tolerance_hours).total_seconds() // 86400))
+    return (wx_start <= start + timedelta(days=tol_days)) and (
+        wx_end >= end - timedelta(days=tol_days)
+    )
+
+
+def ensure_bill_aligned_weather(
+    work: Path,
+    seed: dict[str, Any],
+    data_window: dict[str, Any],
+    *,
+    fetch_open_meteo_if_missing: bool = True,
+) -> dict[str, Any]:
+    """Stash dump weather that misses the bill window; fetch Open-Meteo AMY if needed.
+
+    Returns plan fragment keys: ``weather_aligned``, ``stashed_weather``, ``open_meteo``.
+    """
+    from wattlab.twin import maybe_build_amy_from_open_meteo
+
+    out: dict[str, Any] = {"weather_aligned": False}
+    wx = Path(work) / "weather_observed.csv"
+    need_fetch = False
+
+    if wx.is_file():
+        if weather_csv_covers_window(wx, data_window):
+            out["weather_aligned"] = True
+            out["weather_source"] = "existing_weather_observed"
+            return out
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        stash = Path(work) / f"weather_observed_DUMP_STASH_{stamp}.csv"
+        wx.rename(stash)
+        out["stashed_weather"] = str(stash)
+        out["stash_reason"] = "dump weather does not cover bill data_window"
+        need_fetch = True
+    else:
+        need_fetch = True
+
+    if not fetch_open_meteo_if_missing:
+        out["weather_aligned"] = False
+        return out
+
+    amy_meta = maybe_build_amy_from_open_meteo(
+        seed, work, has_observed_weather=False
+    )
+    if amy_meta is None:
+        raise ValueError(
+            "NEEDS_INPUT: weather_observed.csv missing or off-window and Open-Meteo "
+            "AMY could not be built (need lat/lon + data_window)"
+        )
+    out["open_meteo"] = amy_meta
+    out["weather_aligned"] = True
+    out["weather_source"] = "open_meteo_amy"
+    return out
+
+
 def scale_monthly_energy(
     monthly: list[dict[str, Any]],
     *,
@@ -88,7 +194,6 @@ def run_calibrate_campaign(
 ) -> dict[str, Any]:
     """Bills → data_window → AMY (if needed) → ``run_calibration`` → Twin publish."""
     from wattlab.calibrate import load_utility_bills, run_calibration, _read_json
-    from wattlab.twin import maybe_build_amy_from_open_meteo
 
     bundle = Path(bundle)
     work = bundle
@@ -126,7 +231,11 @@ def run_calibrate_campaign(
     months = [str(b.get("month") or b.get("period") or "")[:7] for b in bills]
     window = data_window_from_bill_months(months)
     seed = dict(seed)
-    seed["data_window"] = {**(seed.get("data_window") or {}), **window}
+    dump_window = seed.get("data_window")
+    if isinstance(dump_window, dict) and dump_window:
+        seed["dump_data_window"] = dict(dump_window)
+    # Bill window replaces dump telemetry window (do not shallow-merge stale fields).
+    seed["data_window"] = dict(window)
     if lat is not None:
         seed["lat"] = float(lat)
     if lon is not None:
@@ -157,22 +266,21 @@ def run_calibrate_campaign(
             "until G14 passes with honest stamps (or document failure → ESCO proxies)."
         ),
     }
+    if seed.get("dump_data_window"):
+        plan["dump_data_window"] = seed["dump_data_window"]
     if dry_run:
         plan["dry_run"] = True
         return plan
 
-    has_wx = (work / "weather_observed.csv").is_file()
-    amy_meta = None
-    if fetch_open_meteo_if_missing and not has_wx:
-        amy_meta = maybe_build_amy_from_open_meteo(
-            seed, work, has_observed_weather=False
-        )
-        if amy_meta is None:
-            raise ValueError(
-                "NEEDS_INPUT: weather_observed.csv missing and Open-Meteo AMY could not "
-                "be built (need lat/lon + data_window)"
-            )
-        plan["open_meteo"] = amy_meta
+    wx_plan = ensure_bill_aligned_weather(
+        work,
+        seed,
+        window,
+        fetch_open_meteo_if_missing=fetch_open_meteo_if_missing,
+    )
+    plan.update({k: v for k, v in wx_plan.items() if k != "weather_aligned"})
+    if wx_plan.get("open_meteo"):
+        plan["open_meteo"] = wx_plan["open_meteo"]
 
     scorecard = run_calibration(
         work,


### PR DESCRIPTION
## Summary
- Fix P0 `ARTIFACTS` UnboundLocalError in `run_calibration` (remove inner re-import).
- Multi-year-aware bill↔sim month join so Dec'24–Nov'25 bills get `months_compared=12`.
- Bill `data_window` replaces dump window (`dump_data_window` audit); stash off-window `weather_observed.csv` before Open-Meteo.
- Editable Docker install so `import wattlab` is `/app/wattlab` only.

## Test plan
- [x] `pytest tests/test_import_bills.py tests/test_deliverables_campaign.py tests/test_calibration.py`
- [ ] PR CI green (incl. vibe20-ghcr amd64 smoke)
- [ ] Merge → watch `vibe20-ghcr` multi-arch publish
- [ ] `ghcr.io/bbartling/vibe20:latest` moves past `ff5caaab`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Calibration campaigns now align simulation periods with the complete billing-month window, including cross-year ranges.
  - Weather data is automatically checked against the billing period; unsuitable weather files are preserved and replacement weather can be generated when needed.

- **Bug Fixes**
  - Billing comparisons no longer produce misleading results from matching month numbers across different years.
  - Campaign scoring now reports the simulation months used for comparison.

- **Documentation**
  - Updated calibration guidance and validation requirements for billing windows and weather coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->