### PR TITLE
polish(vibe20): Studio bootstrap Re-apply + publish upsert

### DIFF
--- a/vibe_code_apps_19/vibe19_agent_spec/AGENTS.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/AGENTS.md
@@ -17,6 +17,11 @@ When Studio WattLab (vibe20) shares `$WATTLAB_HOST_WORKSPACE` (e.g. `~/wattlab_w
 
 **App:** Educational **Streamlit + pandas** FDD demo (`streamlit_app.py`).
 
+**UI stack (do not confuse):** Native **Streamlit only** — not FastAPI/Flask embedding
+Streamlit, not a mid-run HTTP server. Headless agent path is in-process Python
+(`app/agent_api.py` + `scripts/agent_afdd.py`), then bootstrap JSON → Streamlit
+session. Production Rust Open-FDD is a **separate** repo.
+
 **Not this repo:** Production Rust/DataFusion Open-FDD → `C:\Users\ben\Documents\open-fdd`
 
 ---
@@ -33,7 +38,7 @@ When Studio WattLab (vibe20) shares `$WATTLAB_HOST_WORKSPACE` (e.g. `~/wattlab_w
 8. **Building id = folder name** — any site; BUILDING_100 is a demo label only.
 9. **Update this spec after meaningful changes** — skills + `SESSION_LOG.md`.
 10. Run **`python -m pytest -q`** before claiming done (or `scripts/run_tests_local.ps1` on Windows).
-11. **Agent API** — `app/agent_api.py` + `scripts/agent_afdd.py` for headless load/run/export (no FastAPI/Flask).
+11. **Agent API (headless, not FastAPI)** — `app/agent_api.py` + `scripts/agent_afdd.py` for load/run/export without opening the browser. Same pandas cookbook; **no** FastAPI/Flask product UI.
 12. **Motor charts ≠ compressor proof** — motor/pump/DX status first for weekly motor charts. No pump in data model → **omit** that motor series (never invent motor hours from leave temp). Prefer mapped fan/pump roles over column-name invent. **CHW pump status/command alone does not prove compressor operation** for mech-cooling OAT bins (rule 13).
 13. **Mech-cooling OAT bins = compressor devices only** — chillers/CHW plants, DX AHU/RTU, cooling-mode HP, VRF outdoor, typed compressor equipment. Acceptable proof: compressor/chiller **status**, verified **command**, analog **power/current**. Never pump-alone, fan status, cooling demand, or `clg_valve_pct` / chilled-water AHU valves. Sidebar **Use mapped mechanical-cooling status proof** (default checked): status → verified cmd → amps/power. Unchecked: CHW plants may use **CHW leave proof max °F** (`inferred: chw_leave_temp`; never on CHW AHU valves). Coverage: `eligible_no_runtime` for idle mapped compressors. Aggregates: **device-hours** (sum) + **any-active** (union); one running device ⇒ aggregates equal. Sort bins by `bin_start` cold→hot. `include_ahu_chw_valve` deprecated/ignored. **WattLab dump** always `run_rules` complete cookbook; default profile **`summary`** / schema **`wattlab_dump_v3`** (shared `telemetry/`; legacy `fdd_timeseries/` optional). Publish GHCR via `vibe19-ghcr.yml` only — **do not publish Vibe 20** for this change.
 14. **Occupancy calendar is canonical** — Overview weekly time pickers **always** drive `occ_mode` for SCHED-1. Do not re-add “Apply calendar → occ_mode” checkbox or casually remove the schedule UI.

--- a/vibe_code_apps_20/studio.py
+++ b/vibe_code_apps_20/studio.py
@@ -22,9 +22,21 @@ PAGES = [
 ]
 
 
+def _show_bootstrap_result(result: dict) -> None:
+    if result.get("banner"):
+        st.sidebar.success(result["banner"])
+    for note in result.get("needs_input") or []:
+        st.sidebar.info(f"NEEDS_INPUT: {note}")
+    for warn in result.get("warnings") or []:
+        st.sidebar.caption(f"Bootstrap: {warn}")
+    for err in result.get("errors") or []:
+        st.sidebar.warning(err)
+
+
 def _apply_studio_bootstrap_once() -> None:
     """Auto-load Fuel/Twin from studio_bootstrap.json (once per browser session)."""
-    if st.session_state.get("_studio_bootstrapped"):
+    # Avoid SessionState.__getattr__("get") — use `in` / [].
+    if "_studio_bootstrapped" in st.session_state and st.session_state["_studio_bootstrapped"]:
         return
     try:
         from wattlab.studio.bootstrap import apply_bootstrap_to_session
@@ -34,10 +46,51 @@ def _apply_studio_bootstrap_once() -> None:
         st.session_state["_studio_bootstrapped"] = True
         st.sidebar.warning(f"Bootstrap skipped: {exc}")
         return
-    if result.get("banner"):
-        st.sidebar.success(result["banner"])
-    for note in result.get("needs_input") or []:
-        st.sidebar.info(f"NEEDS_INPUT: {note}")
+    if result.get("skipped") == "no_bootstrap_file":
+        return
+    if result.get("applied") or result.get("errors") or result.get("needs_input"):
+        _show_bootstrap_result(result)
+
+
+def _render_bootstrap_sidebar_controls() -> None:
+    """Discoverability: path caption, stale-file warning, Re-apply button."""
+    from wattlab.studio.bootstrap import (
+        apply_bootstrap_to_session,
+        bootstrap_file_mtime,
+        clear_bootstrap_session_flags,
+        resolve_bootstrap_path,
+    )
+
+    path = resolve_bootstrap_path()
+    if path is None:
+        return
+
+    st.sidebar.caption(
+        f"Bootstrap: `{path.name}` — page refresh starts a new session; "
+        "or use Re-apply below."
+    )
+    applied_mtime = st.session_state.get("_studio_bootstrap_applied_mtime")
+    current_mtime = bootstrap_file_mtime(path)
+    if (
+        st.session_state.get("_studio_bootstrapped")
+        and applied_mtime is not None
+        and current_mtime is not None
+        and current_mtime > float(applied_mtime) + 0.01
+    ):
+        st.sidebar.warning("Bootstrap file updated — Re-apply or refresh.")
+
+    if st.sidebar.button("Re-apply bootstrap", key="studio_reapply_bootstrap"):
+        clear_bootstrap_session_flags(st.session_state)
+        try:
+            result = apply_bootstrap_to_session(st.session_state)
+        except Exception as exc:  # noqa: BLE001
+            st.session_state["_studio_bootstrapped"] = True
+            st.sidebar.warning(f"Re-apply failed: {exc}")
+            return
+        if result.get("skipped") == "no_bootstrap_file":
+            st.sidebar.info("No bootstrap file found.")
+            return
+        _show_bootstrap_result(result)
 
 
 def main() -> None:
@@ -53,6 +106,7 @@ def main() -> None:
         "Uploads → Fuel dashboard → Twin / calibrate → ECMs. "
         "AI agents work on the workspace folder; this UI is the viewer."
     )
+    _render_bootstrap_sidebar_controls()
     page = st.sidebar.radio("Workflow", PAGES, key="studio_page")
 
     if page == "Uploads":

--- a/vibe_code_apps_20/tests/test_studio_bootstrap.py
+++ b/vibe_code_apps_20/tests/test_studio_bootstrap.py
@@ -15,7 +15,10 @@ from streamlit.testing.v1 import AppTest
 from wattlab.studio.bootstrap import (
     apply_bootstrap_to_session,
     build_bootstrap_payload,
+    clear_bootstrap_session_flags,
     resolve_bootstrap_path,
+    upsert_bootstrap_preferred_run,
+    validate_bootstrap_payload,
     write_bootstrap,
 )
 
@@ -46,6 +49,40 @@ def test_bootstrap_disable_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     write_bootstrap(build_bootstrap_payload(preferred_run_id="x"))
     monkeypatch.setenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", "1")
     assert resolve_bootstrap_path(tmp_path) is None
+
+
+def test_validate_bootstrap_payload_warnings():
+    assert any("version missing" in w for w in validate_bootstrap_payload({}))
+    assert any("empty bootstrap" in w for w in validate_bootstrap_payload({}))
+    bad = validate_bootstrap_payload({"version": 99, "extra_key": 1})
+    assert any("version=" in w for w in bad)
+    assert any("unknown keys" in w for w in bad)
+    ok = validate_bootstrap_payload(
+        {"version": 1, "preferred_run_id": "run_a", "auto_refresh_runs": True}
+    )
+    assert ok == []
+
+
+def test_upsert_bootstrap_preferred_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    monkeypatch.delenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", raising=False)
+    path = upsert_bootstrap_preferred_run("run_new", workspace=tmp_path)
+    assert path is not None and path.is_file()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["preferred_run_id"] == "run_new"
+    assert data["version"] == 1
+    # Merge preserves campus
+    write_bootstrap(
+        build_bootstrap_payload(
+            energy_campus_dir="uploads/energy/x", preferred_run_id="old"
+        )
+    )
+    upsert_bootstrap_preferred_run("run_merged", workspace=tmp_path)
+    merged = json.loads((tmp_path / "studio_bootstrap.json").read_text(encoding="utf-8"))
+    assert merged["preferred_run_id"] == "run_merged"
+    assert merged["energy_campus_dir"] == "uploads/energy/x"
+    monkeypatch.setenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", "1")
+    assert upsert_bootstrap_preferred_run("nope", workspace=tmp_path) is None
 
 
 def test_apply_bootstrap_loads_campus_and_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -183,3 +220,31 @@ def test_fuel_tabs_render_with_fixture_campus():
     assert any("EUI" in (lab or "") for lab in metric_labels)
     at.button(key="fuel_dash_synth").click().run()
     assert not at.exception
+
+
+def test_studio_reapply_bootstrap_button(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    monkeypatch.delenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", raising=False)
+    write_bootstrap(build_bootstrap_payload(preferred_run_id="reapply_run"))
+    at = AppTest.from_file(str(STUDIO), default_timeout=TIMEOUT)
+    at.run()
+    assert not at.exception
+    assert "_studio_bootstrapped" in at.session_state
+    assert at.session_state["_studio_bootstrapped"] is True
+    # Re-apply present when bootstrap file exists
+    btn = at.button(key="studio_reapply_bootstrap")
+    btn.click().run()
+    assert not at.exception
+    assert at.session_state["_studio_bootstrapped"] is True
+
+
+def test_clear_bootstrap_session_flags():
+    state = {
+        "_studio_bootstrapped": True,
+        "_studio_bootstrap_notes": ["x"],
+        "_studio_bootstrap_applied_mtime": 1.0,
+        "studio_campus": "keep",
+    }
+    clear_bootstrap_session_flags(state)
+    assert "_studio_bootstrapped" not in state
+    assert state["studio_campus"] == "keep"

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -14,9 +14,11 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 
 **App:** ESCO / energy-engineering toolkit — vibe19 FDD dumps in, calibrated EnergyPlus twins + benchmarked capital plans out. Where vibe19 is about **finding faults**, vibe20 is about **pricing the fixes credibly**: ESCO spreadsheet bin-method calculators, EnergyPlus crosschecks, public benchmarks, and ROI guardrails.
 
+**UI stack (do not confuse):** Native **Streamlit Studio** (`studio.py`) — not FastAPI/Flask embedding Streamlit. Agents drive work via `docker exec vibe20 wattlab …` + shared volume; Studio is the browser viewer. Bootstrap: `wattlab studio-bootstrap` → `studio_bootstrap.json` (same idea as vibe19 `.last_agent_session.json`). No mid-run HTTP API required.
+
 **Stack honesty:** EnergyPlus = physics engine; EnergyPlus-MCP = inspect/modify/sim wrench (~35 tools); WattLab + assumption skills = defaults ledger, peers → bins → E+, G14. MCP is not a calibration coach — see [`skills/wattlab-energyplus-mcp/SKILL.md`](skills/wattlab-energyplus-mcp/SKILL.md) and [`skills/wattlab-assumptions/SKILL.md`](skills/wattlab-assumptions/SKILL.md).
 
-**Sibling app:** `../vibe_code_apps_19/` — Streamlit FDD demo that produces the WattLab dump this app consumes. Its spec: `../vibe_code_apps_19/vibe19_agent_spec/`.
+**Sibling app:** `../vibe_code_apps_19/` — Streamlit FDD demo that produces the WattLab dump this app consumes. Its spec: `../vibe19_agent_spec/` (same Streamlit-native pattern; different mission).
 
 ---
 

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -98,10 +98,12 @@ curl -sf http://127.0.0.1:8520/_stcore/health
 ```
 
 Tip image includes the **Docker CLI** (no host `docker` binary bind-mount).
+Prefer tip `c09d26b`+ (`ghcr.io/bbartling/vibe20:latest`).
 `WATTLAB_HOST_WORKSPACE` = host path for the `/data` bind (required for Twin →
 Docker E+ / DinD). Prefer agents: `docker exec vibe20 wattlab …`
 ([`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)).
 G14 + client package: [`docs/CALIBRATE_AND_DELIVERABLES.md`](docs/CALIBRATE_AND_DELIVERABLES.md).
+Both vibe19 and vibe20 are **native Streamlit** (not FastAPI embedding Streamlit).
 
 ## SETUP — EnergyPlus + EnergyPlus-MCP
 
@@ -201,8 +203,9 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 19. Twin **Build client package** → preview report + download md/xlsx/zip without Streamlit exceptions.
 20. **Schedule:File DinD:** File Name `/work/in/<csv>` + CSV staged (not absolute `/data/...`).
 21. Archive hygiene: root-owned `runs/` via `docker exec -u 0` when needed.
-22. After publish: `wattlab studio-bootstrap --campus … --run-id …` so human opens Studio
-    with Fuel + Twin already loaded (no Uploads/Refresh clicks).
+22. After publish: open/refresh Studio (or sidebar **Re-apply bootstrap**). Publish already
+    upserts `preferred_run_id` into `studio_bootstrap.json`; optional
+    `wattlab studio-bootstrap --campus … --run-id …` when campus/dump paths still needed.
 
 ## PASS / FAIL
 

--- a/vibe_code_apps_20/vibe20_agent_spec/DATA_CONTRACT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/DATA_CONTRACT.md
@@ -223,7 +223,10 @@ reports/           # dry-run plans, capital_plan.json, scorecards
 WORKSPACE.md
 ```
 
-Streamlit pages (4 only): **Uploads** → **Fuel dashboard** → **Twin / calibrate** → **ECMs**.
-Agents read/write this tree outside Streamlit; Studio refreshes as a viewer.
+Streamlit pages (sidebar): **Uploads** → **Fuel dashboard** (Phase-1 Plotly tabs:
+Portfolio / Monthly / Weather / Demand / Data Quality; Phase-2 stubs for interval)
+→ **Twin / calibrate** → **ECMs**.
+Agents read/write this tree outside Streamlit; Studio refreshes as a viewer
+(or auto-loads via `studio_bootstrap.json`).
 Energy-use loader: `wattlab.energy_use.load_energy_use_package` (campus +
 `column_map` / `bill_columns`). Tests: `tests/test_energy_use_package.py`.

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -4,8 +4,9 @@ Agents use the **running containers** and a **shared host volume** — not a git
 clone of this repo on the agent machine. Studio (browser) is the human viewer;
 CLI/`docker exec` is the agent surface for this cycle.
 
-> Future: same workspace contract may gain a thin HTTP wrapper. Until then,
-> `docker exec` + shared volumes are the equal vibe19/20 ops path.
+Both vibe19 and vibe20 are **native Streamlit apps** (not FastAPI/Flask shells
+that embed Streamlit). Optional future: a thin HTTP wrapper around the **same**
+workspace contract — that is **not** the current product UI.
 
 ## Shared volume layout
 
@@ -94,6 +95,16 @@ docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 \
 
 Writes `/data/studio_bootstrap.json` (+ `.last_studio_session.json`). Next Studio
 browser session auto-loads Fuel campus + Twin preferred run (sidebar banner).
+
+**Human load path:** browser **page refresh** starts a new Streamlit session (auto-apply once).
+If the session is already open and the JSON changed, use sidebar **Re-apply bootstrap**
+(or refresh). No HTTP wrapper — file handoff only.
+
+**Publish auto-upsert:** `publish_run_for_studio` / `calibrate-campaign` merge
+`preferred_run_id` into `studio_bootstrap.json` (best-effort). Explicit
+`wattlab studio-bootstrap --campus …` is still useful for campus/dump/answers paths;
+run-id alone is often already set after publish.
+
 Disable in CI: `WATTLAB_STUDIO_BOOTSTRAP_DISABLE=1`.
 
 ## Agent flow (no git)

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: wattlab-studio
 description: >-
-  Use when working on WattLab Studio Streamlit: 4 pages (Uploads, Fuel dashboard,
-  Twin/calibrate, ECMs), workspace uploads/runs/reports, Excel→campus fallback,
-  APIHelper-08 Twin panes, AppTest smoke, Plotly. Triggers on: Studio, Streamlit,
-  studio.py, Uploads, Fuel dashboard, Twin, ECMs, AppTest, eplusout, floor plan.
+  Use when working on WattLab Studio Streamlit: 4 sidebar pages (Uploads, Fuel
+  dashboard with Phase-1 Plotly tabs, Twin/calibrate, ECMs), studio_bootstrap.json
+  auto-load, workspace uploads/runs/reports, APIHelper-08 Twin panes, AppTest smoke,
+  Plotly. Native Streamlit only — not FastAPI embedding Streamlit. Triggers on:
+  Studio, Streamlit, studio.py, Uploads, Fuel dashboard, Twin, ECMs, AppTest,
+  eplusout, floor plan, studio-bootstrap.
 ---
 
-# WattLab Studio — ESCO cockpit (4 pages)
+# WattLab Studio — ESCO cockpit (4 sidebar pages)
 
 Human-facing dropzone + results viewer. Launch: `wattlab studio` or GHCR
-`ghcr.io/bbartling/vibe20:latest` on `:8520`. Any AI agent chats **outside**
-Streamlit on `WATTLAB_STUDIO_WORKSPACE` and publishes Twin runs for the browser.
+`ghcr.io/bbartling/vibe20:latest` on `:8520`. **Native Streamlit only** — not
+FastAPI/Flask embedding Streamlit. Any AI agent chats **outside** Streamlit on
+`WATTLAB_STUDIO_WORKSPACE` (or `wattlab studio-bootstrap` for zero-click load)
+and publishes Twin runs for the browser.
 Pages: `wattlab/studio/pages/{uploads,fuel_dashboard,twin_calibrate,ecms}.py`.
+Fuel dashboard uses Phase-1 **tabs** (Portfolio / Monthly / Weather / Demand /
+Data Quality); interval EIS tabs stay Phase 2 NEEDS_INPUT.
 
 ## Hard rule — data-model driven sites
 
@@ -29,7 +35,7 @@ Pages: `wattlab/studio/pages/{uploads,fuel_dashboard,twin_calibrate,ecms}.py`.
 | Page | Does | Key session keys |
 | --- | --- | --- |
 | Uploads | dump v3 + energy package (campus / Excel / Haystack); workspace listing | `studio_bundle`, `studio_energy`, `studio_campus`, `studio_utility_bills_path` |
-| Fuel dashboard | monthly fuel, peers, HDD/CDD, gap-aware charts | `studio_campus` / `fuel_weather_*` |
+| Fuel dashboard | Phase-1 tabs: Portfolio / Monthly / Weather / Demand / Data Quality (+ Phase-2 stubs) | `studio_campus` / `fuel_weather_*` |
 | Twin / calibrate | profile, dry-run, Docker E+, 08 panes (progress/OA/floor or multi-floor schematic), EUI index, G14 scorecard, **client package** downloads, iteration history | `studio_profile`, `studio_plan`, `studio_report`, `studio_active_run`, `studio_deliverable` |
 | ECMs | catalog Easy Buttons + capital guardrails + optional client zip from report | `studio_measures`, `studio_proxies`, `studio_capital_plan`, `studio_guardrail_gate` |
 

--- a/vibe_code_apps_20/wattlab/studio/bootstrap.py
+++ b/vibe_code_apps_20/wattlab/studio/bootstrap.py
@@ -22,6 +22,23 @@ from typing import Any
 BOOTSTRAP_VERSION = 1
 DEFAULT_BOOTSTRAP_NAME = "studio_bootstrap.json"
 FALLBACK_BOOTSTRAP_NAME = ".last_studio_session.json"
+_KNOWN_KEYS = frozenset(
+    {
+        "version",
+        "energy_campus_dir",
+        "dump_zip",
+        "preferred_run_id",
+        "answers_path",
+        "auto_refresh_runs",
+        "notes",
+    }
+)
+_CONTENT_KEYS = (
+    "energy_campus_dir",
+    "dump_zip",
+    "preferred_run_id",
+    "answers_path",
+)
 
 
 def bootstrap_disabled() -> bool:
@@ -32,6 +49,77 @@ def bootstrap_disabled() -> bool:
         "yes",
         "YES",
     }
+
+
+def bootstrap_file_mtime(path: Path | str | None) -> float | None:
+    """Return file mtime, or None if missing."""
+    if path is None:
+        return None
+    p = Path(path)
+    try:
+        return float(p.stat().st_mtime) if p.is_file() else None
+    except OSError:
+        return None
+
+
+def validate_bootstrap_payload(payload: dict[str, Any] | None) -> list[str]:
+    """Return soft warnings (never hard-fail). Empty list = looks fine."""
+    warnings: list[str] = []
+    if not isinstance(payload, dict):
+        return ["bootstrap payload is not an object"]
+    ver = payload.get("version")
+    if ver is None:
+        warnings.append("version missing (expected 1)")
+    elif ver != BOOTSTRAP_VERSION:
+        warnings.append(f"version={ver!r} (expected {BOOTSTRAP_VERSION})")
+    unknown = sorted(set(payload) - _KNOWN_KEYS)
+    if unknown:
+        warnings.append(f"unknown keys: {', '.join(unknown)}")
+    if not any(payload.get(k) for k in _CONTENT_KEYS):
+        warnings.append(
+            "empty bootstrap — set energy_campus_dir, dump_zip, preferred_run_id, and/or answers_path"
+        )
+    return warnings
+
+
+def upsert_bootstrap_preferred_run(
+    run_id: str,
+    *,
+    workspace: Path | None = None,
+) -> Path | None:
+    """Merge ``preferred_run_id`` into studio_bootstrap.json (best-effort).
+
+    Creates a minimal file when missing. No-op when bootstrap is disabled.
+    Never raises for callers — returns written path or None.
+    """
+    if bootstrap_disabled() or not run_id:
+        return None
+    try:
+        from datetime import datetime, timezone
+
+        from wattlab.studio.workspace import ensure_workspace
+
+        root = Path(workspace) if workspace is not None else ensure_workspace()
+        path = root / DEFAULT_BOOTSTRAP_NAME
+        payload: dict[str, Any] = {}
+        if path.is_file():
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    payload = dict(raw)
+            except (OSError, json.JSONDecodeError):
+                payload = {}
+        payload["version"] = BOOTSTRAP_VERSION
+        payload["preferred_run_id"] = str(run_id)
+        payload["auto_refresh_runs"] = bool(payload.get("auto_refresh_runs", True))
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        payload["notes"] = (
+            f"preferred_run_id upserted by publish_run_for_studio @ {stamp}"
+        )
+        write_bootstrap(payload, path=path, also_fallback=True)
+        return path
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def resolve_bootstrap_path(workspace: Path | None = None) -> Path | None:
@@ -151,6 +239,7 @@ def apply_bootstrap_to_session(
         "banner": None,
         "needs_input": [],
         "errors": [],
+        "warnings": [],
     }
     if _ss_get(session_state, "_studio_bootstrapped"):
         result["skipped"] = "already_bootstrapped"
@@ -166,7 +255,16 @@ def apply_bootstrap_to_session(
     except (OSError, json.JSONDecodeError) as exc:
         result["errors"].append(f"bootstrap unreadable: {exc}")
         _ss_set(session_state, "_studio_bootstrapped", True)
+        _ss_set(session_state, "_studio_bootstrap_path", str(path))
+        _ss_set(session_state, "_studio_bootstrap_applied_mtime", bootstrap_file_mtime(path))
         return result
+
+    if not isinstance(payload, dict):
+        result["errors"].append("bootstrap payload is not an object")
+        _ss_set(session_state, "_studio_bootstrapped", True)
+        return result
+
+    result["warnings"] = validate_bootstrap_payload(payload)
 
     from wattlab.studio.workspace import ensure_workspace, runs_dir
 
@@ -242,11 +340,14 @@ def apply_bootstrap_to_session(
             _ss_set(session_state, "studio_active_run", str(run_dir.resolve()))
             notes.append(f"Twin run ← {run_dir.name}")
 
+    mtime = bootstrap_file_mtime(path)
     _ss_set(session_state, "_studio_bootstrapped", True)
     _ss_set(session_state, "_studio_bootstrap_path", str(path))
     _ss_set(session_state, "_studio_bootstrap_notes", notes)
+    _ss_set(session_state, "_studio_bootstrap_applied_mtime", mtime)
     result["applied"] = True
     result["path"] = str(path)
+    result["mtime"] = mtime
     result["notes"] = notes
     if notes or result["needs_input"]:
         result["banner"] = (
@@ -256,6 +357,21 @@ def apply_bootstrap_to_session(
     else:
         result["banner"] = f"Bootstrapped from {path.name}"
     return result
+
+
+def clear_bootstrap_session_flags(session_state: Any) -> None:
+    """Clear once-per-session flags so Re-apply can run again."""
+    for key in (
+        "_studio_bootstrapped",
+        "_studio_bootstrap_notes",
+        "_studio_bootstrap_applied_mtime",
+    ):
+        try:
+            if key in session_state:
+                del session_state[key]
+        except (KeyError, TypeError, AttributeError):
+            if isinstance(session_state, dict):
+                session_state.pop(key, None)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/vibe_code_apps_20/wattlab/studio/ep_viz.py
+++ b/vibe_code_apps_20/wattlab/studio/ep_viz.py
@@ -369,6 +369,13 @@ def publish_run_for_studio(
     # Pointer so Twin auto-selects the latest agent publish
     pointer = dest.parent / "CURRENT_RUN.txt"
     pointer.write_text(str(dest.resolve()), encoding="utf-8")
+    # Best-effort: keep studio_bootstrap.json preferred_run_id in sync.
+    try:
+        from wattlab.studio.bootstrap import upsert_bootstrap_preferred_run
+
+        upsert_bootstrap_preferred_run(rid)
+    except Exception:  # noqa: BLE001
+        pass
     # Best-effort world-writable so host agents can archive without root.
     try:
         import os


### PR DESCRIPTION
## Summary
- Sidebar bootstrap path caption, mtime stale-file cue, and **Re-apply bootstrap** button
- Soft `validate_bootstrap_payload` warnings; `publish_run_for_studio` upserts `preferred_run_id`
- Agent-spec notes (refresh vs Re-apply; Streamlit-native clarifications for vibe19/vibe20)

## Test plan
- [x] `pytest tests/test_studio_bootstrap.py` (11 passed)
- [ ] Watch `vibe20-ghcr` green after merge
- [ ] Soak: after publish, refresh or Re-apply Studio; preferred_run auto-loaded

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer Studio bootstrap status messages, including warnings, errors, and input requirements.
  - Added a sidebar control to view the active bootstrap file and re-apply updated configuration.
  - Published runs now automatically update the preferred run for Studio when possible.
  - Added validation and warnings for incomplete or unrecognized bootstrap data.

- **Documentation**
  - Clarified the native Streamlit workflow, workspace setup, bootstrap behavior, and Studio navigation.
  - Documented Fuel dashboard tabs and the refresh/re-apply workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->