### PR TITLE
feat(vibe20): Studio bootstrap + tabbed Fuel Phase 1

### DIFF
--- a/vibe_code_apps_20/studio.py
+++ b/vibe_code_apps_20/studio.py
@@ -22,8 +22,27 @@ PAGES = [
 ]
 
 
+def _apply_studio_bootstrap_once() -> None:
+    """Auto-load Fuel/Twin from studio_bootstrap.json (once per browser session)."""
+    if st.session_state.get("_studio_bootstrapped"):
+        return
+    try:
+        from wattlab.studio.bootstrap import apply_bootstrap_to_session
+
+        result = apply_bootstrap_to_session(st.session_state)
+    except Exception as exc:  # noqa: BLE001 — never crash Studio on bootstrap
+        st.session_state["_studio_bootstrapped"] = True
+        st.sidebar.warning(f"Bootstrap skipped: {exc}")
+        return
+    if result.get("banner"):
+        st.sidebar.success(result["banner"])
+    for note in result.get("needs_input") or []:
+        st.sidebar.info(f"NEEDS_INPUT: {note}")
+
+
 def main() -> None:
     ensure_workspace()
+    _apply_studio_bootstrap_once()
     invalidate_dependent_state(
         st.session_state,
         profile=st.session_state.get("studio_profile"),

--- a/vibe_code_apps_20/tests/test_studio_bootstrap.py
+++ b/vibe_code_apps_20/tests/test_studio_bootstrap.py
@@ -1,0 +1,185 @@
+"""Unit + AppTest coverage for Studio bootstrap + Fuel tabs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("streamlit")
+
+from streamlit.testing.v1 import AppTest
+
+from wattlab.studio.bootstrap import (
+    apply_bootstrap_to_session,
+    build_bootstrap_payload,
+    resolve_bootstrap_path,
+    write_bootstrap,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+STUDIO = ROOT / "studio.py"
+TIMEOUT = 60
+FIXTURE_CAMPUS = ROOT / "tests" / "fixtures" / "shared_meter_campus" / "campus.json"
+MINIMAL_DUMP = ROOT / "tests" / "fixtures" / "minimal_wattlab_dump"
+EPLUS_FIXTURE = ROOT / "tests" / "fixtures" / "eplusout" / "eplusout.csv"
+
+
+def test_build_and_write_bootstrap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    payload = build_bootstrap_payload(
+        energy_campus_dir="uploads/energy/campus",
+        preferred_run_id="run_a",
+        notes="test",
+    )
+    assert payload["version"] == 1
+    written = write_bootstrap(payload)
+    assert any(p.name == "studio_bootstrap.json" for p in written)
+    assert (tmp_path / "studio_bootstrap.json").is_file()
+    assert resolve_bootstrap_path(tmp_path) is not None
+
+
+def test_bootstrap_disable_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    write_bootstrap(build_bootstrap_payload(preferred_run_id="x"))
+    monkeypatch.setenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", "1")
+    assert resolve_bootstrap_path(tmp_path) is None
+
+
+def test_apply_bootstrap_loads_campus_and_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    energy = tmp_path / "uploads" / "energy" / "shared"
+    energy.mkdir(parents=True)
+    # Copy fixture campus package
+    import shutil
+
+    src = FIXTURE_CAMPUS.parent
+    for item in src.iterdir():
+        dest = energy / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest)
+        else:
+            shutil.copy2(item, dest)
+
+    run_dir = tmp_path / "runs" / "boot_run_1"
+    run_dir.mkdir(parents=True)
+    if EPLUS_FIXTURE.is_file():
+        shutil.copy2(EPLUS_FIXTURE, run_dir / "eplusout.csv")
+    else:
+        (run_dir / "eplusout.csv").write_text("Date/Time,Zone\n", encoding="utf-8")
+    (tmp_path / "runs" / "CURRENT_RUN.txt").write_text(str(run_dir), encoding="utf-8")
+
+    write_bootstrap(
+        build_bootstrap_payload(
+            energy_campus_dir="uploads/energy/shared",
+            preferred_run_id="boot_run_1",
+        )
+    )
+    state: dict = {}
+    result = apply_bootstrap_to_session(state, workspace=tmp_path)
+    assert result["applied"] is True
+    assert "studio_campus" in state
+    assert state.get("studio_active_run")
+    assert state["_studio_bootstrapped"] is True
+    # Idempotent
+    result2 = apply_bootstrap_to_session(state, workspace=tmp_path)
+    assert result2.get("skipped") == "already_bootstrapped"
+
+
+def test_apply_bootstrap_missing_campus_no_crash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    write_bootstrap(
+        build_bootstrap_payload(energy_campus_dir="uploads/energy/does_not_exist")
+    )
+    state: dict = {}
+    result = apply_bootstrap_to_session(state, workspace=tmp_path)
+    assert result["applied"] is True
+    assert result["needs_input"]
+    assert "studio_campus" not in state
+
+
+def test_studio_bootstrap_apptest_zero_clicks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    monkeypatch.delenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", raising=False)
+    import shutil
+
+    energy = tmp_path / "uploads" / "energy" / "shared"
+    energy.mkdir(parents=True)
+    src = FIXTURE_CAMPUS.parent
+    for item in src.iterdir():
+        dest = energy / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest)
+        else:
+            shutil.copy2(item, dest)
+    run_dir = tmp_path / "runs" / "boot_run_1"
+    run_dir.mkdir(parents=True)
+    if EPLUS_FIXTURE.is_file():
+        shutil.copy2(EPLUS_FIXTURE, run_dir / "eplusout.csv")
+    else:
+        (run_dir / "eplusout.csv").write_text("Date/Time,Zone\n", encoding="utf-8")
+    write_bootstrap(
+        build_bootstrap_payload(
+            energy_campus_dir="uploads/energy/shared",
+            preferred_run_id="boot_run_1",
+        )
+    )
+
+    at = AppTest.from_file(str(STUDIO), default_timeout=TIMEOUT)
+    at.run()
+    assert not at.exception
+    assert "studio_campus" in at.session_state or "studio_energy" in at.session_state
+    # Fuel without Uploads clicks
+    at.radio(key="studio_page").set_value("Fuel dashboard").run()
+    assert not at.exception
+    metric_labels = [m.label for m in at.metric]
+    assert any("EUI" in (lab or "") for lab in metric_labels)
+    # Twin without Refresh clicks
+    at.radio(key="studio_page").set_value("Twin / calibrate").run()
+    assert not at.exception
+    assert "studio_active_run" in at.session_state
+
+
+def test_studio_pages_no_exception_when_bootstrapped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    monkeypatch.delenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", raising=False)
+    import shutil
+
+    energy = tmp_path / "uploads" / "energy" / "shared"
+    energy.mkdir(parents=True)
+    src = FIXTURE_CAMPUS.parent
+    for item in src.iterdir():
+        dest = energy / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest)
+        else:
+            shutil.copy2(item, dest)
+    write_bootstrap(build_bootstrap_payload(energy_campus_dir="uploads/energy/shared"))
+    at = AppTest.from_file(str(STUDIO), default_timeout=TIMEOUT)
+    at.run()
+    assert not at.exception
+    for page in ("Uploads", "Fuel dashboard", "Twin / calibrate", "ECMs"):
+        at.radio(key="studio_page").set_value(page).run()
+        assert not at.exception, page
+
+
+def test_fuel_tabs_render_with_fixture_campus():
+    at = AppTest.from_file(str(STUDIO), default_timeout=TIMEOUT)
+    at.run()
+    assert not at.exception
+    at.text_input(key="uploads_energy_path").set_value(str(FIXTURE_CAMPUS.parent)).run()
+    at.button(key="uploads_load_energy").click().run()
+    assert not at.exception
+    at.radio(key="studio_page").set_value("Fuel dashboard").run()
+    assert not at.exception
+    # Tab labels present in markdown/text
+    blob = " ".join(str(getattr(el, "value", el)) for el in list(at.markdown) + list(at.header))
+    # Tabs may not expose labels via markdown — ensure metrics + synth still work
+    metric_labels = [m.label for m in at.metric]
+    assert any("EUI" in (lab or "") for lab in metric_labels)
+    at.button(key="fuel_dash_synth").click().run()
+    assert not at.exception

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -201,6 +201,8 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 19. Twin **Build client package** → preview report + download md/xlsx/zip without Streamlit exceptions.
 20. **Schedule:File DinD:** File Name `/work/in/<csv>` + CSV staged (not absolute `/data/...`).
 21. Archive hygiene: root-owned `runs/` via `docker exec -u 0` when needed.
+22. After publish: `wattlab studio-bootstrap --campus … --run-id …` so human opens Studio
+    with Fuel + Twin already loaded (no Uploads/Refresh clicks).
 
 ## PASS / FAIL
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -81,8 +81,20 @@ Archive root-owned runs when needed:
 docker exec -u 0 vibe20 bash -lc 'mkdir -p /data/runs/_archive && mv /data/runs/<old> /data/runs/_archive/'
 ```
 
-Studio bootstrap (zero-click Fuel/Twin): `wattlab studio-bootstrap …` writes
-`/data/studio_bootstrap.json` — see tip docs after that CLI ships.
+Studio bootstrap (zero-click Fuel/Twin):
+
+```bash
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 \
+  wattlab studio-bootstrap \
+  --campus /data/uploads/energy/my_campus \
+  --dump /data/uploads/dump/wattlab_dump.zip \
+  --run-id calibrate_YYYYMMDDTHHMMSSZ \
+  --answers /data/reports/answers.json
+```
+
+Writes `/data/studio_bootstrap.json` (+ `.last_studio_session.json`). Next Studio
+browser session auto-loads Fuel campus + Twin preferred run (sidebar banner).
+Disable in CI: `WATTLAB_STUDIO_BOOTSTRAP_DISABLE=1`.
 
 ## Agent flow (no git)
 

--- a/vibe_code_apps_20/wattlab/cli.py
+++ b/vibe_code_apps_20/wattlab/cli.py
@@ -27,6 +27,7 @@ def _usage() -> str:
         "  benchmark    Campus bill EUIs, allocation scenarios, peer-band compare\n"
         "  seed         Inspect a vibe19 WattLab dump (summary + gap report)\n"
         "               also: wattlab seed import-bills --electric CSV --gas CSV --out utility_bills.csv\n"
+        "  studio-bootstrap  Write studio_bootstrap.json for Streamlit auto-load\n"
         "  explore-existing  Existing Building Hypothesis Lab orchestration\n"
         "  hypothesis-lab    Alias for explore-existing\n"
         "  ecm          Canonical ECM catalog (list/describe/package/audit)\n"
@@ -158,6 +159,10 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_benchmark(rest)
     if cmd == "seed":
         return _cmd_seed(rest)
+    if cmd in {"studio-bootstrap", "studio_bootstrap"}:
+        from wattlab.studio.bootstrap import main as m
+
+        return int(m(rest) or 0)
     if cmd in {"explore-existing", "hypothesis-lab"}:
         from wattlab.existing_building.cli import main as m
 

--- a/vibe_code_apps_20/wattlab/studio/bootstrap.py
+++ b/vibe_code_apps_20/wattlab/studio/bootstrap.py
@@ -1,0 +1,319 @@
+"""Agent → Streamlit Studio bootstrap (no HTTP API).
+
+After headless ``publish_run_for_studio`` / calibrate-campaign, write
+``studio_bootstrap.json`` under the shared workspace so the next Streamlit
+start auto-loads Fuel + Twin without Uploads / Refresh clicks.
+
+Resolve order:
+1. ``WATTLAB_STUDIO_BOOTSTRAP`` env (absolute file path)
+2. ``$WATTLAB_STUDIO_WORKSPACE/studio_bootstrap.json``
+3. ``$WATTLAB_STUDIO_WORKSPACE/.last_studio_session.json``
+
+Disable: ``WATTLAB_STUDIO_BOOTSTRAP_DISABLE=1``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+BOOTSTRAP_VERSION = 1
+DEFAULT_BOOTSTRAP_NAME = "studio_bootstrap.json"
+FALLBACK_BOOTSTRAP_NAME = ".last_studio_session.json"
+
+
+def bootstrap_disabled() -> bool:
+    return (os.environ.get("WATTLAB_STUDIO_BOOTSTRAP_DISABLE") or "").strip() in {
+        "1",
+        "true",
+        "True",
+        "yes",
+        "YES",
+    }
+
+
+def resolve_bootstrap_path(workspace: Path | None = None) -> Path | None:
+    """Return bootstrap file to apply, or None if missing / disabled."""
+    if bootstrap_disabled():
+        return None
+    env = (os.environ.get("WATTLAB_STUDIO_BOOTSTRAP") or "").strip()
+    if env:
+        p = Path(env).expanduser()
+        return p if p.is_file() else None
+    from wattlab.studio.workspace import workspace_root
+
+    root = Path(workspace) if workspace is not None else workspace_root()
+    for name in (DEFAULT_BOOTSTRAP_NAME, FALLBACK_BOOTSTRAP_NAME):
+        p = root / name
+        if p.is_file():
+            return p
+    return None
+
+
+def build_bootstrap_payload(
+    *,
+    energy_campus_dir: str | Path | None = None,
+    dump_zip: str | Path | None = None,
+    preferred_run_id: str | None = None,
+    answers_path: str | Path | None = None,
+    auto_refresh_runs: bool = True,
+    notes: str = "",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "version": BOOTSTRAP_VERSION,
+        "auto_refresh_runs": bool(auto_refresh_runs),
+        "notes": notes
+        or "Written by agent after publish_run_for_studio for Studio auto-load",
+    }
+    if energy_campus_dir:
+        payload["energy_campus_dir"] = str(energy_campus_dir)
+    if dump_zip:
+        payload["dump_zip"] = str(dump_zip)
+    if preferred_run_id:
+        payload["preferred_run_id"] = str(preferred_run_id)
+    if answers_path:
+        payload["answers_path"] = str(answers_path)
+    return payload
+
+
+def write_bootstrap(
+    payload: dict[str, Any],
+    *,
+    path: str | Path | None = None,
+    also_fallback: bool = True,
+) -> list[Path]:
+    """Write bootstrap JSON under the Studio workspace."""
+    from wattlab.studio.workspace import ensure_workspace
+
+    root = ensure_workspace()
+    if payload.get("version") != BOOTSTRAP_VERSION:
+        payload = {**payload, "version": BOOTSTRAP_VERSION}
+    targets: list[Path] = []
+    if path is not None:
+        targets.append(Path(path))
+    else:
+        targets.append(root / DEFAULT_BOOTSTRAP_NAME)
+    if also_fallback:
+        fb = root / FALLBACK_BOOTSTRAP_NAME
+        if fb not in targets:
+            targets.append(fb)
+    written: list[Path] = []
+    text = json.dumps(payload, indent=2)
+    for t in targets:
+        t.parent.mkdir(parents=True, exist_ok=True)
+        t.write_text(text, encoding="utf-8")
+        written.append(t)
+    return written
+
+
+def _resolve_under_workspace(root: Path, rel: str | None) -> Path | None:
+    if not rel:
+        return None
+    p = Path(rel)
+    if not p.is_absolute():
+        p = root / p
+    return p if p.exists() else None
+
+
+def _ss_get(session_state: Any, key: str, default: Any = None) -> Any:
+    """Read session_state without triggering Streamlit's ``__getattr__`` for ``.get``."""
+    try:
+        if key in session_state:
+            return session_state[key]
+    except TypeError:
+        pass
+    if isinstance(session_state, dict):
+        return session_state.get(key, default)
+    try:
+        return session_state[key]
+    except (KeyError, AttributeError, TypeError):
+        return default
+
+
+def _ss_set(session_state: Any, key: str, value: Any) -> None:
+    session_state[key] = value
+
+
+def apply_bootstrap_to_session(
+    session_state: Any,
+    *,
+    workspace: Path | None = None,
+) -> dict[str, Any]:
+    """Load campus / dump / preferred run into Streamlit session_state.
+
+    Idempotent when ``session_state["_studio_bootstrapped"]`` is already set.
+    Never raises on missing paths — returns NEEDS_INPUT notes instead.
+    """
+    result: dict[str, Any] = {
+        "applied": False,
+        "banner": None,
+        "needs_input": [],
+        "errors": [],
+    }
+    if _ss_get(session_state, "_studio_bootstrapped"):
+        result["skipped"] = "already_bootstrapped"
+        return result
+
+    path = resolve_bootstrap_path(workspace)
+    if path is None:
+        result["skipped"] = "no_bootstrap_file"
+        return result
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        result["errors"].append(f"bootstrap unreadable: {exc}")
+        _ss_set(session_state, "_studio_bootstrapped", True)
+        return result
+
+    from wattlab.studio.workspace import ensure_workspace, runs_dir
+
+    root = Path(workspace) if workspace is not None else ensure_workspace()
+    notes: list[str] = []
+
+    campus_rel = payload.get("energy_campus_dir")
+    campus_path = _resolve_under_workspace(root, campus_rel)
+    if campus_rel and campus_path is None:
+        result["needs_input"].append(f"energy_campus_dir missing: {campus_rel}")
+    elif campus_path is not None:
+        try:
+            from wattlab.energy_use import load_energy_use_package
+
+            load_target = campus_path
+            if campus_path.is_file() and campus_path.name == "campus.json":
+                load_target = campus_path.parent
+            pkg = load_energy_use_package(load_target)
+            _ss_set(session_state, "studio_energy", pkg)
+            _ss_set(session_state, "studio_campus", pkg.campus)
+            notes.append(f"Fuel campus ← {campus_rel}")
+        except Exception as exc:  # noqa: BLE001
+            result["needs_input"].append(f"campus load failed: {exc}")
+
+    dump_rel = payload.get("dump_zip")
+    dump_path = _resolve_under_workspace(root, dump_rel)
+    if dump_rel and dump_path is None:
+        result["needs_input"].append(f"dump_zip missing: {dump_rel}")
+    elif dump_path is not None:
+        try:
+            from wattlab.seed import load_bundle
+
+            bundle = load_bundle(dump_path)
+            _ss_set(session_state, "studio_bundle", bundle)
+            notes.append(f"Twin dump ← {dump_rel}")
+        except Exception as exc:  # noqa: BLE001
+            result["needs_input"].append(f"dump load failed: {exc}")
+
+    answers_rel = payload.get("answers_path")
+    answers_path = _resolve_under_workspace(root, answers_rel)
+    if answers_rel and answers_path is None:
+        result["needs_input"].append(f"answers_path missing: {answers_rel}")
+    elif answers_path is not None:
+        try:
+            _ss_set(
+                session_state,
+                "studio_answers",
+                json.loads(answers_path.read_text(encoding="utf-8")),
+            )
+            notes.append(f"answers ← {answers_rel}")
+        except Exception as exc:  # noqa: BLE001
+            result["needs_input"].append(f"answers load failed: {exc}")
+
+    if payload.get("auto_refresh_runs", True):
+        rid = payload.get("preferred_run_id")
+        run_dir: Path | None = None
+        if rid:
+            cand = runs_dir() / str(rid)
+            if cand.is_dir():
+                run_dir = cand
+            else:
+                result["needs_input"].append(f"preferred_run_id missing under runs/: {rid}")
+        if run_dir is None:
+            pointer = runs_dir() / "CURRENT_RUN.txt"
+            if pointer.is_file():
+                try:
+                    p = Path(pointer.read_text(encoding="utf-8").strip())
+                    if p.is_dir():
+                        run_dir = p
+                except OSError:
+                    pass
+        if run_dir is not None:
+            _ss_set(session_state, "studio_active_run", str(run_dir.resolve()))
+            notes.append(f"Twin run ← {run_dir.name}")
+
+    _ss_set(session_state, "_studio_bootstrapped", True)
+    _ss_set(session_state, "_studio_bootstrap_path", str(path))
+    _ss_set(session_state, "_studio_bootstrap_notes", notes)
+    result["applied"] = True
+    result["path"] = str(path)
+    result["notes"] = notes
+    if notes or result["needs_input"]:
+        result["banner"] = (
+            f"Bootstrapped from {path.name}"
+            + (f" — {'; '.join(notes)}" if notes else "")
+        )
+    else:
+        result["banner"] = f"Bootstrapped from {path.name}"
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: ``wattlab studio-bootstrap --campus … --dump … --run-id …``."""
+    import argparse
+    import sys
+
+    p = argparse.ArgumentParser(
+        description="Write studio_bootstrap.json for Streamlit auto-load"
+    )
+    p.add_argument("--campus", type=Path, default=None, help="energy campus dir or campus.json")
+    p.add_argument("--dump", type=Path, default=None, help="dump zip or folder")
+    p.add_argument("--run-id", type=str, default=None, help="preferred runs/<id>")
+    p.add_argument("--answers", type=Path, default=None)
+    p.add_argument("--notes", type=str, default="")
+    p.add_argument("--out", type=Path, default=None, help="override bootstrap path")
+    p.add_argument("--no-fallback", action="store_true")
+    args = p.parse_args(argv)
+
+    from wattlab.studio.workspace import ensure_workspace
+
+    root = ensure_workspace()
+
+    def _rel(path: Path | None) -> str | None:
+        if path is None:
+            return None
+        path = path.resolve()
+        try:
+            return str(path.relative_to(root)).replace("\\", "/")
+        except ValueError:
+            return str(path)
+
+    campus = args.campus
+    if campus is not None and campus.is_file() and campus.name == "campus.json":
+        campus = campus.parent
+
+    payload = build_bootstrap_payload(
+        energy_campus_dir=_rel(campus) if campus else None,
+        dump_zip=_rel(args.dump) if args.dump else None,
+        preferred_run_id=args.run_id,
+        answers_path=_rel(args.answers) if args.answers else None,
+        notes=args.notes,
+    )
+    if not any(
+        payload.get(k)
+        for k in ("energy_campus_dir", "dump_zip", "preferred_run_id", "answers_path")
+    ):
+        print(
+            json.dumps({"ok": False, "error": "NEEDS_INPUT: pass --campus and/or --dump and/or --run-id"}),
+            file=sys.stderr,
+        )
+        return 1
+    written = write_bootstrap(
+        payload, path=args.out, also_fallback=not args.no_fallback
+    )
+    print(json.dumps({"ok": True, "written": [str(w) for w in written], "payload": payload}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
@@ -1,4 +1,4 @@
-"""ESCO fuel dashboard — bills × Open-Meteo × peers (Excel-grade density)."""
+"""ESCO fuel dashboard — tabbed Plotly workspaces (Phase 1 monthly + peers)."""
 
 from __future__ import annotations
 
@@ -24,6 +24,16 @@ from wattlab.config import ARTIFACTS
 from wattlab.contracts import WeatherRequest
 from wattlab.weather.degree_days import DD_BASE_F
 from wattlab.weather.open_meteo import download_archive_weather
+
+_PHASE2_STUBS = (
+    "Interval Energy Analytics",
+    "Cost & Tariff",
+    "Carbon & Sustainability",
+    "Meter Explorer",
+    "Anomalies & Opportunities",
+    "Projects & M&V",
+    "Reports",
+)
 
 
 def _continuous_months(start: str, end: str) -> list[str]:
@@ -82,65 +92,29 @@ def _fetch_open_meteo(campus: Campus, lat: float, lon: float) -> tuple[pd.DataFr
     return df, meta.model_dump(mode="json")
 
 
-def render(*, campus: Campus | None = None) -> None:
-    import plotly.express as px
-    import plotly.graph_objects as go
+def _peer_rows(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for b in summary["buildings"]:
+        cmp = compare_eui(b["site_eui_kbtu_ft2"], b["property_type"])
+        rows.append(
+            {**b, **{f"peer_{k}": cmp[k] for k in ("p20", "p50", "p80", "band", "vs_median_pct")}}
+        )
+    return rows
 
-    st.header("Fuel dashboard — ESCO energy use")
-    st.caption(
-        f"Monthly bills, Open-Meteo HDD/CDD (base {DD_BASE_F:g}°F), peer EUI bands. "
-        "Load energy package on **Uploads**. Missing months stay blank — no fake continuity."
-    )
 
-    campus = campus or st.session_state.get("studio_campus") or st.session_state.get("fuel_weather_campus")
-    if campus is None:
-        energy = st.session_state.get("studio_energy")
-        if energy is not None and getattr(energy, "campus", None) is not None:
-            campus = energy.campus
-            st.session_state["studio_campus"] = campus
-    if campus is None:
-        st.info("Load an energy-use package on **Uploads** first (campus.json + bill CSVs).")
-        return
-
-    shared = [m.meter_id for m in campus.meters if m.shared]
-    if shared:
-        st.caption(f"Shared meter(s): {', '.join(shared)} — allocation is a scenario, not truth.")
-
-    alloc = st.selectbox(
-        "Shared-meter allocation",
-        list(ALLOCATION_METHODS[:3]),
-        format_func=lambda m: {
-            "area_weighted": "Area-weighted",
-            "equal": "Equal",
-            "gas_share": "Gas-share proxy",
-        }.get(m, m),
-        key="fuel_dash_allocation",
-    )
-
-    try:
-        summary = annual_summary(campus, allocation=alloc)
-    except ValueError as exc:
-        st.error(f"Could not annualize: {exc}")
-        return
-    st.session_state["studio_benchmark_summary"] = summary
-
+def _render_portfolio(summary: dict[str, Any], campus: Campus, px, go) -> None:
     w = summary["window"]
     a1, a2, a3, a4 = st.columns(4)
     a1.metric("Campus site EUI", f"{summary['campus']['site_eui_kbtu_ft2']} kBtu/ft²")
     a2.metric("Electric", f"{summary['campus']['kwh']:,.0f} kWh")
     a3.metric("Gas", f"{summary['campus']['mcf']:,.0f} Mcf")
     a4.metric("Window", f"{w['start']} → {w['end']}")
-
-    # Peer strip — explicit typical / band metrics (spreadsheet-style)
-    st.subheader("Site EUI vs peers (same property type)")
     st.caption(
-        "Peer p20 / p50 (typical) / p80 from public EPA Portfolio Manager / CBECS-style "
-        "registry (kBtu/ft²-yr). Twin page adds EnergyPlus model EUI beside these bands."
+        "Cost / carbon / anomaly KPIs: **NEEDS_INPUT** (not in monthly campus package)."
     )
-    rows = []
-    for b in summary["buildings"]:
-        cmp = compare_eui(b["site_eui_kbtu_ft2"], b["property_type"])
-        rows.append({**b, **{f"peer_{k}": cmp[k] for k in ("p20", "p50", "p80", "band", "vs_median_pct")}})
+
+    st.subheader("Site EUI vs peers (same property type)")
+    rows = _peer_rows(summary)
     dfb = pd.DataFrame(rows)
     b0 = rows[0]
     p1, p2, p3, p4 = st.columns(4)
@@ -148,17 +122,69 @@ def render(*, campus: Campus | None = None) -> None:
     p2.metric("Peer typical (p50)", f"{b0['peer_p50']} kBtu/ft²")
     p3.metric("Peer p20–p80", f"{b0['peer_p20']} – {b0['peer_p80']}")
     p4.metric("vs median", f"{b0['peer_vs_median_pct']:+.1f}% · {b0['peer_band']}")
+
+    fig_peer = go.Figure()
+    p20 = float(dfb["peer_p20"].iloc[0])
+    p50 = float(dfb["peer_p50"].iloc[0])
+    p80 = float(dfb["peer_p80"].iloc[0])
+    fig_peer.add_shape(
+        type="rect",
+        x0=p20,
+        x1=p80,
+        y0=-0.5,
+        y1=0.5,
+        fillcolor="rgba(44,160,44,0.18)",
+        line_width=0,
+    )
+    fig_peer.add_vline(x=p50, line_dash="dash", line_color="#2ca02c")
+    for _, r in dfb.iterrows():
+        fig_peer.add_scatter(
+            x=[r["site_eui_kbtu_ft2"]],
+            y=[0],
+            mode="markers+text",
+            marker=dict(symbol="diamond", size=16),
+            text=[r["label"]],
+            textposition="top center",
+            name=r["label"],
+        )
+    fig_peer.update_layout(
+        height=180,
+        margin=dict(l=10, r=10, t=10, b=10),
+        yaxis=dict(visible=False),
+        xaxis_title="Site EUI (kBtu/ft²-yr)",
+        showlegend=False,
+    )
+    st.plotly_chart(fig_peer, width="stretch", key="fuel_peer_eui_chart")
+
+    # Stacked monthly by commodity
+    totals = campus_fuel_totals(campus)
+    if not totals.empty:
+        pivot = (
+            totals.pivot_table(index="month", columns="fuel", values="kbtu", aggfunc="sum")
+            .sort_index()
+        )
+        fig_stack = go.Figure()
+        for col in pivot.columns:
+            fig_stack.add_bar(x=pivot.index.astype(str), y=pivot[col], name=str(col))
+        fig_stack.update_layout(
+            barmode="stack",
+            height=340,
+            margin=dict(l=10, r=10, t=30, b=10),
+            title="Monthly site energy by commodity (kBtu)",
+            yaxis_title="kBtu",
+        )
+        st.plotly_chart(fig_stack, width="stretch", key="fuel_stack_commodity")
+
+    # Ranked buildings + attention
+    st.subheader("Buildings needing attention")
+    attention = dfb.sort_values("peer_vs_median_pct", ascending=False)
     st.dataframe(
-        dfb[
+        attention[
             [
                 "label",
                 "floor_area_ft2",
-                "kwh",
-                "mcf",
                 "site_eui_kbtu_ft2",
-                "peer_p20",
                 "peer_p50",
-                "peer_p80",
                 "peer_band",
                 "peer_vs_median_pct",
             ]
@@ -166,30 +192,18 @@ def render(*, campus: Campus | None = None) -> None:
         width="stretch",
         hide_index=True,
     )
-    p20 = float(dfb["peer_p20"].iloc[0])
-    p50 = float(dfb["peer_p50"].iloc[0])
-    p80 = float(dfb["peer_p80"].iloc[0])
-    fig_peer = go.Figure()
-    fig_peer.add_shape(
-        type="rect", x0=p20, x1=p80, y0=-0.5, y1=0.5,
-        fillcolor="rgba(44,160,44,0.18)", line_width=0,
+    fig_rank = px.bar(
+        attention,
+        x="site_eui_kbtu_ft2",
+        y="label",
+        orientation="h",
+        title="Ranked site EUI (kBtu/ft²)",
     )
-    fig_peer.add_vline(x=p50, line_dash="dash", line_color="#2ca02c")
-    for _, r in dfb.iterrows():
-        fig_peer.add_scatter(
-            x=[r["site_eui_kbtu_ft2"]], y=[0], mode="markers+text",
-            marker=dict(symbol="diamond", size=16),
-            text=[r["label"]], textposition="top center", name=r["label"],
-        )
-    fig_peer.update_layout(
-        height=180, margin=dict(l=10, r=10, t=10, b=10),
-        yaxis=dict(visible=False), xaxis_title="Site EUI (kBtu/ft²-yr)",
-        showlegend=False,
-    )
-    st.plotly_chart(fig_peer, width="stretch", key="fuel_peer_eui_chart")
+    st.plotly_chart(fig_rank, width="stretch", key="fuel_ranked_eui")
 
-    # Monthly tables + gap-aware charts
-    st.subheader("Monthly fuel (gaps shown as blanks)")
+
+def _render_monthly(campus: Campus, summary: dict[str, Any], go) -> None:
+    st.subheader("Monthly utility analytics")
     totals = campus_fuel_totals(campus)
     for fuel, g in totals.groupby("fuel"):
         unit = str(g["unit"].iloc[0])
@@ -198,54 +212,67 @@ def render(*, campus: Campus | None = None) -> None:
         st.dataframe(filled, width="stretch", hide_index=True, height=220)
         fig = go.Figure()
         fig.add_scatter(
-            x=filled["month"], y=filled["usage"], mode="lines+markers",
-            connectgaps=False, name=fuel,
+            x=filled["month"],
+            y=filled["usage"],
+            mode="lines+markers",
+            connectgaps=False,
+            name=fuel,
         )
         fig.update_layout(
-            height=300, margin=dict(l=10, r=10, t=30, b=10),
-            title=f"{fuel.title()} — connectgaps=False",
+            height=300,
+            margin=dict(l=10, r=10, t=30, b=10),
+            title=f"{fuel.title()} — gaps blank (connectgaps=False)",
             yaxis_title=unit,
         )
         st.plotly_chart(fig, width="stretch", key=f"fuel_monthly_{fuel}_chart")
 
-    # Heatmaps
-    st.subheader("Intensity & demand calendars")
-    h1, h2, h3 = st.columns(3)
-    with h1:
-        mat = intensity_heatmap_frame(campus, fuel="electricity")
-        if not mat.empty:
-            st.plotly_chart(
-                px.imshow(mat, aspect="auto", color_continuous_scale="YlOrRd", title="Elec kBtu/ft²"),
-                width="stretch",
-                key="fuel_heat_elec",
+    # Rolling 12-month EUI when enough history
+    months = _continuous_months(summary["window"]["start"], summary["window"]["end"])
+    if len(months) >= 12 and not totals.empty:
+        by_m = totals.groupby("month", as_index=False)["kbtu"].sum().sort_values("month")
+        by_m["roll_12_kbtu"] = by_m["kbtu"].rolling(12, min_periods=12).sum()
+        area = float(summary["campus"].get("floor_area_ft2") or 0) or sum(
+            float(b.get("floor_area_ft2") or 0) for b in summary["buildings"]
+        )
+        if area > 0:
+            by_m["roll_12_eui"] = by_m["roll_12_kbtu"] / area
+            fig_r = go.Figure()
+            fig_r.add_scatter(
+                x=by_m["month"],
+                y=by_m["roll_12_eui"],
+                mode="lines+markers",
+                connectgaps=False,
+                name="Rolling 12-mo EUI",
             )
-    with h2:
-        mat = intensity_heatmap_frame(campus, fuel="gas")
-        if not mat.empty:
-            st.plotly_chart(
-                px.imshow(mat, aspect="auto", color_continuous_scale="Blues", title="Gas kBtu/ft²"),
-                width="stretch",
-                key="fuel_heat_gas",
+            fig_r.update_layout(
+                height=300,
+                title="Rolling 12-month site EUI",
+                yaxis_title="kBtu/ft²",
             )
-    with h3:
-        mat = demand_heatmap_frame(campus)
-        if not mat.empty:
-            st.plotly_chart(
-                px.imshow(mat, aspect="auto", color_continuous_scale="Viridis", title="Demand kW"),
-                width="stretch",
-                key="fuel_heat_demand",
-            )
-        else:
-            st.caption("No demand_kw column in electric bills.")
+            st.plotly_chart(fig_r, width="stretch", key="fuel_roll12_eui")
 
-    # Per-meter year×month matrix (Excel-like)
+    years = sorted({m[:4] for m in months})
+    if len(years) >= 2:
+        st.caption(f"YoY available across bill years {years[0]}…{years[-1]}.")
+        yoy = totals.copy()
+        yoy["year"] = yoy["month"].astype(str).str[:4]
+        yoy["mm"] = yoy["month"].astype(str).str[5:7]
+        pivot = yoy.pivot_table(
+            index="mm", columns="year", values="kbtu", aggfunc="sum"
+        )
+        st.dataframe(pivot, width="stretch")
+    else:
+        st.caption("YoY compare: **NEEDS_INPUT** — need ≥2 calendar years of bills.")
+
     with st.expander("Year × month usage matrices", expanded=False):
         for m in campus.meters:
             st.markdown(f"**{m.meter_id}** ({m.fuel})")
             st.dataframe(year_month_matrix(m.bills), width="stretch")
 
-    # Weather
-    st.subheader("Weather response (HDD / CDD)")
+
+def _render_weather(campus: Campus, px, go) -> None:
+    st.subheader("Weather & baseline analytics")
+    st.caption(f"HDD/CDD base {DD_BASE_F:g}°F. Prefer Open-Meteo over synthetic OAT.")
     lat = campus.lat
     lon = campus.lon
     lat_s = st.text_input("Latitude", value="" if lat is None else str(lat), key="fuel_dash_lat")
@@ -294,21 +321,29 @@ def render(*, campus: Campus | None = None) -> None:
         sub = aligned[aligned["fuel"] == fit.fuel]
         fig = go.Figure()
         fig.add_scatter(
-            x=sub[fit.x_name], y=sub["usage"], mode="markers",
-            text=sub["month"], name="Bills",
+            x=sub[fit.x_name],
+            y=sub["usage"],
+            mode="markers",
+            text=sub["month"],
+            name="Bills",
         )
         xs = np.linspace(float(sub[fit.x_name].min()), float(sub[fit.x_name].max()), 40)
-        fig.add_scatter(x=xs, y=fit.slope * xs + fit.intercept, mode="lines", name=f"R²={fit.r2:.3f}")
+        fig.add_scatter(
+            x=xs, y=fit.slope * xs + fit.intercept, mode="lines", name=f"R²={fit.r2:.3f}"
+        )
         fig.update_layout(
             title=f"{fit.fuel} vs {fit.x_name.upper()}",
-            height=340, margin=dict(l=10, r=10, t=40, b=10),
-            xaxis_title=fit.x_name.upper(), yaxis_title=fit.unit,
+            height=340,
+            margin=dict(l=10, r=10, t=40, b=10),
+            xaxis_title=fit.x_name.upper(),
+            yaxis_title=fit.unit,
         )
-        st.plotly_chart(fig, width="stretch")
+        st.plotly_chart(fig, width="stretch", key=f"fuel_wx_scatter_{fit.fuel}")
         res = residual_frame(aligned, fit)
         st.plotly_chart(
             px.bar(res, x="month", y="residual", title=f"{fit.fuel} residuals"),
             width="stretch",
+            key=f"fuel_wx_resid_{fit.fuel}",
         )
 
     report = build_fuel_weather_report(
@@ -316,3 +351,137 @@ def render(*, campus: Campus | None = None) -> None:
     )
     with st.expander("Fuel weather report JSON"):
         st.json(report)
+
+
+def _render_demand(campus: Campus, px) -> None:
+    st.subheader("Demand & peak analysis")
+    mat = demand_heatmap_frame(campus)
+    if mat.empty:
+        st.info(
+            "NEEDS_INPUT: no `demand_kw` column in electric bills — peak/demand charts unavailable."
+        )
+        return
+    st.plotly_chart(
+        px.imshow(mat, aspect="auto", color_continuous_scale="Viridis", title="Demand kW"),
+        width="stretch",
+        key="fuel_heat_demand",
+    )
+    # Monthly peak bars when heatmap has numeric values
+    peaks = mat.max(axis=1)
+    if not peaks.empty:
+        fig = px.bar(
+            x=peaks.index.astype(str),
+            y=peaks.values,
+            labels={"x": "month", "y": "peak_kw"},
+            title="Monthly peak demand (from bill demand_kw)",
+        )
+        st.plotly_chart(fig, width="stretch", key="fuel_monthly_peak")
+
+
+def _render_data_quality(campus: Campus, summary: dict[str, Any]) -> None:
+    st.subheader("Data quality")
+    totals = campus_fuel_totals(campus)
+    w = summary["window"]
+    expected = _continuous_months(w["start"], w["end"])
+    st.metric("Expected bill months", len(expected))
+    for fuel, g in totals.groupby("fuel"):
+        present = set(g["month"].astype(str))
+        missing = [m for m in expected if m not in present]
+        pct = 100.0 * (1.0 - len(missing) / max(len(expected), 1))
+        st.markdown(f"**{fuel}** completeness {pct:.0f}% — missing {len(missing)} month(s)")
+        if missing:
+            st.caption(", ".join(missing[:24]) + ("…" if len(missing) > 24 else ""))
+    st.caption(
+        f"Allocation method is a scenario (not meter truth). Shared meters: "
+        f"{[m.meter_id for m in campus.meters if m.shared] or 'none'}."
+    )
+    h1, h2 = st.columns(2)
+    with h1:
+        mat = intensity_heatmap_frame(campus, fuel="electricity")
+        if not mat.empty:
+            import plotly.express as px
+
+            st.plotly_chart(
+                px.imshow(mat, aspect="auto", color_continuous_scale="YlOrRd", title="Elec kBtu/ft²"),
+                width="stretch",
+                key="fuel_heat_elec",
+            )
+    with h2:
+        mat = intensity_heatmap_frame(campus, fuel="gas")
+        if not mat.empty:
+            import plotly.express as px
+
+            st.plotly_chart(
+                px.imshow(mat, aspect="auto", color_continuous_scale="Blues", title="Gas kBtu/ft²"),
+                width="stretch",
+                key="fuel_heat_gas",
+            )
+
+
+def render(*, campus: Campus | None = None) -> None:
+    import plotly.express as px
+    import plotly.graph_objects as go
+
+    st.header("Fuel dashboard — ESCO energy use")
+    st.caption(
+        f"Tabbed monthly analytics (Plotly). HDD/CDD base {DD_BASE_F:g}°F. "
+        "Missing months stay blank — no fake continuity. Interval/Haystack tabs are Phase 2."
+    )
+
+    campus = campus or st.session_state.get("studio_campus") or st.session_state.get("fuel_weather_campus")
+    if campus is None:
+        energy = st.session_state.get("studio_energy")
+        if energy is not None and getattr(energy, "campus", None) is not None:
+            campus = energy.campus
+            st.session_state["studio_campus"] = campus
+    if campus is None:
+        st.info("Load an energy-use package on **Uploads** first (campus.json + bill CSVs).")
+        return
+
+    shared = [m.meter_id for m in campus.meters if m.shared]
+    if shared:
+        st.caption(f"Shared meter(s): {', '.join(shared)} — allocation is a scenario, not truth.")
+
+    alloc = st.selectbox(
+        "Shared-meter allocation",
+        list(ALLOCATION_METHODS[:3]),
+        format_func=lambda m: {
+            "area_weighted": "Area-weighted",
+            "equal": "Equal",
+            "gas_share": "Gas-share proxy",
+        }.get(m, m),
+        key="fuel_dash_allocation",
+    )
+
+    try:
+        summary = annual_summary(campus, allocation=alloc)
+    except ValueError as exc:
+        st.error(f"Could not annualize: {exc}")
+        return
+    st.session_state["studio_benchmark_summary"] = summary
+
+    tab_names = [
+        "Portfolio Overview",
+        "Monthly Utility Analytics",
+        "Weather & Baseline",
+        "Demand & Peak",
+        "Data Quality",
+        *_PHASE2_STUBS,
+    ]
+    tabs = st.tabs(tab_names)
+    with tabs[0]:
+        _render_portfolio(summary, campus, px, go)
+    with tabs[1]:
+        _render_monthly(campus, summary, go)
+    with tabs[2]:
+        _render_weather(campus, px, go)
+    with tabs[3]:
+        _render_demand(campus, px)
+    with tabs[4]:
+        _render_data_quality(campus, summary)
+    for i, name in enumerate(_PHASE2_STUBS, start=5):
+        with tabs[i]:
+            st.info(
+                f"**{name}** — Phase 2 / NEEDS_INPUT. Requires interval meters, tariffs, "
+                "or carbon factors not present in the monthly campus package."
+            )


### PR DESCRIPTION
## Summary
- `wattlab studio-bootstrap` + `studio_bootstrap.json` auto-loads Fuel campus + Twin preferred run (vibe19-style, once per session).
- Fuel dashboard Phase-1 tabs (Portfolio, Monthly, Weather, Demand, Data Quality) + Phase-2 NEEDS_INPUT stubs — Plotly kept, no fake fills.
- AppTest: zero-click bootstrap + all pages without Streamlit exceptions.

## Test plan
- [x] `pytest tests/test_studio_bootstrap.py tests/test_studio_app.py`
- [ ] vibe20-ghcr PR smoke + merge publish

Made with [Cursor](https://cursor.com)