### PR TITLE
fix(vibe20): preserve bootstrap notes on upsert

### DIFF
--- a/vibe_code_apps_20/tests/test_studio_bootstrap.py
+++ b/vibe_code_apps_20/tests/test_studio_bootstrap.py
@@ -71,16 +71,20 @@ def test_upsert_bootstrap_preferred_run(tmp_path: Path, monkeypatch: pytest.Monk
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["preferred_run_id"] == "run_new"
     assert data["version"] == 1
-    # Merge preserves campus
+    # Merge preserves campus + prior --notes text
     write_bootstrap(
         build_bootstrap_payload(
-            energy_campus_dir="uploads/energy/x", preferred_run_id="old"
+            energy_campus_dir="uploads/energy/x",
+            preferred_run_id="old",
+            notes="agent campus handoff for Liberty",
         )
     )
     upsert_bootstrap_preferred_run("run_merged", workspace=tmp_path)
     merged = json.loads((tmp_path / "studio_bootstrap.json").read_text(encoding="utf-8"))
     assert merged["preferred_run_id"] == "run_merged"
     assert merged["energy_campus_dir"] == "uploads/energy/x"
+    assert "agent campus handoff for Liberty" in merged["notes"]
+    assert "preferred_run_id upserted by publish_run_for_studio @" in merged["notes"]
     monkeypatch.setenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", "1")
     assert upsert_bootstrap_preferred_run("nope", workspace=tmp_path) is None
 

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -98,7 +98,7 @@ curl -sf http://127.0.0.1:8520/_stcore/health
 ```
 
 Tip image includes the **Docker CLI** (no host `docker` binary bind-mount).
-Prefer tip `c09d26b`+ (`ghcr.io/bbartling/vibe20:latest`).
+Prefer tip `b368842`+ (`ghcr.io/bbartling/vibe20:latest`) — notes-append upsert + Re-apply polish.
 `WATTLAB_HOST_WORKSPACE` = host path for the `/data` bind (required for Twin →
 Docker E+ / DinD). Prefer agents: `docker exec vibe20 wattlab …`
 ([`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)).
@@ -206,6 +206,9 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 22. After publish: open/refresh Studio (or sidebar **Re-apply bootstrap**). Publish already
     upserts `preferred_run_id` into `studio_bootstrap.json`; optional
     `wattlab studio-bootstrap --campus … --run-id …` when campus/dump paths still needed.
+23. **NEEDS_HUMAN (browser):** Fuel without Uploads clicks + Re-apply / stale cue cannot be
+    closed by headless API soak alone — leave an explicit **NEEDS_HUMAN** line in
+    `CALIBRATE_SESSION.md`. Pytest/AppTest is CI/host only (tip image has no pytest).
 
 ## PASS / FAIL
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -101,9 +101,14 @@ If the session is already open and the JSON changed, use sidebar **Re-apply boot
 (or refresh). No HTTP wrapper — file handoff only.
 
 **Publish auto-upsert:** `publish_run_for_studio` / `calibrate-campaign` merge
-`preferred_run_id` into `studio_bootstrap.json` (best-effort). Explicit
+`preferred_run_id` into `studio_bootstrap.json` (best-effort) and **append** a
+timestamp line to `notes` (does not wipe `--notes` text). Explicit
 `wattlab studio-bootstrap --campus …` is still useful for campus/dump/answers paths;
 run-id alone is often already set after publish.
+
+**Pytest:** runtime `ghcr.io/bbartling/vibe20:latest` does **not** include pytest.
+AppTest lives in CI / host: `pip install -e ".[dev]"` then
+`python -m pytest tests/test_studio_bootstrap.py -q`. Do not `docker exec … pytest`.
 
 Disable in CI: `WATTLAB_STUDIO_BOOTSTRAP_DISABLE=1`.
 

--- a/vibe_code_apps_20/wattlab/studio/bootstrap.py
+++ b/vibe_code_apps_20/wattlab/studio/bootstrap.py
@@ -113,9 +113,13 @@ def upsert_bootstrap_preferred_run(
         payload["preferred_run_id"] = str(run_id)
         payload["auto_refresh_runs"] = bool(payload.get("auto_refresh_runs", True))
         stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        payload["notes"] = (
-            f"preferred_run_id upserted by publish_run_for_studio @ {stamp}"
-        )
+        stamp_line = f"preferred_run_id upserted by publish_run_for_studio @ {stamp}"
+        prev = str(payload.get("notes") or "").strip()
+        if prev and stamp_line not in prev:
+            payload["notes"] = f"{prev}\n{stamp_line}"
+        elif not prev:
+            payload["notes"] = stamp_line
+        # else: stamp already present — leave notes unchanged
         write_bootstrap(payload, path=path, also_fallback=True)
         return path
     except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- Append publish upsert stamp to `notes` (keep `wattlab studio-bootstrap --notes`)
- Docs: pytest/AppTest is CI/host only — tip runtime has no pytest
- Tester checklist: browser Fuel/Re-apply = **NEEDS_HUMAN**

## Test plan
- [x] `pytest tests/test_studio_bootstrap.py` (11 passed)
- [ ] Watch `vibe20-ghcr` after merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Studio bootstrap updates now preserve existing notes while recording preferred run information.
  - Repeated updates no longer duplicate the same attribution entry.

- **Documentation**
  - Clarified the Studio calibration workflow, including browser-based completion and required human review notes.
  - Updated setup guidance for the latest container image and host-based test execution.

- **Tests**
  - Expanded coverage to verify preferred run updates, preserved configuration values, and merged notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->