### PR TITLE
feat(vibe20): live DinD 08 progress + t12 status/bootstrap fixes

### DIFF
--- a/vibe_code_apps_20/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/CONTAINER_AGENT.md
@@ -3,13 +3,29 @@
 You are inside **`ghcr.io/bbartling/vibe20:latest`** (or vibe19). Work on the shared volume
 `/data` ↔ host `WATTLAB_HOST_WORKSPACE`. Streamlit is for the **human** browser only.
 
+## Behind the scenes (agent ↔ Studio)
+
+```text
+agent: wattlab twin | calibrate-campaign | easy-button | ecm_scenario.json
+        │
+        ▼  Docker energyplus-mcp-dev (DinD)
+runs/<id>/progress.json + console.log   ← live while sim runs
+runs/<id>/eplusout.csv                  ← after ReadVars (-r)
+publish_run_for_studio → CURRENT_RUN + bootstrap preferred_run_id
+        │
+        ▼
+Human Studio Twin: fragment polls progress; OA/floor charts after CSV
+```
+
+No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live 08 panes are **file polls**.
+
 ## Read first
 
 | Path | Why |
 | --- | --- |
 | `/app/CONTAINER_AGENT.md` | This file |
 | `/app/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + DinD + bootstrap |
-| `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS (prefer over root clone demos) |
+| `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS |
 | `/app/vibe20_agent_spec/DATA_CONTRACT.md` | Dump / answers / campus schemas |
 | `/app/vibe20_agent_spec/AGENT_TESTER_PROMPT.md` | Soak checklist |
 | `/app/vibe20_agent_spec/skills/wattlab-*/SKILL.md` | Procedure skills |
@@ -24,12 +40,13 @@ docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
 
 Useful commands:
 
-- `wattlab studio-status --write` → `reports/session_status.json` (missing vs answered)
-- `wattlab studio-bootstrap --campus … --dump … --run-id … --answers …`
+- `wattlab studio-status --write` → `reports/session_status.json` (missing | answered | phase2; G14 from scorecard)
+- `wattlab studio-bootstrap --campus … --dump … --run-id … --answers … --ecm-scenario …`
+  (merges existing keys — does not drop `ecm_scenario_path`)
 - `wattlab calibrate-campaign …` / `wattlab twin …` / `wattlab ecm list|packages`
-- `wattlab seed <dump> --gaps`
+- Write `reports/ecm_scenario.json` → Studio ECMs Easy Buttons after Re-apply
 
-Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**.
+Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**. Twin DinD shows live progress bar.
 
 ## Do not
 

--- a/vibe_code_apps_20/tests/test_live_08_status_fixes.py
+++ b/vibe_code_apps_20/tests/test_live_08_status_fixes.py
@@ -1,0 +1,169 @@
+"""Live 08 progress helpers + t12 status/bootstrap fixes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wattlab.energyplus.docker import heuristic_ep_percent, write_progress
+from wattlab.studio.bootstrap import (
+    build_bootstrap_payload,
+    merge_bootstrap_payload,
+    write_bootstrap,
+)
+from wattlab.studio.ecm_scenario import load_ecm_scenario, save_ecm_scenario
+from wattlab.studio.status import build_session_status, soften_required_gaps
+
+
+def test_heuristic_ep_percent_increases():
+    pct = 0
+    pct = heuristic_ep_percent("Warmup Simulation", pct)
+    assert pct >= 10
+    pct = heuristic_ep_percent("Starting Simulation", pct)
+    assert pct >= 25
+    pct = heuristic_ep_percent("Simulating January", pct)
+    assert pct >= 40
+    pct = heuristic_ep_percent("EnergyPlus Completed Successfully", pct)
+    assert pct >= 98
+
+
+def test_write_progress_atomic(tmp_path: Path):
+    write_progress(tmp_path, percent=42, status="running")
+    data = json.loads((tmp_path / "progress.json").read_text(encoding="utf-8"))
+    assert data["percent"] == 42
+    assert data["status"] == "running"
+
+
+def test_load_ecm_scenario_status_from_ids(tmp_path: Path):
+    path = tmp_path / "ecm_scenario.json"
+    path.write_text(
+        json.dumps({"version": 1, "selected_ecm_ids": ["ECM-A", "ECM-B"]}),
+        encoding="utf-8",
+    )
+    loaded = load_ecm_scenario(path)
+    assert loaded["status"] == "2 ECMs selected"
+    save_ecm_scenario({"selected_ecm_ids": []}, path=path)
+    assert load_ecm_scenario(path)["status"].startswith("empty")
+
+
+def test_session_status_g14_and_bills(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    (tmp_path / "reports").mkdir(parents=True)
+    (tmp_path / "runs" / "cal_run").mkdir(parents=True)
+    answers = {
+        "building_type": "office",
+        "city": "detroit",
+        "floor_area_ft2": 140000,
+        "utility_bills": [{"month": "2024-01", "kwh": 1}],
+        "utility": {"elec_usd_per_kwh": 0.12},
+    }
+    (tmp_path / "reports" / "answers.json").write_text(json.dumps(answers), encoding="utf-8")
+    (tmp_path / "reports" / "utility_bills.csv").write_text("month,kwh\n2024-01,1\n", encoding="utf-8")
+    scorecard = {
+        "status": "screening",
+        "utility_bills": {
+            "pass_fail": "fail",
+            "months_compared": 12,
+            "stats_electricity": {"nmbe_pct": 52.1, "cvrmse_pct": 57.0},
+        },
+    }
+    (tmp_path / "runs" / "cal_run" / "calibration_scorecard.json").write_text(
+        json.dumps(scorecard), encoding="utf-8"
+    )
+    (tmp_path / "studio_bootstrap.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "answers_path": "reports/answers.json",
+                "preferred_run_id": "cal_run",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "reports" / "ecm_scenario.json").write_text(
+        json.dumps({"selected_ecm_ids": ["ECM-AHU-SCHED-ALIGN"]}),
+        encoding="utf-8",
+    )
+    status = build_session_status(workspace=tmp_path)
+    assert status["fields"]["utility_bills"]["status"] == "answered"
+    assert status["twin"]["g14"]["nmbe_elec_pct"] == 52.1
+    assert "1 ECMs" in status["ecm_scenario"]["status"]
+    soft = soften_required_gaps(
+        [{"field": "utility", "severity": "recommended", "status": "missing"}],
+        answers,
+    )
+    assert soft[0]["status"] == "answered"
+
+
+def test_bootstrap_ecm_merge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    write_bootstrap(
+        build_bootstrap_payload(
+            energy_campus_dir="uploads/energy/x",
+            ecm_scenario_path="reports/ecm_scenario.json",
+            notes="keep me",
+        )
+    )
+    merged = merge_bootstrap_payload(
+        build_bootstrap_payload(preferred_run_id="new_run"),
+        existing_path=tmp_path / "studio_bootstrap.json",
+    )
+    # preferred updated; campus + ecm preserved
+    assert merged["preferred_run_id"] == "new_run"
+    assert merged["energy_campus_dir"] == "uploads/energy/x"
+    assert merged["ecm_scenario_path"] == "reports/ecm_scenario.json"
+
+
+def test_detroit_latlon_epw_note():
+    from wattlab.defaults import resolve_profile
+
+    profile = resolve_profile(
+        {
+            "building_type": "office",
+            "city": "detroit",
+            "floor_area_ft2": 140000,
+            "lat": 42.33,
+            "lon": -83.04,
+        }
+    )
+    note = str((profile.get("energyplus") or {}).get("epw_note") or "")
+    assert "Open-Meteo" in note or "lat=" in note or "AMY" in note.upper() or "screening TMY" in note
+
+
+def test_studio_apptest_no_exception_with_answers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip("streamlit")
+    from streamlit.testing.v1 import AppTest
+
+    from wattlab.studio.bootstrap import build_bootstrap_payload, write_bootstrap
+
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    monkeypatch.delenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", raising=False)
+    (tmp_path / "reports").mkdir(parents=True)
+    answers = {
+        "building_type": "office",
+        "city": "detroit",
+        "floor_area_ft2": 140000,
+        "floors": 6,
+        "lat": 42.33,
+        "lon": -83.04,
+    }
+    (tmp_path / "reports" / "answers.json").write_text(json.dumps(answers), encoding="utf-8")
+    write_bootstrap(
+        build_bootstrap_payload(
+            preferred_run_id="noop",
+            answers_path="reports/answers.json",
+        )
+    )
+    root = Path(__file__).resolve().parents[1]
+    at = AppTest.from_file(str(root / "studio.py"), default_timeout=60)
+    at.run()
+    assert not at.exception
+    assert "studio_profile" in at.session_state
+    at.radio(key="studio_page").set_value("ECMs").run()
+    assert not at.exception
+    at.radio(key="studio_page").set_value("Twin / calibrate").run()
+    assert not at.exception
+    at.radio(key="studio_page").set_value("Fuel dashboard").run()
+    assert not at.exception

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -98,9 +98,9 @@ curl -sf http://127.0.0.1:8520/_stcore/health
 ```
 
 Tip image includes the **Docker CLI** (no host `docker` binary bind-mount).
-Prefer tip after agent/UI tip (`ghcr.io/bbartling/vibe20:latest`) — studio-status,
-profile→ECMs, ecm_scenario, iteration elapsed, richer deliverables.
+Prefer tip after live-08 + status fixes (`ghcr.io/bbartling/vibe20:latest`).
 Start inside the image: `docker exec vibe20 cat /app/CONTAINER_AGENT.md`.
+Live Twin 08 = DinD `progress.json` poll (not pyenergyplus).
 `WATTLAB_HOST_WORKSPACE` = host path for the `/data` bind (required for Twin →
 Docker E+ / DinD). Prefer agents: `docker exec vibe20 wattlab …`
 ([`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md)).
@@ -215,6 +215,10 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
     **answered** when answers fill dump nulls; bootstrap answers → `studio_profile` unlocks ECMs.
 25. Twin iteration table shows **elapsed** when manifests have timestamps; client package
     zip includes `05_Source_Data` + report/workbook individual downloads.
+26. **Studio DinD live 08:** Run EnergyPlus button shows progress % updating from
+    `progress.json` (no Streamlit exception); OA/floor after CSV.
+27. `studio-status`: `ecm_scenario.status` reflects selected ids; `twin.g14` from
+    scorecard; `utility_bills` answered from answers/CSV; bootstrap `--ecm-scenario` merge-safe.
 
 ## PASS / FAIL
 

--- a/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
@@ -3,6 +3,22 @@
 You are inside **`ghcr.io/bbartling/vibe20:latest`** (or vibe19). Work on the shared volume
 `/data` ↔ host `WATTLAB_HOST_WORKSPACE`. Streamlit is for the **human** browser only.
 
+## Behind the scenes (agent ↔ Studio)
+
+```text
+agent: wattlab twin | calibrate-campaign | easy-button | ecm_scenario.json
+        │
+        ▼  Docker energyplus-mcp-dev (DinD)
+runs/<id>/progress.json + console.log   ← live while sim runs
+runs/<id>/eplusout.csv                  ← after ReadVars (-r)
+publish_run_for_studio → CURRENT_RUN + bootstrap preferred_run_id
+        │
+        ▼
+Human Studio Twin: fragment polls progress; OA/floor charts after CSV
+```
+
+No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live 08 panes are **file polls**.
+
 ## Read first
 
 | Path | Why |
@@ -10,10 +26,9 @@ You are inside **`ghcr.io/bbartling/vibe20:latest`** (or vibe19). Work on the sh
 | `/app/CONTAINER_AGENT.md` | Root copy of this guide |
 | `/app/vibe20_agent_spec/CONTAINER_AGENT.md` | Same |
 | `/app/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + DinD + bootstrap |
-| `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS (prefer over root clone demos) |
+| `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS |
 | `/app/vibe20_agent_spec/DATA_CONTRACT.md` | Dump / answers / campus schemas |
 | `/app/vibe20_agent_spec/AGENT_TESTER_PROMPT.md` | Soak checklist |
-| `/app/vibe20_agent_spec/skills/wattlab-*/SKILL.md` | Procedure skills |
 
 ## Run (preferred)
 
@@ -23,17 +38,12 @@ docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
   wattlab <cmd>
 ```
 
-Useful commands:
-
-- `wattlab studio-status --write` → `reports/session_status.json` (missing vs answered)
-- `wattlab studio-bootstrap --campus … --dump … --run-id … --answers …`
-- `wattlab calibrate-campaign …` / `wattlab twin …` / `wattlab ecm list|packages`
-- Write `reports/ecm_scenario.json` → Studio ECMs Easy Buttons (after profile from answers)
-
-Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**.
+- `wattlab studio-status --write`
+- `wattlab studio-bootstrap … --ecm-scenario /data/reports/ecm_scenario.json` (merge-safe)
+- Write `reports/ecm_scenario.json` for Easy Buttons
 
 ## Do not
 
-- Require `git clone` / `pip install -e` for production soaks (host contrib only)
-- Invent `building_type` / `city` / `floor_area_ft2` — write `reports/answers*.json`
+- Require git clone for soaks
+- Invent required site facts
 - Claim calibrated ROI without G14 stamps

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -150,6 +150,31 @@ workbook.xlsx, and full zip (`05_Source_Data` included when answers/bills presen
 
 Fuel **Portfolio** peer metrics have `?` help text + “How buildings are benchmarked”.
 
+## DinD live progress → APIHelper-08 panes
+
+While EnergyPlus runs in `energyplus-mcp-dev`, WattLab streams console lines into
+`runs/<id>/console.log` and updates `runs/<id>/progress.json` (percent + status).
+Studio Twin polls that folder (fragment / live status box) — **not** embedded
+`pyenergyplus`. OA / floor-plan charts appear after `eplusout.csv` (ReadVars `-r`).
+
+Agent path publishes the same files; human **Refresh agent runs** or leave Twin open.
+
+## studio-bootstrap --ecm-scenario (merge-safe)
+
+```bash
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 \
+  wattlab studio-bootstrap \
+  --run-id calibrate_… \
+  --ecm-scenario /data/reports/ecm_scenario.json
+```
+
+Rewrites **merge** existing `studio_bootstrap.json` keys (campus/dump/answers/ecm)
+so a partial CLI call does not drop `ecm_scenario_path`.
+
+`wattlab studio-status` fills `twin.g14` from scorecard / campaign_stamp, marks
+`utility_bills` answered from answers array or `reports/utility_bills.csv`, and
+normalizes `ecm_scenario.status` when ids are selected.
+
 ## Agent flow (no git)
 
 ```text

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -10,6 +10,10 @@ Studio refreshes from `uploads/`, `runs/`, `reports/`. Agents must **publish** e
 E+ iteration so Twin 08 panes appear in the browser
 (`publish_run_for_studio` / `runs/CURRENT_RUN.txt`).
 
+**Live 08:** DinD writes `progress.json` + `console.log` during the sim; Twin polls
+(progress/log live). OA + floor-plan charts update when `eplusout.csv` exists
+(after ReadVars). Not embedded pyenergyplus / not Flask APIHelper.
+
 Full paste prompt for QA + calibrate sessions:
 [`../AGENT_TESTER_PROMPT.md`](../AGENT_TESTER_PROMPT.md).
 

--- a/vibe_code_apps_20/wattlab/defaults.py
+++ b/vibe_code_apps_20/wattlab/defaults.py
@@ -279,11 +279,28 @@ def resolve_profile(minimal: dict[str, Any] | None = None) -> dict[str, Any]:
         proto = arch.get("prototype_idf") or "examples/prototypes/5ZoneAirCooled.idf"
         field_sources["prototype_idf"] = _tagged(proto, "default")
     user_epw = m.get("epw") or m.get("amy_epw")
+    has_latlon = m.get("lat") is not None and m.get("lon") is not None
     if user_epw:
         epw_rel = str(user_epw)
         epw_note = m.get("epw_note") or "User / AMY EPW override"
         field_sources["epw"] = _tagged(epw_rel, "user", note=epw_note)
     else:
+        # Soften Chicago-substitute noise when lat/lon AMY campaigns will replace TMY
+        if has_latlon and epw_note and "Chicago" in str(epw_note):
+            epw_note = (
+                f"{epw_note} — screening TMY only; calibrate-campaign / AMY uses "
+                f"Open-Meteo from lat={m.get('lat')} lon={m.get('lon')}."
+            )
+        elif (
+            city_id == "detroit"
+            and epw_note
+            and "Chicago" in str(epw_note)
+            and not has_latlon
+        ):
+            epw_note = (
+                f"{epw_note} Provide lat/lon for Open-Meteo AMY "
+                "(Detroit preferred EPW path may be absent in the image)."
+            )
         field_sources["epw"] = _tagged(epw_rel, "default", note=epw_note)
 
     lpd = float(arch.get("lpd_w_per_ft2") or 0.9) * float(

--- a/vibe_code_apps_20/wattlab/easy_button.py
+++ b/vibe_code_apps_20/wattlab/easy_button.py
@@ -230,6 +230,7 @@ def run_easy_button(
     skip_ecm2: bool = False,
     dry_run: bool = False,
     measure_set: str | None = None,
+    progress_dir: Path | str | None = None,
 ) -> dict[str, Any]:
     if profile is None:
         if profile_path is None:
@@ -257,6 +258,29 @@ def run_easy_button(
     run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     art_root = artifacts_root()
+
+    # Claim Studio runs/<id> early so Twin can poll progress.json mid-DinD.
+    studio_progress: Path | None = Path(progress_dir) if progress_dir else None
+    if studio_progress is not None:
+        run_id = studio_progress.name
+        studio_progress.mkdir(parents=True, exist_ok=True)
+        try:
+            from wattlab.energyplus.docker import write_progress
+
+            write_progress(studio_progress, percent=0, status="running", note="easy-button")
+        except Exception:  # noqa: BLE001
+            pass
+    else:
+        try:
+            from wattlab.energyplus.docker import write_progress
+            from wattlab.studio.workspace import runs_dir
+
+            studio_progress = runs_dir() / run_id
+            studio_progress.mkdir(parents=True, exist_ok=True)
+            write_progress(studio_progress, percent=0, status="running", note="easy-button claimed")
+        except Exception:  # noqa: BLE001
+            studio_progress = None
+
     run_dir = art_root / f"wattlab_{run_id}"
     run_dir.mkdir(parents=True, exist_ok=True)
 
@@ -304,7 +328,7 @@ def run_easy_button(
     if run_period_meta:
         patch_log.insert(1, run_period_meta)
     base_out = run_dir / "sim_baseline"
-    sim_meta = simulate(baseline_idf, epw, base_out)
+    sim_meta = simulate(baseline_idf, epw, base_out, progress_dir=studio_progress)
     sizing_scenario = "autosize"
     hard_size = (ep.get("hard_size") or profile.get("hard_size") or {})
     if isinstance(hard_size, dict) and (
@@ -356,7 +380,7 @@ def run_easy_button(
             patch_log.append(freeze_meta)
             baseline_idf = hard_idf
             base_out = run_dir / "sim_baseline_hard"
-            sim_meta = simulate(baseline_idf, epw, base_out)
+            sim_meta = simulate(baseline_idf, epw, base_out, progress_dir=studio_progress)
             sizing_scenario = "hard_size"
         else:
             sizing_scenario = "autosize_observe_hard_size_unavailable"
@@ -402,7 +426,7 @@ def run_easy_button(
         meta = _apply_patch(pname, current_idf, next_idf, m)
         patch_log.append(meta)
         out = run_dir / f"sim_{mid}"
-        simulate(next_idf, epw, out)
+        simulate(next_idf, epw, out, progress_dir=studio_progress)
         ann = annual_from_output_dir(
             out, elec_rate_usd_per_kwh=elec_rate, gas_rate_usd_per_therm=gas_rate
         )

--- a/vibe_code_apps_20/wattlab/energyplus/docker.py
+++ b/vibe_code_apps_20/wattlab/energyplus/docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -117,6 +118,127 @@ def energyplus_docker_user() -> str | None:
     return raw or None
 
 
+def write_progress(
+    progress_dir: Path | str | None,
+    *,
+    percent: int,
+    status: str,
+    note: str | None = None,
+) -> None:
+    """Atomically write ``progress.json`` for Twin APIHelper-08 live panes."""
+    if progress_dir is None:
+        return
+    root = Path(progress_dir)
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        payload: dict = {
+            "percent": max(0, min(100, int(percent))),
+            "status": str(status),
+        }
+        if note:
+            payload["note"] = note
+        tmp = root / "progress.json.tmp"
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(root / "progress.json")
+    except OSError:
+        pass
+
+
+def heuristic_ep_percent(line: str, current: int) -> int:
+    """Bump progress from EnergyPlus console tokens (best-effort)."""
+    low = line.lower()
+    pct = current
+    if "warmup" in low and pct < 15:
+        pct = max(pct, 10)
+    if "starting simulation" in low or "begin simulation" in low:
+        pct = max(pct, 25)
+    if "simulating" in low or "processing weather" in low:
+        pct = max(pct, 35)
+    # Month-ish tokens
+    months = (
+        "january",
+        "february",
+        "march",
+        "april",
+        "may",
+        "june",
+        "july",
+        "august",
+        "september",
+        "october",
+        "november",
+        "december",
+    )
+    for i, m in enumerate(months):
+        if m in low:
+            pct = max(pct, 40 + int((i + 1) * 4.5))
+    if "readvars" in low or "writing tabular" in low or "csv" in low:
+        pct = max(pct, 90)
+    if "energyplus completed" in low or "======= final" in low:
+        pct = max(pct, 98)
+    return min(99, pct)
+
+
+def _run_docker_streaming(
+    args: list[str],
+    *,
+    timeout: int | None,
+    progress_dir: Path | None,
+) -> subprocess.CompletedProcess[str]:
+    """Popen docker; stream lines to log + progress.json when progress_dir set."""
+    import time
+
+    write_progress(progress_dir, percent=1, status="running", note="docker starting")
+    log_path = Path(progress_dir) / "console.log" if progress_dir else None
+    if log_path is not None:
+        try:
+            log_path.write_text("", encoding="utf-8")
+        except OSError:
+            log_path = None
+
+    proc = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    chunks: list[str] = []
+    percent = 1
+    started = time.monotonic()
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            chunks.append(line)
+            if log_path is not None:
+                try:
+                    with log_path.open("a", encoding="utf-8", errors="replace") as fh:
+                        fh.write(line)
+                except OSError:
+                    pass
+            percent = heuristic_ep_percent(line, percent)
+            write_progress(progress_dir, percent=percent, status="running")
+            if timeout is not None and (time.monotonic() - started) > timeout:
+                proc.kill()
+                write_progress(progress_dir, percent=percent, status="failed", note="timeout")
+                break
+        rc = proc.wait(timeout=30)
+    except Exception as exc:  # noqa: BLE001
+        try:
+            proc.kill()
+        except OSError:
+            pass
+        write_progress(progress_dir, percent=percent, status="failed", note=str(exc))
+        return subprocess.CompletedProcess(args, returncode=1, stdout="".join(chunks), stderr=str(exc))
+
+    out = "".join(chunks)
+    if rc == 0:
+        write_progress(progress_dir, percent=100, status="ok")
+    else:
+        write_progress(progress_dir, percent=percent, status="failed", note=f"returncode={rc}")
+    return subprocess.CompletedProcess(args, returncode=rc, stdout=out, stderr="")
+
+
 def run_in_container(
     cmd: list[str],
     *,
@@ -155,11 +277,14 @@ def run_energyplus(
     *,
     timeout: int | None = 3600,
     readvars: bool = True,
+    progress_dir: Path | str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Annual (or IDF run-period) EnergyPlus simulate via Docker.
 
     ``readvars=True`` (default) passes ``-r`` so EnergyPlus writes
     ``eplusout.csv`` for Twin APIHelper-08 timeseries panes.
+    When ``progress_dir`` is set, streams console into that folder's
+    ``console.log`` / ``progress.json`` for live Twin panes.
     Mount sources are translated via ``host_path_for_docker`` when Studio runs
     with docker.sock + ``WATTLAB_HOST_WORKSPACE``.
 
@@ -239,4 +364,7 @@ def run_energyplus(
         ]
     )
     ensure_image(build=False)
+    prog = Path(progress_dir) if progress_dir else None
+    if prog is not None:
+        return _run_docker_streaming(args, timeout=timeout, progress_dir=prog)
     return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)

--- a/vibe_code_apps_20/wattlab/energyplus/mcp.py
+++ b/vibe_code_apps_20/wattlab/energyplus/mcp.py
@@ -243,11 +243,13 @@ def simulate(
     *,
     timeout: int | None = 3600,
     align_run_period: bool = True,
+    progress_dir: Path | str | None = None,
 ) -> dict[str, Any]:
     """Run EnergyPlus simulation (parity with MCP run_energyplus_simulation).
 
     When ``align_run_period`` is True (default), partial-year EPWs auto-clip
     the IDF RunPeriod before Docker invoke — avoids FATAL GetNextEnvironment.
+    ``progress_dir`` streams console → Twin ``progress.json`` / ``console.log``.
     """
     idf = Path(idf)
     epw = Path(epw)
@@ -267,7 +269,9 @@ def simulate(
         except Exception as exc:  # noqa: BLE001
             align_meta = {"patch": "run_period", "applied": False, "error": str(exc)}
 
-    proc = run_energyplus(idf_run, epw, output_dir, timeout=timeout)
+    proc = run_energyplus(
+        idf_run, epw, output_dir, timeout=timeout, progress_dir=progress_dir
+    )
     out: dict[str, Any] = {
         "returncode": proc.returncode,
         "stdout_tail": (proc.stdout or "")[-2000:],

--- a/vibe_code_apps_20/wattlab/studio/bootstrap.py
+++ b/vibe_code_apps_20/wattlab/studio/bootstrap.py
@@ -39,6 +39,7 @@ _CONTENT_KEYS = (
     "dump_zip",
     "preferred_run_id",
     "answers_path",
+    "ecm_scenario_path",
 )
 
 
@@ -151,15 +152,16 @@ def build_bootstrap_payload(
     dump_zip: str | Path | None = None,
     preferred_run_id: str | None = None,
     answers_path: str | Path | None = None,
+    ecm_scenario_path: str | Path | None = None,
     auto_refresh_runs: bool = True,
     notes: str = "",
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "version": BOOTSTRAP_VERSION,
         "auto_refresh_runs": bool(auto_refresh_runs),
-        "notes": notes
-        or "Written by agent after publish_run_for_studio for Studio auto-load",
     }
+    if notes:
+        payload["notes"] = notes
     if energy_campus_dir:
         payload["energy_campus_dir"] = str(energy_campus_dir)
     if dump_zip:
@@ -168,7 +170,39 @@ def build_bootstrap_payload(
         payload["preferred_run_id"] = str(preferred_run_id)
     if answers_path:
         payload["answers_path"] = str(answers_path)
+    if ecm_scenario_path:
+        payload["ecm_scenario_path"] = str(ecm_scenario_path)
     return payload
+
+
+def merge_bootstrap_payload(
+    new_fields: dict[str, Any],
+    *,
+    existing_path: Path | None = None,
+) -> dict[str, Any]:
+    """Merge into existing studio_bootstrap.json so unspecified keys survive."""
+    from wattlab.studio.workspace import ensure_workspace
+
+    root = ensure_workspace()
+    path = existing_path or (root / DEFAULT_BOOTSTRAP_NAME)
+    base: dict[str, Any] = {}
+    if path.is_file():
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                base = dict(raw)
+        except (OSError, json.JSONDecodeError):
+            base = {}
+    for k, v in new_fields.items():
+        if v is None or v == "":
+            continue
+        base[k] = v
+    base["version"] = BOOTSTRAP_VERSION
+    if "auto_refresh_runs" not in base:
+        base["auto_refresh_runs"] = True
+    if not base.get("notes"):
+        base["notes"] = "Written by agent after publish_run_for_studio for Studio auto-load"
+    return base
 
 
 def write_bootstrap(
@@ -425,6 +459,12 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--dump", type=Path, default=None, help="dump zip or folder")
     p.add_argument("--run-id", type=str, default=None, help="preferred runs/<id>")
     p.add_argument("--answers", type=Path, default=None)
+    p.add_argument(
+        "--ecm-scenario",
+        type=Path,
+        default=None,
+        help="reports/ecm_scenario.json (persisted; merge keeps prior keys)",
+    )
     p.add_argument("--notes", type=str, default="")
     p.add_argument("--out", type=Path, default=None, help="override bootstrap path")
     p.add_argument("--no-fallback", action="store_true")
@@ -447,19 +487,27 @@ def main(argv: list[str] | None = None) -> int:
     if campus is not None and campus.is_file() and campus.name == "campus.json":
         campus = campus.parent
 
-    payload = build_bootstrap_payload(
+    new_fields = build_bootstrap_payload(
         energy_campus_dir=_rel(campus) if campus else None,
         dump_zip=_rel(args.dump) if args.dump else None,
         preferred_run_id=args.run_id,
         answers_path=_rel(args.answers) if args.answers else None,
+        ecm_scenario_path=_rel(args.ecm_scenario) if args.ecm_scenario else None,
         notes=args.notes,
     )
-    if not any(
-        payload.get(k)
-        for k in ("energy_campus_dir", "dump_zip", "preferred_run_id", "answers_path")
-    ):
+    # Drop empty notes so merge does not wipe richer prior notes unless --notes passed
+    if not args.notes:
+        new_fields.pop("notes", None)
+    existing = Path(args.out) if args.out else (root / DEFAULT_BOOTSTRAP_NAME)
+    payload = merge_bootstrap_payload(new_fields, existing_path=existing)
+    if not any(payload.get(k) for k in _CONTENT_KEYS):
         print(
-            json.dumps({"ok": False, "error": "NEEDS_INPUT: pass --campus and/or --dump and/or --run-id"}),
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": "NEEDS_INPUT: pass --campus and/or --dump and/or --run-id and/or --ecm-scenario",
+                }
+            ),
             file=sys.stderr,
         )
         return 1

--- a/vibe_code_apps_20/wattlab/studio/ecm_scenario.py
+++ b/vibe_code_apps_20/wattlab/studio/ecm_scenario.py
@@ -46,6 +46,10 @@ def load_ecm_scenario(path: Path | str | None = None) -> dict[str, Any]:
     if not isinstance(ids, list):
         ids = []
     out["selected_ecm_ids"] = [str(x) for x in ids]
+    if out["selected_ecm_ids"]:
+        out["status"] = f"{len(out['selected_ecm_ids'])} ECMs selected"
+    else:
+        out["status"] = "empty — waiting agent or Easy Buttons"
     return out
 
 

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -199,75 +199,109 @@ def _resolve_active_run() -> Path | None:
 def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
     st.subheader("EnergyPlus visualizer (APIHelper 08 — browser)")
     st.caption(
-        "Populated by any AI agent (or Studio buttons) writing `runs/<id>/` "
-        "with eplusout.csv. Human: use **Refresh agent runs** after each iteration."
+        "Live progress from DinD console → `progress.json` / `console.log` "
+        "(APIHelper-08 style; not embedded pyenergyplus). "
+        "OA / floor charts appear after `eplusout.csv` is published. "
+        "Agents: publish to `runs/<id>/`; human: Refresh or watch live while Studio DinD runs."
     )
-    info = read_run_progress(run_dir)
-    if info.get("replay"):
-        st.info("Demo replay — fixture eplusout.csv (no live Docker EnergyPlus run).")
 
-    left, right = st.columns([2, 3])
-    with left:
-        st.markdown("**Manage simulation**")
-        st.progress(min(100, max(0, int(info.get("progress") or 0))) / 100.0)
-        st.caption(f"status={info.get('status')} · run_id={info.get('run_id')}")
-        log = info.get("log_tail") or "(no eplusout.err / console log yet)"
-        st.text_area("EnergyPlus output", value=log, height=220, key=f"twin_ep_log_{run_dir.name}")
-    with right:
-        ts = load_sim_timeseries(run_dir)
-        if ts is None:
-            nested = find_eplusout_csv(run_dir)
-            ts = load_sim_timeseries(nested.parent) if nested else None
-        if ts is not None and not ts.outdoor.empty:
-            st.plotly_chart(outdoor_figure(ts.outdoor), width="stretch", key=f"twin_oa_{run_dir.name}")
-        else:
-            st.caption("No outdoor timeseries yet (need eplusout.csv in this run folder).")
+    live = False
+    try:
+        info0 = read_run_progress(run_dir)
+        live = str(info0.get("status") or "").lower() in {"running", "starting"}
+    except Exception:
+        live = False
 
-    ts2 = load_sim_timeseries(run_dir)
-    if ts2 is None:
-        nested = find_eplusout_csv(run_dir)
-        if nested:
-            ts2 = load_sim_timeseries(nested.parent)
-    if ts2 is not None:
-        roles = zone_mean_by_role(ts2)
-        if roles:
-            floors = int(n_floors or 1)
-            profile = _profile() or {}
-            if floors < 2:
-                floors = int(
-                    profile.get("number_of_floors")
-                    or profile.get("floors")
-                    or st.session_state.get("twin_floors")
-                    or 1
-                )
-            btype = str(profile.get("building_type") or profile.get("property_type") or "").lower()
-            use_multi = floors >= 2 or ("office" in btype and floors >= 2)
-            if use_multi and floors >= 2:
-                highlight = None
-                if floors > 8:
-                    highlight = int(
-                        st.selectbox(
-                            "Highlight floor",
-                            options=list(range(1, floors + 1)),
-                            index=floors - 1,
-                            key=f"twin_floor_sel_{run_dir.name}",
-                        )
-                    )
+    def _draw() -> None:
+        info = read_run_progress(run_dir)
+        if info.get("replay"):
+            st.info("Demo replay — fixture eplusout.csv (no live Docker EnergyPlus run).")
+
+        left, right = st.columns([2, 3])
+        with left:
+            st.markdown("**Manage simulation**")
+            st.progress(min(100, max(0, int(info.get("progress") or 0))) / 100.0)
+            st.caption(f"status={info.get('status')} · run_id={info.get('run_id')}")
+            log = info.get("log_tail") or "(no eplusout.err / console log yet)"
+            st.text_area(
+                "EnergyPlus output",
+                value=log,
+                height=220,
+                key=f"twin_ep_log_{run_dir.name}_{info.get('progress')}",
+            )
+        with right:
+            ts = load_sim_timeseries(run_dir)
+            if ts is None:
+                nested = find_eplusout_csv(run_dir)
+                ts = load_sim_timeseries(nested.parent) if nested else None
+            if ts is not None and not ts.outdoor.empty:
                 st.plotly_chart(
-                    multifloor_office_figure(roles, n_floors=floors, highlight_floor=highlight),
+                    outdoor_figure(ts.outdoor),
                     width="stretch",
-                    key=f"twin_multifloor_{run_dir.name}",
+                    key=f"twin_oa_{run_dir.name}",
                 )
-                st.caption(MULTIFLOOR_HONESTY.replace("N-story", f"{floors}-story"))
             else:
-                st.plotly_chart(
-                    floor_plan_figure(roles),
-                    width="stretch",
-                    key=f"twin_floor_{run_dir.name}",
-                )
-        means = ts2.zone_mean_temps()
-        if not means.empty:
-            st.dataframe(means, width="stretch", hide_index=True)
+                st.caption("No outdoor timeseries yet (need eplusout.csv in this run folder).")
+
+        ts2 = load_sim_timeseries(run_dir)
+        if ts2 is None:
+            nested = find_eplusout_csv(run_dir)
+            if nested:
+                ts2 = load_sim_timeseries(nested.parent)
+        if ts2 is not None:
+            roles = zone_mean_by_role(ts2)
+            if roles:
+                floors = int(n_floors or 1)
+                profile = _profile() or {}
+                if floors < 2:
+                    floors = int(
+                        profile.get("number_of_floors")
+                        or profile.get("floors")
+                        or st.session_state.get("twin_floors")
+                        or 1
+                    )
+                btype = str(profile.get("building_type") or profile.get("property_type") or "").lower()
+                use_multi = floors >= 2 or ("office" in btype and floors >= 2)
+                if use_multi and floors >= 2:
+                    highlight = None
+                    if floors > 8:
+                        highlight = int(
+                            st.selectbox(
+                                "Highlight floor",
+                                options=list(range(1, floors + 1)),
+                                index=floors - 1,
+                                key=f"twin_floor_sel_{run_dir.name}",
+                            )
+                        )
+                    st.plotly_chart(
+                        multifloor_office_figure(roles, n_floors=floors, highlight_floor=highlight),
+                        width="stretch",
+                        key=f"twin_multifloor_{run_dir.name}",
+                    )
+                    st.caption(MULTIFLOOR_HONESTY.replace("N-story", f"{floors}-story"))
+                else:
+                    st.plotly_chart(
+                        floor_plan_figure(roles),
+                        width="stretch",
+                        key=f"twin_floor_{run_dir.name}",
+                    )
+            means = ts2.zone_mean_temps()
+            if not means.empty:
+                st.dataframe(means, width="stretch", hide_index=True)
+
+    if live:
+        try:
+            from datetime import timedelta
+
+            @st.fragment(run_every=timedelta(seconds=2))
+            def _live_fragment() -> None:
+                _draw()
+
+            _live_fragment()
+            return
+        except Exception:
+            pass
+    _draw()
 
 
 def render() -> None:
@@ -473,36 +507,71 @@ def render() -> None:
         st.success(f"Dry-run plan → {out}")
 
     if d2.button("Run EnergyPlus (Docker)", key="twin_real_run"):
+        from threading import Thread
+        import time
+
         from wattlab.easy_button import run_easy_button
+        from wattlab.energyplus.docker import write_progress
 
         if not img_ok:
             st.error(f"Cannot run: `{DOCKER_IMAGE}` missing. Use dry-run or demo replay.")
         else:
-            with st.spinner("Running EnergyPlus via Docker…"):
+            # Claim run id early so 08 panes can poll progress while DinD runs.
+            from datetime import datetime, timezone
+
+            rid = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            dest = runs_dir() / rid
+            dest.mkdir(parents=True, exist_ok=True)
+            write_progress(dest, percent=0, status="running", note="Studio Twin DinD")
+            st.session_state["studio_active_run"] = str(dest)
+            box: dict[str, Any] = {"report": None, "exc": None}
+
+            def _worker() -> None:
                 try:
-                    report = run_easy_button(profile=run_profile, measure_set=measure_set)
-                    st.session_state["studio_report"] = report
-                    rid = str(report.get("run_id") or "run")
-                    art = Path(
-                        report.get("studio_run_dir")
-                        or report.get("artifacts_dir")
-                        or report.get("artifact_dir")
-                        or ""
+                    box["report"] = run_easy_button(
+                        profile=run_profile,
+                        measure_set=measure_set,
+                        progress_dir=dest,
                     )
-                    if art.is_dir() and (runs_dir() / rid).is_dir():
-                        dest = runs_dir() / rid
-                    elif art.is_dir():
-                        dest = publish_run_for_studio(art, run_id=rid, report=report)
+                except Exception as exc:  # noqa: BLE001
+                    box["exc"] = exc
+
+            thr = Thread(target=_worker, daemon=True)
+            thr.start()
+            status_box = st.empty()
+            while thr.is_alive():
+                info = read_run_progress(dest)
+                with status_box.container():
+                    st.progress(min(100, max(0, int(info.get("progress") or 0))) / 100.0)
+                    st.caption(
+                        f"Live DinD · status={info.get('status')} · "
+                        f"{info.get('progress')}% · run_id={rid}"
+                    )
+                time.sleep(1.0)
+            thr.join(timeout=5)
+            if box["exc"] is not None:
+                write_progress(dest, percent=0, status="failed", note=str(box["exc"]))
+                st.error(f"EnergyPlus run failed: {box['exc']}")
+            else:
+                report = box["report"] or {}
+                st.session_state["studio_report"] = report
+                art = Path(
+                    report.get("studio_run_dir")
+                    or report.get("artifacts_dir")
+                    or report.get("artifact_dir")
+                    or ""
+                )
+                try:
+                    if art.is_dir():
+                        published = publish_run_for_studio(art, run_id=rid, report=report)
+                        st.session_state["studio_active_run"] = str(published)
+                        st.success(f"Run published for browser Twin panes → {published}")
                     else:
-                        dest = publish_run_for_studio(
-                            Path(report.get("artifacts_dir") or "."),
-                            run_id=rid,
-                            report=report,
-                        )
-                    st.session_state["studio_active_run"] = str(dest)
-                    st.success(f"Run published for browser Twin panes → {dest}")
+                        st.session_state["studio_active_run"] = str(dest)
+                        st.success(f"Run finished → {dest}")
                 except Exception as exc:
-                    st.error(f"EnergyPlus run failed: {exc}")
+                    st.error(f"Publish failed: {exc}")
+                st.rerun()
 
     if d3.button("Load demo replay (fixture eplusout)", key="twin_demo_replay"):
         fixture = _fixture_eplusout()

--- a/vibe_code_apps_20/wattlab/studio/status.py
+++ b/vibe_code_apps_20/wattlab/studio/status.py
@@ -105,6 +105,15 @@ def soften_required_gaps(
             row["status"] = "answered"
             row["value"] = answers.get(field)
             row["via"] = "answers.json"
+        # Align utility dual-view when answers.utility is filled
+        if (
+            field == "utility"
+            and row.get("status") == "missing"
+            and _truthy(answers.get("utility"))
+        ):
+            row["status"] = "answered"
+            row["value"] = answers.get("utility")
+            row["via"] = "answers.json"
         out.append(row)
     return out
 
@@ -217,28 +226,73 @@ def build_session_status(
     for name in PHASE2_FIELDS:
         fields[name] = _field_row(required=False, phase=2, answers=answers.get(name))
 
-    # utility_bills from gap or answers note
+    # utility_bills from dump gap, answers array, or reports CSV
     ub = gap_by_field.get("utility_bills") or {}
-    fields["utility_bills"] = {
-        "required": False,
-        "status": "answered" if ub.get("status") == "ok" else "missing",
-        "note": ub.get("value") or ub.get("why"),
-    }
+    bills_csv = root / "reports" / "utility_bills.csv"
+    if ub.get("status") == "ok":
+        fields["utility_bills"] = {
+            "required": False,
+            "status": "answered",
+            "note": ub.get("value") or ub.get("why"),
+        }
+    elif _truthy(answers.get("utility_bills")):
+        fields["utility_bills"] = {
+            "required": False,
+            "status": "answered",
+            "note": "from answers.json",
+            "answers": answers.get("utility_bills"),
+        }
+    elif bills_csv.is_file():
+        fields["utility_bills"] = {
+            "required": False,
+            "status": "answered",
+            "note": "reports/utility_bills.csv",
+        }
+    else:
+        fields["utility_bills"] = {
+            "required": False,
+            "status": "missing",
+            "note": ub.get("value") or ub.get("why"),
+        }
 
     run_p: Path | None = Path(run_dir) if run_dir else None
     if run_p is None and boot.get("preferred_run_id"):
-        cand = runs_dir() / str(boot["preferred_run_id"])
-        if workspace is not None:
-            cand = root / "runs" / str(boot["preferred_run_id"])
+        cand = root / "runs" / str(boot["preferred_run_id"])
         if cand.is_dir():
             run_p = cand
-    scorecard = _load_json(run_p / "calibration_scorecard.json") if run_p else {}
+    if run_p is None:
+        pointer = root / "runs" / "CURRENT_RUN.txt"
+        if pointer.is_file():
+            try:
+                p = Path(pointer.read_text(encoding="utf-8").strip())
+                if p.is_dir():
+                    run_p = p
+            except OSError:
+                pass
+
+    scorecard: dict[str, Any] = {}
+    if run_p is not None:
+        scorecard = _load_json(run_p / "calibration_scorecard.json")
+        if not scorecard:
+            stamp = _load_json(run_p / "campaign_stamp.json")
+            sp = stamp.get("scorecard_path")
+            if sp and Path(str(sp)).is_file():
+                scorecard = _load_json(Path(str(sp)))
+            elif stamp:
+                scorecard = stamp
+        if not scorecard:
+            report = _load_json(run_p / "wattlab_report.json")
+            if report.get("utility_bills") or report.get("calibration"):
+                scorecard = report
     g14_block: dict[str, Any] = {}
     bills = scorecard.get("utility_bills") or {}
     stats = bills.get("stats_electricity") or bills.get("stats") or {}
-    if bills or stats:
+    if bills or stats or scorecard.get("pass_fail") or scorecard.get("status"):
         g14_block = {
-            "overall": bills.get("pass_fail") or scorecard.get("status") or "n/a",
+            "overall": bills.get("pass_fail")
+            or scorecard.get("pass_fail")
+            or scorecard.get("status")
+            or "n/a",
             "nmbe_elec_pct": stats.get("nmbe_pct"),
             "cvrmse_elec_pct": stats.get("cvrmse_pct"),
             "months_compared": bills.get("months_compared"),
@@ -250,6 +304,10 @@ def build_session_status(
         if not cand.is_absolute():
             cand = root / cand
         ecm_path = cand
+    if ecm_path is None:
+        default_ecm = root / "reports" / "ecm_scenario.json"
+        if default_ecm.is_file():
+            ecm_path = default_ecm
     ecm = load_ecm_scenario(ecm_path)
 
     return {


### PR DESCRIPTION
## Summary
- Stream EnergyPlus DinD stdout into `progress.json` / `console.log`; Twin APIHelper-08 panes poll via Streamlit fragment (and Studio button uses a background thread so UI can update mid-run).
- Fix t12 status quirks: ECM status string, G14 from scorecard/stamp, utility bills from answers/CSV, merge-safe `studio-bootstrap --ecm-scenario`, softer Chicago EPW note when lat/lon AMY applies.
- Agent docs (CONTAINER_AGENT, AGENT_DOCKER_WORKSPACE, TESTER, TWIN_LOOP) document behind-the-scenes publish → live 08 flow.

## Test plan
- [x] `pytest tests/test_live_08_status_fixes.py` (+ bootstrap/status suites) green
- [x] AppTest Twin/Fuel/ECMs with answers — no Streamlit exceptions
- [ ] After merge: vibe20-ghcr success; `docker pull ghcr.io/bbartling/vibe20:latest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live EnergyPlus simulation progress, status updates, and log streaming in Studio.
  * Added support for loading and merging ECM scenario settings without overwriting existing configuration.
  * Expanded session status reporting for utility bills, calibration scores, selected ECMs, and active runs.
  * Improved Detroit and location-based EPW guidance.

* **Bug Fixes**
  * Corrected ECM scenario status, run selection, bootstrap merging, and utility bill availability reporting.

* **Documentation**
  * Updated setup and workflow guidance for live simulation progress, scenario configuration, and Studio verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->