### PR TITLE
feat(vibe20): agent UI status, ECM scenario, Twin/Fuel UX, deliverables

### DIFF
--- a/vibe_code_apps_20/AGENTS.md
+++ b/vibe_code_apps_20/AGENTS.md
@@ -12,7 +12,27 @@
 
 Optimize for engineering defensibility, reproducibility, and honest limits (uncalibrated prototypes are screens, not calibrated models).
 
-## Tomorrow demo — vibe19 dump → EnergyPlus twin (generalized)
+## Tomorrow demo — vibe19 dump → EnergyPlus twin (GHCR-first)
+
+**Prefer the container** — see [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) and
+[`vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md`](vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md).
+No playground clone required for production soaks.
+
+```bash
+docker exec vibe20 cat /app/CONTAINER_AGENT.md
+
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
+  -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace vibe20 \
+  wattlab seed /data/uploads/dump/wattlab_dump.zip --gaps
+
+# Fill /data/reports/answers.json (never invent type/city/area), then:
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
+  -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace vibe20 \
+  wattlab twin /data/uploads/dump/wattlab_dump.zip \
+  --inputs /data/reports/answers.json --out /data/.artifacts/twin_demo --measure-set better
+
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 wattlab studio-status --write
+```
 
 Works for **any** building zip processed through vibe19 Export → **Build WattLab dump (zip)**.
 Do **not** hardcode BUILDING_100, Liberty, Detroit, or any site IDs, paths,
@@ -25,9 +45,9 @@ buildings ship their own JSON + CSVs.
 
 1. Load the historian package zip in vibe19 (Folder | Zip picker).
 2. Optionally run rules (Export auto-runs all rules if none have run yet).
-3. **Export** → **Build WattLab dump (zip)** → download `wattlab_dump_<id>.zip`.
+3. **Export** → **Build WattLab dump (zip)** → place under shared `/data/uploads/dump/`.
 
-### Agent prep (vibe20) — start with `wattlab twin`
+### Host contrib only (optional — not for GHCR soaks)
 
 ```powershell
 cd vibe_code_apps_20

--- a/vibe_code_apps_20/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/CONTAINER_AGENT.md
@@ -1,0 +1,38 @@
+# Container agent — start here (no git clone)
+
+You are inside **`ghcr.io/bbartling/vibe20:latest`** (or vibe19). Work on the shared volume
+`/data` ↔ host `WATTLAB_HOST_WORKSPACE`. Streamlit is for the **human** browser only.
+
+## Read first
+
+| Path | Why |
+| --- | --- |
+| `/app/CONTAINER_AGENT.md` | This file |
+| `/app/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + DinD + bootstrap |
+| `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS (prefer over root clone demos) |
+| `/app/vibe20_agent_spec/DATA_CONTRACT.md` | Dump / answers / campus schemas |
+| `/app/vibe20_agent_spec/AGENT_TESTER_PROMPT.md` | Soak checklist |
+| `/app/vibe20_agent_spec/skills/wattlab-*/SKILL.md` | Procedure skills |
+
+## Run (preferred)
+
+```bash
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
+  -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace vibe20 \
+  wattlab <cmd>
+```
+
+Useful commands:
+
+- `wattlab studio-status --write` → `reports/session_status.json` (missing vs answered)
+- `wattlab studio-bootstrap --campus … --dump … --run-id … --answers …`
+- `wattlab calibrate-campaign …` / `wattlab twin …` / `wattlab ecm list|packages`
+- `wattlab seed <dump> --gaps`
+
+Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**.
+
+## Do not
+
+- Require `git clone` / `pip install -e` for production soaks (host contrib only)
+- Invent `building_type` / `city` / `floor_area_ft2` — write `reports/answers*.json`
+- Claim calibrated ROI without G14 stamps

--- a/vibe_code_apps_20/tests/test_studio_status_deliverables.py
+++ b/vibe_code_apps_20/tests/test_studio_status_deliverables.py
@@ -1,0 +1,108 @@
+"""Tests for studio-status, ecm_scenario, gap soften, iteration elapsed."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wattlab.studio.ecm_scenario import load_ecm_scenario, save_ecm_scenario
+from wattlab.studio.ep_viz import list_iteration_runs, read_run_progress
+from wattlab.studio.status import (
+    answers_complete,
+    build_session_status,
+    required_gaps_still_missing,
+    soften_required_gaps,
+)
+
+
+def test_soften_required_gaps_when_answers_filled():
+    gaps = [
+        {"field": "building_type", "severity": "required", "status": "missing"},
+        {"field": "city", "severity": "required", "status": "missing"},
+        {"field": "floor_area_ft2", "severity": "required", "status": "ok", "value": 1},
+    ]
+    answers = {"building_type": "office", "city": "detroit", "floor_area_ft2": 140000}
+    soft = soften_required_gaps(gaps, answers)
+    assert soft[0]["status"] == "answered"
+    assert soft[0]["via"] == "answers.json"
+    assert required_gaps_still_missing(gaps, answers) == []
+    assert answers_complete(answers)
+
+
+def test_ecm_scenario_roundtrip(tmp_path: Path):
+    path = tmp_path / "ecm_scenario.json"
+    save_ecm_scenario(
+        {"selected_ecm_ids": ["a", "b"], "notes": "chat"},
+        path=path,
+    )
+    loaded = load_ecm_scenario(path)
+    assert loaded["selected_ecm_ids"] == ["a", "b"]
+    assert "2 ECMs" in loaded["status"]
+
+
+def test_build_session_status_answers_answered(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    (tmp_path / "reports").mkdir(parents=True)
+    (tmp_path / "runs").mkdir(parents=True)
+    answers = {
+        "building_type": "office",
+        "city": "detroit",
+        "floor_area_ft2": 140000,
+    }
+    (tmp_path / "reports" / "answers.json").write_text(json.dumps(answers), encoding="utf-8")
+    (tmp_path / "studio_bootstrap.json").write_text(
+        json.dumps({"version": 1, "answers_path": "reports/answers.json", "preferred_run_id": "r1"}),
+        encoding="utf-8",
+    )
+    status = build_session_status(workspace=tmp_path)
+    assert status["fields"]["building_type"]["status"] == "answered"
+    assert status["twin"]["profile_resolvable"] is True
+
+
+def test_list_iteration_runs_elapsed(tmp_path: Path):
+    run = tmp_path / "runs" / "demo_run"
+    run.mkdir(parents=True)
+    (run / "run_manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": "demo_run",
+                "status": "published",
+                "started_at": "2026-07-22T10:00:00Z",
+                "finished_at": "2026-07-22T10:05:30Z",
+                "hypothesis": "lockout 60F",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run / "eplusout.csv").write_text("Date/Time\n", encoding="utf-8")
+    info = read_run_progress(run)
+    assert info["elapsed_s"] == 330.0
+    assert info["hypothesis"] == "lockout 60F"
+    rows = list_iteration_runs(tmp_path / "runs", limit=5)
+    assert rows and rows[0]["elapsed_s"] == 330.0
+
+
+def test_package_deliverables_has_source_and_iteration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    (tmp_path / "reports").mkdir(parents=True)
+    (tmp_path / "reports" / "answers.json").write_text(
+        json.dumps({"building_type": "office", "city": "x", "floor_area_ft2": 1}),
+        encoding="utf-8",
+    )
+    from wattlab.deliverables import package_deliverables
+    from openpyxl import load_workbook
+    import io
+
+    out = tmp_path / "deliverable_test"
+    meta = package_deliverables(
+        out_dir=out,
+        scorecard={"run_id": "r1", "status": "screening", "utility_bills": {}},
+        profile={"building_type": "office", "city": "x"},
+        iteration_runs=[{"run_id": "r1", "hypothesis": "baseline", "elapsed_s": 12}],
+    )
+    assert (out / "05_Source_Data" / "answers.json").is_file()
+    assert "Executive summary" in Path(meta["report_md"]).read_text(encoding="utf-8")
+    wb = load_workbook(io.BytesIO(Path(meta["workbook_xlsx"]).read_bytes()))
+    assert "Iteration_Runs" in wb.sheetnames

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -10,6 +10,8 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 
 **Docker exec + shared volume (no git clone):** [`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)
 
+**Container start-here (in image):** [`CONTAINER_AGENT.md`](CONTAINER_AGENT.md) → also `/app/CONTAINER_AGENT.md`
+
 **G14 calibrate campaign + client report/xlsx/zip:** [`docs/CALIBRATE_AND_DELIVERABLES.md`](docs/CALIBRATE_AND_DELIVERABLES.md)
 
 **App:** ESCO / energy-engineering toolkit — vibe19 FDD dumps in, calibrated EnergyPlus twins + benchmarked capital plans out. Where vibe19 is about **finding faults**, vibe20 is about **pricing the fixes credibly**: ESCO spreadsheet bin-method calculators, EnergyPlus crosschecks, public benchmarks, and ROI guardrails.

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -98,7 +98,9 @@ curl -sf http://127.0.0.1:8520/_stcore/health
 ```
 
 Tip image includes the **Docker CLI** (no host `docker` binary bind-mount).
-Prefer tip `b368842`+ (`ghcr.io/bbartling/vibe20:latest`) — notes-append upsert + Re-apply polish.
+Prefer tip after agent/UI tip (`ghcr.io/bbartling/vibe20:latest`) — studio-status,
+profile→ECMs, ecm_scenario, iteration elapsed, richer deliverables.
+Start inside the image: `docker exec vibe20 cat /app/CONTAINER_AGENT.md`.
 `WATTLAB_HOST_WORKSPACE` = host path for the `/data` bind (required for Twin →
 Docker E+ / DinD). Prefer agents: `docker exec vibe20 wattlab …`
 ([`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)).
@@ -209,6 +211,10 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 23. **NEEDS_HUMAN (browser):** Fuel without Uploads clicks + Re-apply / stale cue cannot be
     closed by headless API soak alone — leave an explicit **NEEDS_HUMAN** line in
     `CALIBRATE_SESSION.md`. Pytest/AppTest is CI/host only (tip image has no pytest).
+24. `wattlab studio-status --write` → `session_status.json` shows required fields
+    **answered** when answers fill dump nulls; bootstrap answers → `studio_profile` unlocks ECMs.
+25. Twin iteration table shows **elapsed** when manifests have timestamps; client package
+    zip includes `05_Source_Data` + report/workbook individual downloads.
 
 ## PASS / FAIL
 

--- a/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
@@ -1,0 +1,39 @@
+# Container agent — start here (no git clone)
+
+You are inside **`ghcr.io/bbartling/vibe20:latest`** (or vibe19). Work on the shared volume
+`/data` ↔ host `WATTLAB_HOST_WORKSPACE`. Streamlit is for the **human** browser only.
+
+## Read first
+
+| Path | Why |
+| --- | --- |
+| `/app/CONTAINER_AGENT.md` | Root copy of this guide |
+| `/app/vibe20_agent_spec/CONTAINER_AGENT.md` | Same |
+| `/app/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + DinD + bootstrap |
+| `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS (prefer over root clone demos) |
+| `/app/vibe20_agent_spec/DATA_CONTRACT.md` | Dump / answers / campus schemas |
+| `/app/vibe20_agent_spec/AGENT_TESTER_PROMPT.md` | Soak checklist |
+| `/app/vibe20_agent_spec/skills/wattlab-*/SKILL.md` | Procedure skills |
+
+## Run (preferred)
+
+```bash
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
+  -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace vibe20 \
+  wattlab <cmd>
+```
+
+Useful commands:
+
+- `wattlab studio-status --write` → `reports/session_status.json` (missing vs answered)
+- `wattlab studio-bootstrap --campus … --dump … --run-id … --answers …`
+- `wattlab calibrate-campaign …` / `wattlab twin …` / `wattlab ecm list|packages`
+- Write `reports/ecm_scenario.json` → Studio ECMs Easy Buttons (after profile from answers)
+
+Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**.
+
+## Do not
+
+- Require `git clone` / `pip install -e` for production soaks (host contrib only)
+- Invent `building_type` / `city` / `floor_area_ft2` — write `reports/answers*.json`
+- Claim calibrated ROI without G14 stamps

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -112,6 +112,44 @@ AppTest lives in CI / host: `pip install -e ".[dev]"` then
 
 Disable in CI: `WATTLAB_STUDIO_BOOTSTRAP_DISABLE=1`.
 
+## Session status + answers vs dump
+
+```bash
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 wattlab studio-status --write
+# → /data/reports/session_status.json  (missing | answered | phase2)
+# Template: /app/wattlab/studio/templates/answers.schema.template.json
+```
+
+Dump `model_seed` may still have null type/city/area while answers are filled —
+that is dual-source honesty. Studio softens the NEEDS_INPUT banner when answers
+cover required fields. Bootstrap with `answers_path` also builds `studio_profile`
+so the ECMs page unlocks without a Twin form click.
+
+## ECM scenario (agent → Easy Buttons)
+
+Write `/data/reports/ecm_scenario.json`:
+
+```json
+{
+  "version": 1,
+  "selected_ecm_ids": ["fan_schedule_optimization"],
+  "measure_set": "best",
+  "notes": "from chat",
+  "recommendations": ["chiller_lockout_reset"]
+}
+```
+
+Human Re-apply / open ECMs → checkboxes prefilled. Studio **Save to ecm_scenario.json**
+writes back. Optional bootstrap key: `ecm_scenario_path`.
+
+## Twin iteration dashboard + client package
+
+Twin **Iteration history** shows run_id, hypothesis, weather, status, eplusout,
+elapsed (from `run_manifest.json`). **Build client package** downloads report.md,
+workbook.xlsx, and full zip (`05_Source_Data` included when answers/bills present).
+
+Fuel **Portfolio** peer metrics have `?` help text + “How buildings are benchmarked”.
+
 ## Agent flow (no git)
 
 ```text

--- a/vibe_code_apps_20/wattlab/cli.py
+++ b/vibe_code_apps_20/wattlab/cli.py
@@ -28,6 +28,7 @@ def _usage() -> str:
         "  seed         Inspect a vibe19 WattLab dump (summary + gap report)\n"
         "               also: wattlab seed import-bills --electric CSV --gas CSV --out utility_bills.csv\n"
         "  studio-bootstrap  Write studio_bootstrap.json for Streamlit auto-load\n"
+        "  studio-status     Merge dump/answers/bootstrap/run → session_status.json\n"
         "  explore-existing  Existing Building Hypothesis Lab orchestration\n"
         "  hypothesis-lab    Alias for explore-existing\n"
         "  ecm          Canonical ECM catalog (list/describe/package/audit)\n"
@@ -161,6 +162,10 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_seed(rest)
     if cmd in {"studio-bootstrap", "studio_bootstrap"}:
         from wattlab.studio.bootstrap import main as m
+
+        return int(m(rest) or 0)
+    if cmd in {"studio-status", "studio_status"}:
+        from wattlab.studio.status import main as m
 
         return int(m(rest) or 0)
     if cmd in {"explore-existing", "hypothesis-lab"}:

--- a/vibe_code_apps_20/wattlab/deliverables.py
+++ b/vibe_code_apps_20/wattlab/deliverables.py
@@ -2,10 +2,11 @@
 
 Produces a curated folder + zip:
 
-  01_Report/   executive markdown
-  02_Results/  workbook (xlsx) + scorecard JSON + eplustbl when present
+  01_Report/   executive markdown (14-section outline)
+  02_Results/  workbook (xlsx) + scorecard JSON + Iteration_Runs sheet
   03_Models/   IDF + EPW + README (reproducibility)
   04_Outputs/  selected native EnergyPlus files
+  05_Source_Data/  answers / bills / session_status when present
   06_Documentation/ assumption + change stamps
 
 Not a substitute for a signed PE report — stamps honesty / G14 / area scale.
@@ -50,7 +51,7 @@ def build_executive_markdown(
     report: dict[str, Any] | None = None,
     profile: dict[str, Any] | None = None,
 ) -> str:
-    """Readable engineering report (markdown) — client layer."""
+    """Readable engineering report (markdown) — client layer (14-section outline)."""
     sc = scorecard or {}
     rp = report or {}
     pr = profile or {}
@@ -60,6 +61,7 @@ def build_executive_markdown(
         ann = (rp["result_records"][0] or {}).get("annual") or {}
     wx = sc.get("weather_suitability") or rp.get("weather_suitability") or {}
     g14 = bills.get("stats_electricity") or bills.get("stats") or {}
+    gas = bills.get("stats_gas") or {}
     lines = [
         "# Energy modeling report (WattLab)",
         "",
@@ -79,25 +81,28 @@ def build_executive_markdown(
         "> This package supports existing-building screening / calibration. "
         "It is **not** final equipment selection, TAB, or construction documents.",
         "",
-        "## 2. Scope and objectives",
+        "## 2. Project scope and objectives",
         "",
         "Baseline EnergyPlus simulation with optional ASHRAE Guideline 14 monthly "
-        "gates (NMBE ±5%, CV(RMSE) ≤15%) when utility bills and AMY weather align.",
+        "gates (NMBE ±5%, CV(RMSE) ≤15%) when utility bills and AMY weather align. "
+        "Retrofit screening via catalog ECMs / measure sets when requested.",
         "",
-        "## 3. Building description (from profile / dump)",
+        "## 3. Existing-building description",
         "",
         f"- Building type: {pr.get('building_type') or '—'}",
         f"- City (user label): {pr.get('climate_city') or pr.get('city') or '—'}",
         f"- Floor area ft²: {pr.get('floor_area_ft2') or pr.get('conditioned_floor_area_ft2') or '—'}",
         f"- Floors: {pr.get('floors') or pr.get('number_of_floors') or '—'}",
+        f"- Lat/lon: {pr.get('lat') or '—'} / {pr.get('lon') or '—'}",
         "",
-        "## 4. Data sources",
+        "## 4. Data sources and site observations",
         "",
         f"- Data window: `{json.dumps(sc.get('data_window') or {})}`",
         f"- EPW / AMY: see `03_Models/`",
         f"- Utility bills compared: {bills.get('months_compared', 0)} months",
+        f"- Answers / source data: see `05_Source_Data/` when packaged",
         "",
-        "## 5. Methodology and assumptions",
+        "## 5. Modeling methodology",
         "",
         "- Engine: EnergyPlus via Docker (`energyplus-mcp-dev`)",
         "- Seed prototype: DOE 5ZoneAirCooled unless a custom IDF is supplied",
@@ -105,25 +110,31 @@ def build_executive_markdown(
         "prototype geometry is **not** site CAD",
         f"- G14 scale mode: `{json.dumps(sc.get('g14_scale') or {})}`",
         "",
+        "## 6. Major assumptions",
+        "",
         f"Area honesty: {rp.get('area_honesty') or sc.get('honesty') or '—'}",
         "",
-        "## 6. Baseline results",
+        "See `06_Documentation/Assumption_Register.csv` for input confidence tags.",
+        "",
+        "## 7. Baseline-model results",
         "",
         f"- Electricity kWh/yr: {(ann.get('electricity_kwh_year') if isinstance(ann, dict) else None)}",
         f"- Natural gas therm/yr: {(ann.get('natural_gas_therm_year') if isinstance(ann, dict) else None)}",
         f"- Peak demand kW: {(ann.get('peak_demand_kw') if isinstance(ann, dict) else None)}",
         "",
-        "## 7. Utility calibration (ASHRAE G14 monthly)",
+        "## 8. Utility calibration (ASHRAE G14 monthly)",
         "",
         f"- Pass/fail: **{bills.get('pass_fail')}**",
         f"- Electricity NMBE %: {g14.get('nmbe_pct')}",
         f"- Electricity CV(RMSE) %: {g14.get('cvrmse_pct')}",
+        f"- Gas NMBE %: {gas.get('nmbe_pct') if gas else '—'}",
+        f"- Gas CV(RMSE) %: {gas.get('cvrmse_pct') if gas else '—'}",
         f"- Period mismatch: {bills.get('period_mismatch')}",
         "",
         "Do not claim “calibrated” without these statistics and disclosure of "
         "which inputs were changed.",
         "",
-        "## 8. Measures / savings",
+        "## 9. Energy-conservation measures",
         "",
     ]
     savings = rp.get("savings_by_measure") or []
@@ -138,27 +149,41 @@ def build_executive_markdown(
                 f"{vs.get('kwh_saved')} |"
             )
     else:
-        lines.append("_No progressive ECM table in this package (baseline-only or calibrate run)._")
+        lines.append(
+            "_No progressive ECM table in this package (baseline-only or calibrate run). "
+            "See `reports/ecm_scenario.json` / Easy Buttons for screening selections._"
+        )
     lines.extend(
         [
             "",
-            "## 9. Limitations",
+            "## 10. Savings, cost and emissions",
+            "",
+            "_Cost / emissions: NEEDS_INPUT unless rates and carbon factors were provided._",
+            "",
+            "## 11. HVAC sizing and operational findings",
+            "",
+            f"- Sizing scenario: **{sc.get('sizing_scenario') or rp.get('sizing_scenario') or 'autosize'}**",
+            f"- Peak demand kW: **{(ann.get('peak_demand_kw') if isinstance(ann, dict) else None) or '—'}**",
+            "",
+            "## 12. Limitations",
             "",
             "- Unscaled prototype footprint unless a site-specific IDF is provided",
             "- Weather may be AMY (calibration) or TMY substitute (screening only)",
             "- Shared-meter electric splits are scenarios, not measured submeters",
             "",
-            "## 10. Conclusions and next steps",
+            "## 13. Conclusions and recommendations",
             "",
             "1. Confirm NEEDS_INPUT site facts (area, stories, plant nameplates, meter split).",
             "2. Iterate AMY + constrained HVAC until G14 passes or document failure → ESCO proxies.",
             "3. Do not publish calibrated ROI until G14 status is VALIDATED / CALIBRATED_NOT_VALIDATED.",
             "",
-            "## Appendices",
+            "## 14. Technical appendices",
             "",
-            "- `02_Results/` — workbook + scorecard",
-            "- `03_Models/` — IDF / EPW / rerun README",
+            "- `02_Results/` — workbook + scorecard + Iteration_Runs",
+            "- `03_Models/` — IDF / EPW / rerun README (EnergyPlus version pin)",
             "- `04_Outputs/` — selected EnergyPlus tabular / err files",
+            "- `05_Source_Data/` — answers / bills / session_status when present",
+            "- `06_Documentation/` — assumption register + package stamp",
             "",
         ]
     )
@@ -169,6 +194,7 @@ def build_results_workbook_bytes(
     *,
     scorecard: dict[str, Any] | None = None,
     report: dict[str, Any] | None = None,
+    iteration_runs: list[dict[str, Any]] | None = None,
 ) -> bytes:
     """Excel workbook (openpyxl) — engineering layer."""
     from openpyxl import Workbook
@@ -304,6 +330,46 @@ def build_results_workbook_bytes(
     ]:
         ws5.append(list(row))
 
+    # Iteration runs dashboard
+    ws6 = wb.create_sheet("Iteration_Runs")
+    ws6.append(
+        [
+            "run_id",
+            "hypothesis",
+            "status",
+            "elapsed_s",
+            "weather_mode",
+            "g14_pass_fail",
+            "nmbe_elec_pct",
+        ]
+    )
+    g14_snip = (sc.get("utility_bills") or {}).get("pass_fail")
+    nmbe = ((sc.get("utility_bills") or {}).get("stats_electricity") or {}).get("nmbe_pct")
+    for it in iteration_runs or []:
+        ws6.append(
+            [
+                it.get("run_id"),
+                it.get("hypothesis"),
+                it.get("status"),
+                it.get("elapsed_s"),
+                it.get("weather_mode") or it.get("weather"),
+                it.get("g14_pass_fail") or g14_snip,
+                it.get("nmbe_elec_pct") or nmbe,
+            ]
+        )
+    if not iteration_runs and sc.get("run_id"):
+        ws6.append(
+            [
+                sc.get("run_id"),
+                "primary scorecard run",
+                sc.get("status"),
+                None,
+                (sc.get("weather_suitability") or {}).get("mode"),
+                g14_snip,
+                nmbe,
+            ]
+        )
+
     buf = io.BytesIO()
     wb.save(buf)
     return buf.getvalue()
@@ -342,6 +408,8 @@ def package_deliverables(
     report: dict[str, Any] | None = None,
     profile: dict[str, Any] | None = None,
     zip_name: str | None = None,
+    source_files: list[Path] | None = None,
+    iteration_runs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Write curated deliverable tree + zip; return paths/meta."""
     out = Path(out_dir)
@@ -352,6 +420,7 @@ def package_deliverables(
         "02_Results",
         "03_Models/Baseline",
         "04_Outputs/Baseline",
+        "05_Source_Data",
         "06_Documentation",
     ):
         (out / sub).mkdir(parents=True, exist_ok=True)
@@ -365,11 +434,24 @@ def package_deliverables(
     if not rp and run_dir:
         rp = _safe_read_json(Path(run_dir) / "wattlab_report.json")
 
+    # Collect iteration rows for workbook when not provided
+    iters = list(iteration_runs or [])
+    if not iters and run_dir is not None:
+        try:
+            from wattlab.studio.ep_viz import list_iteration_runs
+            from wattlab.studio.workspace import runs_dir
+
+            iters = list_iteration_runs(runs_dir(), limit=20)
+        except Exception:  # noqa: BLE001
+            iters = []
+
     md = build_executive_markdown(scorecard=sc, report=rp, profile=profile)
     report_path = out / "01_Report" / "Energy_Modeling_Report.md"
     report_path.write_text(md, encoding="utf-8")
 
-    xlsx_bytes = build_results_workbook_bytes(scorecard=sc, report=rp)
+    xlsx_bytes = build_results_workbook_bytes(
+        scorecard=sc, report=rp, iteration_runs=iters
+    )
     xlsx_path = out / "02_Results" / "Energy_Model_Results.xlsx"
     xlsx_path.write_bytes(xlsx_bytes)
 
@@ -442,11 +524,54 @@ def package_deliverables(
         manifest = _safe_read_json(root / "run_manifest.json")
         ep_ver = manifest.get("energyplus_version") or manifest.get("docker_image")
 
+        # Campaign change log if present
+        for name in ("campaign_stamp.json", "Model_Change_Log.json", "change_log.json"):
+            cl = root / name
+            if cl.is_file():
+                shutil.copy2(cl, out / "06_Documentation" / name)
+                break
+
     readme = build_rerun_readme(
         energyplus_version=str(ep_ver) if ep_ver else None,
         run_id=str(sc.get("run_id") or rp.get("run_id") or ""),
     )
     (out / "03_Models" / "Baseline" / "README.md").write_text(readme, encoding="utf-8")
+
+    # 05_Source_Data — answers / bills / session_status
+    src_dest = out / "05_Source_Data"
+    copied_src: list[str] = []
+    candidates = list(source_files or [])
+    try:
+        from wattlab.studio.workspace import reports_dir
+
+        reports = reports_dir()
+        for name in (
+            "answers.json",
+            "answers_building_100.json",
+            "answers_building_50.json",
+            "utility_bills.csv",
+            "session_status.json",
+            "ecm_scenario.json",
+        ):
+            p = reports / name
+            if p.is_file():
+                candidates.append(p)
+    except Exception:  # noqa: BLE001
+        pass
+    seen: set[str] = set()
+    for p in candidates:
+        p = Path(p)
+        if not p.is_file() or p.name in seen:
+            continue
+        seen.add(p.name)
+        shutil.copy2(p, src_dest / p.name)
+        copied_src.append(p.name)
+    (src_dest / "README.md").write_text(
+        "# Source data\n\n"
+        "Copies of answers / bills / session_status / ecm_scenario when present "
+        "on the Studio workspace at package time.\n",
+        encoding="utf-8",
+    )
 
     stamp = {
         "product": "WattLab deliverable package",
@@ -455,6 +580,8 @@ def package_deliverables(
         "g14_pass_fail": (sc.get("utility_bills") or {}).get("pass_fail"),
         "weather_mode": (sc.get("weather_suitability") or {}).get("mode"),
         "prototype_area_scale": sc.get("prototype_area_scale") or rp.get("prototype_area_scale"),
+        "source_data_files": copied_src,
+        "iteration_runs_count": len(iters),
         "intended_use": (
             "Existing-building energy analysis and retrofit screening. "
             "Not a substitute for detailed mechanical design."

--- a/vibe_code_apps_20/wattlab/studio/bootstrap.py
+++ b/vibe_code_apps_20/wattlab/studio/bootstrap.py
@@ -29,6 +29,7 @@ _KNOWN_KEYS = frozenset(
         "dump_zip",
         "preferred_run_id",
         "answers_path",
+        "ecm_scenario_path",
         "auto_refresh_runs",
         "notes",
     }
@@ -322,6 +323,14 @@ def apply_bootstrap_to_session(
         except Exception as exc:  # noqa: BLE001
             result["needs_input"].append(f"answers load failed: {exc}")
 
+    ecm_rel = payload.get("ecm_scenario_path")
+    ecm_path = _resolve_under_workspace(root, ecm_rel) if ecm_rel else None
+    if ecm_rel and ecm_path is None:
+        result["needs_input"].append(f"ecm_scenario_path missing: {ecm_rel}")
+    elif ecm_path is not None:
+        _ss_set(session_state, "studio_ecm_scenario_path", str(ecm_path))
+        notes.append(f"ecm_scenario ← {ecm_rel}")
+
     if payload.get("auto_refresh_runs", True):
         rid = payload.get("preferred_run_id")
         run_dir: Path | None = None
@@ -343,6 +352,32 @@ def apply_bootstrap_to_session(
         if run_dir is not None:
             _ss_set(session_state, "studio_active_run", str(run_dir.resolve()))
             notes.append(f"Twin run ← {run_dir.name}")
+
+            # Prefer resolved_profile.json from the run when answers incomplete
+            if not _ss_get(session_state, "studio_profile"):
+                rp = run_dir / "resolved_profile.json"
+                if rp.is_file():
+                    try:
+                        profile = json.loads(rp.read_text(encoding="utf-8"))
+                        if isinstance(profile, dict) and profile:
+                            _ss_set(session_state, "studio_profile", profile)
+                            notes.append("studio_profile ← run resolved_profile.json")
+                    except (OSError, json.JSONDecodeError):
+                        pass
+
+    # Promote answers → studio_profile so ECMs unlock without Twin form click
+    answers = _ss_get(session_state, "studio_answers")
+    if isinstance(answers, dict) and not _ss_get(session_state, "studio_profile"):
+        try:
+            from wattlab.studio.status import answers_complete, profile_minimal_from_answers
+            from wattlab.defaults import resolve_profile
+
+            if answers_complete(answers):
+                profile = resolve_profile(profile_minimal_from_answers(answers))
+                _ss_set(session_state, "studio_profile", profile)
+                notes.append("studio_profile ← answers.json")
+        except Exception as exc:  # noqa: BLE001
+            result["warnings"].append(f"profile from answers skipped: {exc}")
 
     mtime = bootstrap_file_mtime(path)
     _ss_set(session_state, "_studio_bootstrapped", True)

--- a/vibe_code_apps_20/wattlab/studio/ecm_scenario.py
+++ b/vibe_code_apps_20/wattlab/studio/ecm_scenario.py
@@ -1,0 +1,69 @@
+"""Load / save ``reports/ecm_scenario.json`` for Easy Buttons ↔ agent handoff."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ECM_SCENARIO_NAME = "ecm_scenario.json"
+ECM_SCENARIO_VERSION = 1
+
+
+def default_ecm_scenario_path(workspace: Path | None = None) -> Path:
+    from wattlab.studio.workspace import reports_dir
+
+    if workspace is not None:
+        return Path(workspace) / "reports" / DEFAULT_ECM_SCENARIO_NAME
+    return reports_dir() / DEFAULT_ECM_SCENARIO_NAME
+
+
+def empty_ecm_scenario() -> dict[str, Any]:
+    return {
+        "version": ECM_SCENARIO_VERSION,
+        "selected_ecm_ids": [],
+        "measure_set": None,
+        "notes": "",
+        "recommendations": [],
+        "status": "empty — waiting agent or Easy Buttons",
+    }
+
+
+def load_ecm_scenario(path: Path | str | None = None) -> dict[str, Any]:
+    p = Path(path) if path is not None else default_ecm_scenario_path()
+    if not p.is_file():
+        return empty_ecm_scenario()
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return empty_ecm_scenario()
+    if not isinstance(raw, dict):
+        return empty_ecm_scenario()
+    out = empty_ecm_scenario()
+    out.update(raw)
+    out["version"] = ECM_SCENARIO_VERSION
+    ids = out.get("selected_ecm_ids") or []
+    if not isinstance(ids, list):
+        ids = []
+    out["selected_ecm_ids"] = [str(x) for x in ids]
+    return out
+
+
+def save_ecm_scenario(
+    payload: dict[str, Any],
+    *,
+    path: Path | str | None = None,
+) -> Path:
+    p = Path(path) if path is not None else default_ecm_scenario_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    body = empty_ecm_scenario()
+    body.update(payload or {})
+    body["version"] = ECM_SCENARIO_VERSION
+    ids = body.get("selected_ecm_ids") or []
+    body["selected_ecm_ids"] = [str(x) for x in ids] if isinstance(ids, list) else []
+    if body["selected_ecm_ids"]:
+        body["status"] = f"{len(body['selected_ecm_ids'])} ECMs selected"
+    else:
+        body["status"] = "empty — waiting agent or Easy Buttons"
+    p.write_text(json.dumps(body, indent=2), encoding="utf-8")
+    return p

--- a/vibe_code_apps_20/wattlab/studio/ep_viz.py
+++ b/vibe_code_apps_20/wattlab/studio/ep_viz.py
@@ -233,6 +233,27 @@ def outdoor_figure(outdoor: pd.DataFrame):
     return fig
 
 
+def _elapsed_seconds(manifest: dict[str, Any] | None) -> float | None:
+    """Parse started_at / finished_at ISO stamps into elapsed seconds."""
+    if not manifest:
+        return None
+    started = manifest.get("started_at")
+    finished = manifest.get("finished_at")
+    if not started or not finished:
+        return None
+    try:
+        from datetime import datetime
+
+        def _parse(s: str) -> datetime:
+            s = str(s).replace("Z", "+00:00")
+            return datetime.fromisoformat(s)
+
+        delta = _parse(finished) - _parse(started)
+        return max(0.0, float(delta.total_seconds()))
+    except (TypeError, ValueError, OSError):
+        return None
+
+
 def read_run_progress(run_dir: Path) -> dict[str, Any]:
     """Load progress/log/manifest for the 08 left-hand manage card."""
     run_dir = Path(run_dir)
@@ -243,6 +264,11 @@ def read_run_progress(run_dir: Path) -> dict[str, Any]:
         "log_tail": "",
         "manifest": {},
         "replay": False,
+        "started_at": None,
+        "finished_at": None,
+        "elapsed_s": None,
+        "hypothesis": None,
+        "weather_mode": None,
     }
     manifest_path = run_dir / "run_manifest.json"
     if manifest_path.is_file():
@@ -250,8 +276,43 @@ def read_run_progress(run_dir: Path) -> dict[str, Any]:
             out["manifest"] = json.loads(manifest_path.read_text(encoding="utf-8"))
             out["status"] = str(out["manifest"].get("status") or out["status"])
             out["run_id"] = str(out["manifest"].get("run_id") or out["run_id"])
+            out["started_at"] = out["manifest"].get("started_at")
+            out["finished_at"] = out["manifest"].get("finished_at")
+            out["elapsed_s"] = _elapsed_seconds(out["manifest"])
+            out["hypothesis"] = (
+                out["manifest"].get("hypothesis")
+                or out["manifest"].get("notes")
+                or out["manifest"].get("label")
+            )
+            out["weather_mode"] = out["manifest"].get("weather_mode") or (
+                (out["manifest"].get("weather") or {}) if isinstance(out["manifest"].get("weather"), dict) else {}
+            )
+            if isinstance(out["weather_mode"], dict):
+                out["weather_mode"] = out["weather_mode"].get("mode")
         except (OSError, json.JSONDecodeError):
             pass
+    # Hypothesis from wattlab_report / scorecard when manifest lacks it
+    if not out["hypothesis"]:
+        for name in ("wattlab_report.json", "calibration_scorecard.json"):
+            rp = run_dir / name
+            if rp.is_file():
+                try:
+                    data = json.loads(rp.read_text(encoding="utf-8"))
+                    out["hypothesis"] = (
+                        data.get("hypothesis")
+                        or data.get("notes")
+                        or (data.get("weather_suitability") or {}).get("reason")
+                    )
+                    if not out["weather_mode"]:
+                        out["weather_mode"] = (data.get("weather_suitability") or {}).get("mode")
+                    if out["hypothesis"]:
+                        break
+                except (OSError, json.JSONDecodeError):
+                    continue
+    if not out["hypothesis"]:
+        # Readable stem: t10_b100_r2_amy_lockout60 → amy lockout60
+        stem = out["run_id"]
+        out["hypothesis"] = stem.replace("_", " ") if stem else None
     progress_path = run_dir / "progress.json"
     if progress_path.is_file():
         try:
@@ -260,7 +321,7 @@ def read_run_progress(run_dir: Path) -> dict[str, Any]:
             out["status"] = str(prog.get("status") or out["status"])
         except (OSError, json.JSONDecodeError, TypeError, ValueError):
             pass
-    elif out["status"] in {"ok", "success", "completed", "complete"}:
+    elif out["status"] in {"ok", "success", "completed", "complete", "published"}:
         out["progress"] = 100
     for log_name in ("eplusout.err", "energyplus.log", "console.log", "run.log"):
         lp = run_dir / log_name
@@ -275,6 +336,10 @@ def read_run_progress(run_dir: Path) -> dict[str, Any]:
         out["replay"] = True
         out["progress"] = max(out["progress"], 100)
         out["status"] = out["status"] if out["status"] != "unknown" else "replay"
+    try:
+        out["mtime"] = float(run_dir.stat().st_mtime)
+    except OSError:
+        out["mtime"] = None
     return out
 
 
@@ -284,7 +349,7 @@ def list_iteration_runs(runs_root: Path, limit: int = 20) -> list[dict[str, Any]
         return []
     rows: list[dict[str, Any]] = []
     for d in sorted(root.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
-        if not d.is_dir():
+        if not d.is_dir() or d.name.startswith("_"):
             continue
         info = read_run_progress(d)
         info["dir"] = str(d)

--- a/vibe_code_apps_20/wattlab/studio/pages/ecm_easy_buttons.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecm_easy_buttons.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -12,6 +13,7 @@ import streamlit as st
 from wattlab.ecm.catalog import ECMEntry, load_catalog
 from wattlab.ecm.interactions import detect_incompatibilities
 from wattlab.ecm.packages import PACKAGES, resolve_package
+from wattlab.studio.ecm_scenario import load_ecm_scenario, save_ecm_scenario
 from wattlab.studio.state import namespaced_key
 
 NS = "ecm_easy"
@@ -33,6 +35,27 @@ def _selected_entries(entries: list[ECMEntry], package_names: list[str]) -> list
     return list(dict.fromkeys(selected))
 
 
+def _scenario_path() -> Path | None:
+    raw = st.session_state.get("studio_ecm_scenario_path")
+    if raw:
+        return Path(str(raw))
+    return None
+
+
+def _ensure_checkbox_defaults(entries: list[ECMEntry], selected_ids: list[str]) -> None:
+    """Seed checkbox keys once from ecm_scenario.json (agent prefill)."""
+    if st.session_state.get(_key("scenario_seeded")):
+        return
+    want = set(selected_ids)
+    for entry in entries:
+        k = _key(f"select.{entry.ecm_id}")
+        if k not in st.session_state:
+            st.session_state[k] = entry.ecm_id in want
+    st.session_state[_key("scenario_seeded")] = True
+    if selected_ids:
+        st.session_state[_key("scenario_ids")] = list(selected_ids)
+
+
 def render(
     *,
     profile: dict[str, Any] | None = None,
@@ -43,6 +66,7 @@ def render(
     st.header("ECM Easy Buttons")
     st.caption(
         "Build a screening scenario from the canonical ECM catalog. "
+        "Agents write `reports/ecm_scenario.json`; Re-apply / open this page to pre-check. "
         "Availability and evidence status remain visible before every action."
     )
     try:
@@ -50,6 +74,15 @@ def render(
     except (OSError, ValueError, ImportError) as exc:
         st.info(f"The ECM catalog is unavailable: {exc}")
         return
+
+    scenario = load_ecm_scenario(_scenario_path())
+    _ensure_checkbox_defaults(entries, list(scenario.get("selected_ecm_ids") or []))
+    recs = scenario.get("recommendations") or []
+    if recs:
+        st.info(
+            "Agent recommendations (unchecked suggestions): "
+            + ", ".join(str(r) for r in recs[:12])
+        )
 
     packages = st.multiselect(
         "Bulk-select packages",
@@ -83,7 +116,7 @@ def render(
     for issue in issues:
         st.warning(issue.note)
 
-    a1, a2, a3 = st.columns(3)
+    a1, a2, a3, a4 = st.columns(4)
     if a1.button("Add to scenario", key=_key("add"), width="stretch"):
         st.session_state[_key("scenario_ids")] = selected
         if selected:
@@ -93,6 +126,22 @@ def render(
 
     scenario_ids = st.session_state.get(_key("scenario_ids"), selected)
     if a2.button(
+        "Save to ecm_scenario.json",
+        key=_key("save_scenario"),
+        width="stretch",
+    ):
+        path = save_ecm_scenario(
+            {
+                **scenario,
+                "selected_ecm_ids": list(scenario_ids or selected),
+                "measure_set": (profile or {}).get("measure_set") or scenario.get("measure_set"),
+                "notes": scenario.get("notes") or "Saved from Studio Easy Buttons",
+            },
+            path=_scenario_path(),
+        )
+        st.success(f"Wrote `{path}`")
+
+    if a3.button(
         "Calculate Proxy",
         key=_key("calculate_proxy"),
         width="stretch",
@@ -118,7 +167,7 @@ def render(
         if load_catalog().get(ecm_id).status in {"NEEDS_IMPLEMENTATION", "RESEARCH"}
     ]
     run_disabled = not scenario_ids or bool(blocked)
-    a3.button(
+    a4.button(
         "Run EnergyPlus",
         key=_key("run_energyplus"),
         width="stretch",

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -24,7 +24,18 @@ def render() -> None:
 
     profile = st.session_state.get("studio_profile")
     if not profile:
-        st.info("Resolve a profile on **Twin / calibrate** first.")
+        answers = st.session_state.get("studio_answers")
+        st.info(
+            "Resolve a profile on **Twin / calibrate** first — or bootstrap with "
+            "`answers_path` so Re-apply builds `studio_profile` automatically. "
+            "Agents: `wattlab studio-status --write` then fill answers / "
+            "`reports/ecm_scenario.json`."
+        )
+        if isinstance(answers, dict):
+            st.caption(
+                f"answers.json present (type={answers.get('building_type')}, "
+                f"city={answers.get('city')}) — Re-apply bootstrap to unlock ECMs."
+            )
         return
 
     # --- Easy Buttons catalog ---

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
@@ -114,14 +114,38 @@ def _render_portfolio(summary: dict[str, Any], campus: Campus, px, go) -> None:
     )
 
     st.subheader("Site EUI vs peers (same property type)")
+    with st.expander("How buildings are benchmarked", expanded=False):
+        st.markdown(
+            "Site EUI is annualized utility energy ÷ floor area (kBtu/ft²·yr). "
+            "Peer **p20 / p50 / p80** come from a public EPA/CBECS-style registry "
+            "keyed by each building's `property_type` (office, school, …). "
+            "Below p20 ≈ efficient vs peers; above p80 ≈ needs attention. "
+            "This is a screening band — not ENERGY STAR scores or calibrated models."
+        )
     rows = _peer_rows(summary)
     dfb = pd.DataFrame(rows)
     b0 = rows[0]
     p1, p2, p3, p4 = st.columns(4)
-    p1.metric("Bill site EUI", f"{b0['site_eui_kbtu_ft2']} kBtu/ft²")
-    p2.metric("Peer typical (p50)", f"{b0['peer_p50']} kBtu/ft²")
-    p3.metric("Peer p20–p80", f"{b0['peer_p20']} – {b0['peer_p80']}")
-    p4.metric("vs median", f"{b0['peer_vs_median_pct']:+.1f}% · {b0['peer_band']}")
+    p1.metric(
+        "Bill site EUI",
+        f"{b0['site_eui_kbtu_ft2']} kBtu/ft²",
+        help="Annualized campus/building bills ÷ floor area (kBtu/ft²·yr).",
+    )
+    p2.metric(
+        "Peer typical (p50)",
+        f"{b0['peer_p50']} kBtu/ft²",
+        help="Median peer site EUI for this property_type (EPA/CBECS-style registry).",
+    )
+    p3.metric(
+        "Peer p20–p80",
+        f"{b0['peer_p20']} – {b0['peer_p80']}",
+        help="Typical peer band: p20 (efficient side) to p80 (high side).",
+    )
+    p4.metric(
+        "vs median",
+        f"{b0['peer_vs_median_pct']:+.1f}% · {b0['peer_band']}",
+        help="Percent vs peer p50 and band label (efficient / typical / high).",
+    )
 
     fig_peer = go.Figure()
     p20 = float(dfb["peer_p20"].iloc[0])

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -47,8 +47,10 @@ def _render_eui_index(
 
     st.subheader("EUI index — bills vs peers vs model")
     st.caption(
-        "Peer bands from public EPA/CBECS-style registry (kBtu/ft²-yr). "
-        "Model EUI is on the prototype footprint unless scaled — see note."
+        "**Bills** = your campus annualized site EUI. "
+        "**Peers** = EPA/CBECS-style registry p20/p50/p80 for this property type. "
+        "**Model** = EnergyPlus intensity on the prototype footprint "
+        "(comparable as EUI; absolute kWh is not site totals until geometry is scaled)."
     )
     bill_eui = None
     ptype = "office"
@@ -102,13 +104,26 @@ def _render_eui_index(
         model_label=str(model.get("run_id") or report.get("run_id") or "EnergyPlus"),
     )
     m1, m2, m3, m4 = st.columns(4)
-    m1.metric("Bills site EUI", f"{idx['bill_eui_kbtu_ft2']} kBtu/ft²" if idx["bill_eui_kbtu_ft2"] is not None else "—")
-    m2.metric("Peer typical (p50)", f"{idx['peer_p50']} kBtu/ft²")
+    m1.metric(
+        "Bills site EUI",
+        f"{idx['bill_eui_kbtu_ft2']} kBtu/ft²" if idx["bill_eui_kbtu_ft2"] is not None else "—",
+        help="Annualized utility bills ÷ floor area (kBtu/ft²·yr).",
+    )
+    m2.metric(
+        "Peer typical (p50)",
+        f"{idx['peer_p50']} kBtu/ft²",
+        help="Median peer site EUI for this property type (public registry).",
+    )
     m3.metric(
         "Model EUI (prototype)",
         f"{idx['model_eui_kbtu_ft2']} kBtu/ft²" if idx["model_eui_kbtu_ft2"] is not None else "—",
+        help="EnergyPlus site EUI on prototype area (intensity comparable; scale absolute kWh).",
     )
-    m4.metric("Peer band", f"p20={idx['peer_p20']} · p80={idx['peer_p80']}")
+    m4.metric(
+        "Peer band",
+        f"p20={idx['peer_p20']} · p80={idx['peer_p80']}",
+        help="p20–p80 peer band: below p20 is efficient vs peers; above p80 needs attention.",
+    )
 
     df = pd.DataFrame(idx["rows"])
     st.dataframe(df, width="stretch", hide_index=True)
@@ -331,9 +346,22 @@ def render() -> None:
 
     if bundle is not None:
         gaps = gap_report(bundle)
-        missing = [g for g in gaps if g.get("severity") == "required" and g.get("status") == "missing"]
+        answers = st.session_state.get("studio_answers")
+        from wattlab.studio.status import required_gaps_still_missing, soften_required_gaps
+
+        soft = soften_required_gaps(gaps, answers if isinstance(answers, dict) else None)
+        missing = required_gaps_still_missing(gaps, answers if isinstance(answers, dict) else None)
+        answered_via = [
+            g for g in soft
+            if g.get("severity") == "required" and g.get("status") == "answered" and g.get("via")
+        ]
         if missing:
             st.warning("Dump still missing: " + ", ".join(g["field"] for g in missing))
+        elif answered_via:
+            st.info(
+                "Dump seed nulls covered by answers.json: "
+                + ", ".join(g["field"] for g in answered_via)
+            )
 
     profile = _profile()
     active_preview = _resolve_active_run()
@@ -729,10 +757,15 @@ def render() -> None:
                     key="dl_deliverable_zip",
                 )
             st.caption(
-                "Zip layout: `01_Report` · `02_Results` · `03_Models` · `04_Outputs` · `06_Documentation`"
+                "Zip: `01_Report` · `02_Results` · `03_Models` · `04_Outputs` · "
+                "`05_Source_Data` · `06_Documentation` — or download report/workbook alone."
             )
 
     st.subheader("Iteration history (agent + Studio)")
+    st.caption(
+        "Each published `runs/<id>/` after agent/CLI EnergyPlus. "
+        "Elapsed comes from `run_manifest.json` started_at → finished_at."
+    )
     hist = list_iteration_runs(runs_dir(), limit=15)
     if not hist:
         manifests = sorted(ARTIFACTS.glob("wattlab_*/run_manifest.json"), reverse=True)[:10]
@@ -745,6 +778,10 @@ def render() -> None:
                         "status": m.get("status"),
                         "dir": str(mp.parent),
                         "progress": 100 if m.get("status") in {"ok", "success", "SUCCESS"} else 0,
+                        "started_at": m.get("started_at"),
+                        "finished_at": m.get("finished_at"),
+                        "elapsed_s": None,
+                        "hypothesis": m.get("hypothesis") or m.get("notes"),
                     }
                 )
             except Exception:
@@ -752,20 +789,55 @@ def render() -> None:
     if not hist:
         st.caption("No prior runs in workspace runs/.")
     else:
+        st.metric("Published iterations shown", len(hist))
         enriched = []
         for h in hist:
-            row = dict(h)
+            row = {
+                "run_id": h.get("run_id"),
+                "hypothesis": h.get("hypothesis"),
+                "weather": h.get("weather_mode"),
+                "status": h.get("status"),
+                "eplusout": "yes" if h.get("has_eplusout") else "no",
+                "elapsed_s": h.get("elapsed_s"),
+                "progress": h.get("progress"),
+                "dir": h.get("dir"),
+            }
             model = load_model_eui_from_run(Path(str(h["dir"])) if h.get("dir") else None)
             if model.get("model_eui_kbtu_ft2") is not None:
                 row["model_eui_kbtu_ft2"] = model["model_eui_kbtu_ft2"]
             if model.get("prototype_area_scale") is not None:
                 row["prototype_area_scale"] = model["prototype_area_scale"]
-            if model.get("weather_mode"):
-                row["weather_mode"] = model["weather_mode"]
+            if model.get("weather_mode") and not row.get("weather"):
+                row["weather"] = model["weather_mode"]
             if model.get("peak_demand_kw") is not None:
                 row["peak_demand_kw"] = model["peak_demand_kw"]
+            if row.get("elapsed_s") is not None:
+                try:
+                    row["elapsed_min"] = round(float(row["elapsed_s"]) / 60.0, 2)
+                except (TypeError, ValueError):
+                    pass
             enriched.append(row)
-        st.dataframe(pd.DataFrame(enriched), width="stretch", hide_index=True)
+        show_cols = [
+            c
+            for c in (
+                "run_id",
+                "hypothesis",
+                "weather",
+                "status",
+                "eplusout",
+                "elapsed_min",
+                "elapsed_s",
+                "model_eui_kbtu_ft2",
+                "peak_demand_kw",
+                "prototype_area_scale",
+            )
+            if any(c in r for r in enriched)
+        ]
+        st.dataframe(
+            pd.DataFrame(enriched)[show_cols] if show_cols else pd.DataFrame(enriched),
+            width="stretch",
+            hide_index=True,
+        )
         pick = st.selectbox(
             "Inspect iteration",
             options=[h.get("dir") for h in hist if h.get("dir")],

--- a/vibe_code_apps_20/wattlab/studio/pages/uploads.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/uploads.py
@@ -184,12 +184,26 @@ def render() -> None:
         m3.metric("Tables", str(len(s.get("tables") or {})))
         m4.metric("Bills in dump", "yes" if s.get("has_bills") else "no")
         gaps = gap_report(bundle)
-        missing = [g for g in gaps if g.get("severity") == "required" and g.get("status") == "missing"]
+        answers = st.session_state.get("studio_answers")
+        from wattlab.studio.status import required_gaps_still_missing, soften_required_gaps
+
+        soft = soften_required_gaps(gaps, answers if isinstance(answers, dict) else None)
+        missing = required_gaps_still_missing(gaps, answers if isinstance(answers, dict) else None)
+        answered_via = [
+            g for g in soft
+            if g.get("severity") == "required" and g.get("status") == "answered" and g.get("via")
+        ]
         if missing:
             st.warning(
                 "NEEDS_INPUT: "
                 + ", ".join(str(g["field"]) for g in missing)
                 + " — fill on Twin / calibrate (or via agent answers.json)."
+            )
+        elif answered_via:
+            st.info(
+                "Dump seed nulls answered via answers.json: "
+                + ", ".join(str(g["field"]) for g in answered_via)
+                + " — Re-apply bootstrap or Twin form if profile not loaded."
             )
         if bundle.manifest:
             with st.expander("MANIFEST.json", expanded=False):

--- a/vibe_code_apps_20/wattlab/studio/status.py
+++ b/vibe_code_apps_20/wattlab/studio/status.py
@@ -1,0 +1,334 @@
+"""Machine-readable Studio session status (agent-first).
+
+``wattlab studio-status`` merges dump gaps ∩ answers ∩ bootstrap ∩ run
+scorecard ∩ ecm_scenario into ``reports/session_status.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+STATUS_VERSION = 1
+REQUIRED_ANSWER_FIELDS = ("building_type", "city", "floor_area_ft2")
+OPTIONAL_ANSWER_FIELDS = ("floors", "lat", "lon", "wwr", "utility", "measure_set")
+PHASE2_FIELDS = ("interval_meters", "tariffs", "carbon")
+
+
+def answers_template_path() -> Path:
+    return Path(__file__).resolve().parent / "templates" / "answers.schema.template.json"
+
+
+def ecm_scenario_template_path() -> Path:
+    return Path(__file__).resolve().parent / "templates" / "ecm_scenario.template.json"
+
+
+def _truthy(val: Any) -> bool:
+    return val not in (None, "", {}, [])
+
+
+def _field_row(
+    *,
+    required: bool,
+    dump: Any = None,
+    answers: Any = None,
+    phase: int | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {"required": required}
+    if phase is not None:
+        row["phase"] = phase
+    if dump is not None or (required and phase is None):
+        row["dump"] = dump
+    if answers is not None or _truthy(answers):
+        row["answers"] = answers
+    if phase == 2:
+        row["status"] = "phase2" if not _truthy(answers) else "answered"
+    elif _truthy(answers):
+        row["status"] = "answered"
+    elif _truthy(dump):
+        row["status"] = "answered"
+        row["note"] = note or "from dump"
+    elif required:
+        row["status"] = "missing"
+    else:
+        row["status"] = "missing"
+    if note and "note" not in row:
+        row["note"] = note
+    return row
+
+
+def answers_complete(answers: dict[str, Any] | None) -> bool:
+    if not isinstance(answers, dict):
+        return False
+    return all(_truthy(answers.get(k)) for k in REQUIRED_ANSWER_FIELDS)
+
+
+def profile_minimal_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
+    """Shape Twin form / resolve_profile expects."""
+    minimal: dict[str, Any] = {
+        "building_type": str(answers["building_type"]).strip(),
+        "city": str(answers["city"]).strip(),
+        "floor_area_ft2": float(answers["floor_area_ft2"]),
+    }
+    if _truthy(answers.get("floors")):
+        minimal["floors"] = int(answers["floors"])
+    if _truthy(answers.get("lat")):
+        minimal["lat"] = float(answers["lat"])
+    if _truthy(answers.get("lon")):
+        minimal["lon"] = float(answers["lon"])
+    if _truthy(answers.get("measure_set")):
+        minimal["measure_set"] = str(answers["measure_set"])
+    if isinstance(answers.get("utility"), dict):
+        minimal["utility"] = answers["utility"]
+    return minimal
+
+
+def soften_required_gaps(
+    gaps: list[dict[str, Any]],
+    answers: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Mark dump required gaps answered when answers.json fills them."""
+    if not answers:
+        return list(gaps)
+    out: list[dict[str, Any]] = []
+    for g in gaps:
+        row = dict(g)
+        field = str(row.get("field") or "")
+        if (
+            row.get("severity") == "required"
+            and row.get("status") == "missing"
+            and field in REQUIRED_ANSWER_FIELDS
+            and _truthy(answers.get(field))
+        ):
+            row["status"] = "answered"
+            row["value"] = answers.get(field)
+            row["via"] = "answers.json"
+        out.append(row)
+    return out
+
+
+def required_gaps_still_missing(
+    gaps: list[dict[str, Any]],
+    answers: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    soft = soften_required_gaps(gaps, answers)
+    return [
+        g
+        for g in soft
+        if g.get("severity") == "required" and g.get("status") == "missing"
+    ]
+
+
+def _load_json(path: Path | None) -> dict[str, Any]:
+    if path is None or not Path(path).is_file():
+        return {}
+    try:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def build_session_status(
+    *,
+    workspace: Path | None = None,
+    dump_path: Path | str | None = None,
+    answers_path: Path | str | None = None,
+    bootstrap_path: Path | str | None = None,
+    run_dir: Path | str | None = None,
+    ecm_scenario_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Merge workspace artifacts into one agent-readable status sheet."""
+    from wattlab.studio.bootstrap import resolve_bootstrap_path
+    from wattlab.studio.ecm_scenario import load_ecm_scenario
+    from wattlab.studio.workspace import ensure_workspace, reports_dir, runs_dir
+
+    root = Path(workspace) if workspace is not None else ensure_workspace()
+    boot_path = Path(bootstrap_path) if bootstrap_path else resolve_bootstrap_path(root)
+    boot = _load_json(boot_path)
+
+    ans_path = Path(answers_path) if answers_path else None
+    if ans_path is None and boot.get("answers_path"):
+        cand = Path(str(boot["answers_path"]))
+        if not cand.is_absolute():
+            cand = root / cand
+        ans_path = cand if cand.is_file() else None
+    reports = root / "reports"
+    if ans_path is None:
+        for name in (
+            "answers.json",
+            "answers_building_100.json",
+            "answers_building_50.json",
+        ):
+            hit = reports / name
+            if hit.is_file():
+                ans_path = hit
+                break
+    answers = _load_json(ans_path)
+
+    dump_p = Path(dump_path) if dump_path else None
+    if dump_p is None and boot.get("dump_zip"):
+        cand = Path(str(boot["dump_zip"]))
+        if not cand.is_absolute():
+            cand = root / cand
+        dump_p = cand if cand.exists() else None
+
+    gaps: list[dict[str, Any]] = []
+    dump_seed: dict[str, Any] = {}
+    building_id = None
+    if dump_p is not None and dump_p.exists():
+        try:
+            from wattlab.seed import gap_report, load_bundle
+
+            bundle = load_bundle(dump_p)
+            gaps = gap_report(bundle)
+            dump_seed = dict(bundle.model_seed or {})
+            building_id = (
+                dump_seed.get("building_id")
+                or (bundle.building_profile or {}).get("building_id")
+                or dump_p.stem
+            )
+        except Exception as exc:  # noqa: BLE001
+            gaps = [{"field": "_dump", "severity": "required", "status": "blocked", "why": str(exc)}]
+
+    soft_gaps = soften_required_gaps(gaps, answers)
+    gap_by_field = {str(g.get("field")): g for g in soft_gaps}
+
+    fields: dict[str, Any] = {}
+    for name in REQUIRED_ANSWER_FIELDS:
+        g = gap_by_field.get(name) or {}
+        fields[name] = _field_row(
+            required=True,
+            dump=g.get("value") if g.get("status") in {"ok", "answered"} and not g.get("via") else dump_seed.get(name),
+            answers=answers.get(name),
+            note=g.get("via"),
+        )
+        if g.get("via") == "answers.json" and fields[name]["status"] == "answered":
+            fields[name]["note"] = "answered via answers.json (dump null)"
+    for name in OPTIONAL_ANSWER_FIELDS:
+        g = gap_by_field.get(name) or {}
+        fields[name] = _field_row(
+            required=False,
+            dump=g.get("value") if g.get("status") == "ok" else dump_seed.get(name),
+            answers=answers.get(name),
+        )
+    for name in PHASE2_FIELDS:
+        fields[name] = _field_row(required=False, phase=2, answers=answers.get(name))
+
+    # utility_bills from gap or answers note
+    ub = gap_by_field.get("utility_bills") or {}
+    fields["utility_bills"] = {
+        "required": False,
+        "status": "answered" if ub.get("status") == "ok" else "missing",
+        "note": ub.get("value") or ub.get("why"),
+    }
+
+    run_p: Path | None = Path(run_dir) if run_dir else None
+    if run_p is None and boot.get("preferred_run_id"):
+        cand = runs_dir() / str(boot["preferred_run_id"])
+        if workspace is not None:
+            cand = root / "runs" / str(boot["preferred_run_id"])
+        if cand.is_dir():
+            run_p = cand
+    scorecard = _load_json(run_p / "calibration_scorecard.json") if run_p else {}
+    g14_block: dict[str, Any] = {}
+    bills = scorecard.get("utility_bills") or {}
+    stats = bills.get("stats_electricity") or bills.get("stats") or {}
+    if bills or stats:
+        g14_block = {
+            "overall": bills.get("pass_fail") or scorecard.get("status") or "n/a",
+            "nmbe_elec_pct": stats.get("nmbe_pct"),
+            "cvrmse_elec_pct": stats.get("cvrmse_pct"),
+            "months_compared": bills.get("months_compared"),
+        }
+
+    ecm_path = Path(ecm_scenario_path) if ecm_scenario_path else None
+    if ecm_path is None and boot.get("ecm_scenario_path"):
+        cand = Path(str(boot["ecm_scenario_path"]))
+        if not cand.is_absolute():
+            cand = root / cand
+        ecm_path = cand
+    ecm = load_ecm_scenario(ecm_path)
+
+    return {
+        "version": STATUS_VERSION,
+        "building_id": building_id or answers.get("building_id"),
+        "paths": {
+            "workspace": str(root),
+            "bootstrap": str(boot_path) if boot_path else None,
+            "answers": str(ans_path) if ans_path else None,
+            "dump": str(dump_p) if dump_p else None,
+            "preferred_run": str(run_p) if run_p else None,
+            "ecm_scenario": str(ecm_path or (root / "reports" / "ecm_scenario.json")),
+        },
+        "fields": fields,
+        "twin": {
+            "profile_resolvable": answers_complete(answers),
+            "preferred_run_id": boot.get("preferred_run_id") or (run_p.name if run_p else None),
+            "g14": g14_block or None,
+        },
+        "ecm_scenario": {
+            "source": "agent" if ecm.get("selected_ecm_ids") else "empty",
+            "selected_ecm_ids": ecm.get("selected_ecm_ids") or [],
+            "measure_set": ecm.get("measure_set"),
+            "status": ecm.get("status"),
+            "recommendations": ecm.get("recommendations") or [],
+        },
+        "gaps_softened": soft_gaps,
+    }
+
+
+def write_session_status(
+    status: dict[str, Any] | None = None,
+    *,
+    workspace: Path | None = None,
+    path: Path | None = None,
+) -> Path:
+    from wattlab.studio.workspace import ensure_workspace, reports_dir
+
+    root = Path(workspace) if workspace is not None else ensure_workspace()
+    out = path or (root / "reports" / "session_status.json")
+    if workspace is None and path is None:
+        out = reports_dir() / "session_status.json"
+    payload = status if status is not None else build_session_status(workspace=workspace)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    import sys
+
+    p = argparse.ArgumentParser(
+        description="Merge dump/answers/bootstrap/run/ecm into session_status.json"
+    )
+    p.add_argument("--write", action="store_true", help="write reports/session_status.json")
+    p.add_argument("--dump", type=Path, default=None)
+    p.add_argument("--answers", type=Path, default=None)
+    p.add_argument("--run", type=Path, default=None)
+    p.add_argument("--out", type=Path, default=None)
+    p.add_argument("--template", action="store_true", help="print answers schema template path")
+    args = p.parse_args(argv)
+
+    if args.template:
+        print(json.dumps({"answers_template": str(answers_template_path())}, indent=2))
+        return 0
+
+    status = build_session_status(
+        dump_path=args.dump,
+        answers_path=args.answers,
+        run_dir=args.run,
+    )
+    if args.write or args.out:
+        written = write_session_status(status, path=args.out)
+        print(json.dumps({"ok": True, "written": str(written), "status": status}, indent=2, default=str))
+    else:
+        print(json.dumps(status, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vibe_code_apps_20/wattlab/studio/templates/answers.schema.template.json
+++ b/vibe_code_apps_20/wattlab/studio/templates/answers.schema.template.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "_meta": {
+    "description": "Blank answers template — fill nulls; do not invent required site facts.",
+    "required": ["building_type", "city", "floor_area_ft2"],
+    "optional": ["floors", "lat", "lon", "wwr", "utility", "measure_set", "cooling_tons", "fan_hp"],
+    "phase2": ["interval_meters", "tariffs", "carbon"]
+  },
+  "building_type": null,
+  "city": null,
+  "floor_area_ft2": null,
+  "floors": null,
+  "lat": null,
+  "lon": null,
+  "wwr": null,
+  "measure_set": null,
+  "utility": {
+    "elec_usd_per_kwh": null,
+    "gas_usd_per_therm": null
+  },
+  "cooling_tons": null,
+  "fan_hp": null
+}

--- a/vibe_code_apps_20/wattlab/studio/templates/ecm_scenario.template.json
+++ b/vibe_code_apps_20/wattlab/studio/templates/ecm_scenario.template.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "selected_ecm_ids": [],
+  "measure_set": null,
+  "notes": "",
+  "recommendations": [],
+  "status": "empty — waiting agent or Easy Buttons"
+}


### PR DESCRIPTION
## Summary
- `wattlab studio-status` + templates → `session_status.json` (missing/answered/phase2)
- Bootstrap answers → `studio_profile`; soften dump NEEDS_INPUT when answered
- `ecm_scenario.json` ↔ Easy Buttons; Fuel peer help; Twin iteration elapsed
- Client package: 14-section report, Iteration_Runs sheet, `05_Source_Data`, individual downloads
- GHCR-first `CONTAINER_AGENT.md` + docs

## Test plan
- [x] `pytest tests/test_studio_status_deliverables.py tests/test_studio_bootstrap.py` (16 passed)
- [ ] Watch `vibe20-ghcr` green after merge
- [ ] Turnkey: `docker pull ghcr.io/bbartling/vibe20:latest` + recreate container

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added machine-readable Studio session status, including answer completion, Twin readiness, calibration details, and ECM scenario information.
  * Added ECM scenario save/load support between Easy Buttons and agent workflows.
  * Improved Twin iteration history with elapsed time, hypotheses, weather details, and additional performance metrics.
  * Enhanced client deliverables with source data, iteration history, expanded reports, and workbook details.
  * Added clearer benchmarking guidance and metric tooltips throughout Studio.

* **Bug Fixes**
  * Required gaps are now recognized as answered when valid answers are provided, reducing unnecessary input prompts.

* **Documentation**
  * Added container-based workflow and operator guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->