### PR TITLE
feat(vibe20): horizontal EUI bullets, multi-year weather fit, Twin 08 bottom

### DIFF
--- a/vibe_code_apps_20/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/CONTAINER_AGENT.md
@@ -11,13 +11,15 @@ agent: wattlab twin | calibrate-campaign | easy-button | ecm_scenario.json
         ▼  Docker energyplus-mcp-dev (DinD)
 runs/<id>/progress.json + console.log   ← live while sim runs
 runs/<id>/eplusout.csv                  ← after ReadVars (-r)
+runs/<id>/model.idf                     ← for Twin 3D massing (unique per building)
 publish_run_for_studio → CURRENT_RUN + bootstrap preferred_run_id
         │
         ▼
 Human Studio Twin: fragment polls progress; OA/floor charts after CSV
 ```
 
-No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live 08 panes are **file polls**.
+No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live panes are **file polls**.
+Twin massing parses published IDF surfaces (not a hard-coded prototype footprint).
 
 ## Read first
 

--- a/vibe_code_apps_20/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/CONTAINER_AGENT.md
@@ -6,20 +6,43 @@ You are inside **`ghcr.io/bbartling/vibe20:latest`** (or vibe19). Work on the sh
 ## Behind the scenes (agent ↔ Studio)
 
 ```text
-agent: wattlab twin | calibrate-campaign | easy-button | ecm_scenario.json
+agent: wattlab twin | calibrate-campaign | geo-idf | dial-loads | score-monthly
         │
         ▼  Docker energyplus-mcp-dev (DinD)
 runs/<id>/progress.json + console.log   ← live while sim runs
 runs/<id>/eplusout.csv                  ← after ReadVars (-r)
-runs/<id>/model.idf                     ← for Twin 3D massing (unique per building)
+runs/<id>/model.idf                     ← Twin 3D massing (unique per building)
 publish_run_for_studio → CURRENT_RUN + bootstrap preferred_run_id
         │
         ▼
-Human Studio Twin: fragment polls progress; OA/floor charts after CSV
+Human Studio Twin: fragment polls progress; IDF massing + OA after publish
 ```
 
 No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live panes are **file polls**.
 Twin massing parses published IDF surfaces (not a hard-coded prototype footprint).
+
+## Geometry gate (before G14 / fuel matching)
+
+Answers `floors` / `wwr` / `floor_area_ft2` do **not** rebuild the IDF. Default remains
+`5ZoneAirCooled` × `prototype_area_scale` — that **cannot** represent a multistory glass
+office for fuel matching.
+
+For site-scale glass / multistory offices (any building):
+
+1. `wattlab geo-idf --src <DOE Large Office>.idf --dst … --target-area-ft2 … --stories … --wwr … --lat … --lon …`
+2. Profile / answers: `custom_idf` → that IDF, **`prototype_area_scale = 1`**
+3. Publish `model.idf` + `eplusout.csv` for Twin 3D massing
+4. Fuel-mix heuristic: high elec + low gas ⇒ excess internal gains — dial Lights/Equip down and
+   infiltration up via **EnergyPlus MCP** (`wattlab dial-loads`), not more fan/DAT schedule
+   patches on a tiny prototype.
+5. Score: `wattlab score-monthly eplusout.csv --bills … --area-ft2 …` (last-12 Monthly meters)
+
+**EnergyPlus MCP:** tip image = `simulate_only`. Full inspect/modify needs
+`third_party/EnergyPlus-MCP` + `energyplus-mcp-dev` docker one-shot (or Cursor MCP).
+Use MCP for load/envelope edits; use WattLab DinD for annual sims. Skip vendor
+`validate_idf` if eppy MSequence errors.
+
+**Bills honesty:** campus area-weighted half elec + per-building gas — never double-half.
 
 ## Read first
 
@@ -30,6 +53,7 @@ Twin massing parses published IDF surfaces (not a hard-coded prototype footprint
 | `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS |
 | `/app/vibe20_agent_spec/DATA_CONTRACT.md` | Dump / answers / campus schemas |
 | `/app/vibe20_agent_spec/AGENT_TESTER_PROMPT.md` | Soak checklist |
+| `/app/vibe20_agent_spec/docs/TWIN_LOOP.md` | Twin loop + geometry gate |
 | `/app/vibe20_agent_spec/skills/wattlab-*/SKILL.md` | Procedure skills |
 
 ## Run (preferred)
@@ -42,16 +66,19 @@ docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
 
 Useful commands:
 
-- `wattlab studio-status --write` → `reports/session_status.json` (missing | answered | phase2; G14 from scorecard)
+- `wattlab studio-status --write` → `reports/session_status.json`
 - `wattlab studio-bootstrap --campus … --dump … --run-id … --answers … --ecm-scenario …`
   (merges existing keys — does not drop `ecm_scenario_path`)
-- `wattlab calibrate-campaign …` / `wattlab twin …` / `wattlab ecm list|packages`
+- `wattlab geo-idf` / `wattlab dial-loads` / `wattlab score-monthly` — site-scale twin ladder
+- `wattlab calibrate-campaign …` / `wattlab twin …` / `wattlab benchmark …`
 - Write `reports/ecm_scenario.json` → Studio ECMs Easy Buttons after Re-apply
 
-Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**. Twin DinD shows live progress bar.
+Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**. Twin DinD shows live progress + IDF massing when `model.idf` is published.
 
 ## Do not
 
 - Require `git clone` / `pip install -e` for production soaks (host contrib only)
 - Invent `building_type` / `city` / `floor_area_ft2` — write `reports/answers*.json`
 - Claim calibrated ROI without G14 stamps
+- Expect answers `floors`/`wwr` alone to rebuild geometry
+- Double-half shared electric that is already area-weighted

--- a/vibe_code_apps_20/tests/test_geo_dial_score_tools.py
+++ b/vibe_code_apps_20/tests/test_geo_dial_score_tools.py
@@ -1,0 +1,75 @@
+"""Generalized geo-idf / score-monthly tools (any building)."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wattlab.energyplus.geo_idf import process_geometry, rewrite_vert_line
+from wattlab.energyplus.score_monthly import last12_monthly, score_monthly_run
+
+
+def test_last12_monthly_skips_extra():
+    s = pd.Series([0.0] + [float(i) for i in range(1, 15)])
+    out = last12_monthly(s)
+    assert len(out) == 12
+    assert float(out.iloc[0]) == 3.0
+
+
+def test_score_monthly_vs_bills(tmp_path: Path):
+    months = [f"01/{i:02d} 24:00:00" for i in range(1, 13)]
+    j_per_mo = 1000.0 * 3.6e6
+    g_per_mo = 10.0 * 1.05506e8
+    df = pd.DataFrame(
+        {
+            "Date/Time": months,
+            "Electricity:Facility [J](Monthly)": [j_per_mo] * 12,
+            "NaturalGas:Facility [J](Monthly)": [g_per_mo] * 12,
+        }
+    )
+    ep = tmp_path / "eplusout.csv"
+    df.to_csv(ep, index=False)
+    bills = tmp_path / "bills.csv"
+    with bills.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=["month", "kwh", "therms"])
+        w.writeheader()
+        for i in range(12):
+            w.writerow({"month": f"2024-{i+1:02d}", "kwh": 1000, "therms": 10})
+    sc = score_monthly_run(ep, bills, area_ft2=10000.0, run_id="t")
+    assert sc["area_scale"] == 1.0
+    assert sc["elec_delta_pct"] == pytest.approx(0.0, abs=0.2)
+    assert sc["gas_delta_pct"] == pytest.approx(0.0, abs=0.2)
+
+
+def test_vert_semicolon_before_comment():
+    line = "    0.0,0.0,3.0;  !- X,Y,Z ==> Vertex 4 {m}\n"
+    out = rewrite_vert_line(line, 1.0, 2.0, 3.5)
+    assert ";" in out.split("!")[0]
+    assert "1.0000,2.0000,3.5000;" in out
+
+
+def test_process_geometry_scales_wall():
+    idf = """  BuildingSurface:Detailed,
+    WallA,                   !- Name
+    Wall,                    !- Surface Type
+    Const,                   !- Construction Name
+    ZoneA,                   !- Zone Name
+    ,                        !- Space Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    0.5,                     !- View Factor to Ground
+    4,                       !- Number of Vertices
+    0.0,0.0,0.0,  !- X,Y,Z ==> Vertex 1 {m}
+    10.0,0.0,0.0,  !- X,Y,Z ==> Vertex 2 {m}
+    10.0,0.0,3.0,  !- X,Y,Z ==> Vertex 3 {m}
+    0.0,0.0,3.0;  !- X,Y,Z ==> Vertex 4 {m}
+
+"""
+    out, nb, _nf = process_geometry(idf, xy_scale=2.0, wwr_target=0.6)
+    assert nb == 4
+    assert "20.0000,0.0000,0.0000" in out

--- a/vibe_code_apps_20/tests/test_idf_geometry_viz.py
+++ b/vibe_code_apps_20/tests/test_idf_geometry_viz.py
@@ -1,0 +1,136 @@
+"""IDF geometry viewer + publish model.idf coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+FIVE_ZONE = ROOT / "examples" / "prototypes" / "5ZoneAirCooled.idf"
+
+# Tiny synthetic shoebox — different footprint than 5Zone (proves non-hardcoded)
+_SYNTH_IDF = """
+  BuildingSurface:Detailed,
+    Wall-South,              !- Name
+    WALL,                    !- Surface Type
+    ExtWall,                 !- Construction Name
+    ZoneA,                   !- Zone Name
+    ,                        !- Space Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    0.5,                     !- View Factor to Ground
+    4,                       !- Number of Vertices
+    0,0,0,  !- X,Y,Z ==> Vertex 1 {m}
+    60,0,0,  !- X,Y,Z ==> Vertex 2 {m}
+    60,0,20,  !- X,Y,Z ==> Vertex 3 {m}
+    0,0,20;  !- X,Y,Z ==> Vertex 4 {m}
+
+  BuildingSurface:Detailed,
+    Roof-1,                  !- Name
+    ROOF,                    !- Surface Type
+    RoofConst,               !- Construction Name
+    ZoneA,                   !- Zone Name
+    ,                        !- Space Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    0.0,                     !- View Factor to Ground
+    4,                       !- Number of Vertices
+    0,0,20,
+    0,40,20,
+    60,40,20,
+    60,0,20;
+"""
+
+
+def test_parse_5zone_idf_surfaces():
+    from wattlab.studio.idf_geometry import idf_massing_figure, parse_idf_geometry
+
+    assert FIVE_ZONE.is_file()
+    geom = parse_idf_geometry(FIVE_ZONE)
+    assert len(geom.surfaces) >= 10
+    assert any(z.startswith("SPACE") for z in geom.zone_names)
+    summary = geom.summary()
+    assert summary["bbox_m"]["dx"] > 1
+    fig = idf_massing_figure(geom)
+    assert len(fig.data) >= 1
+
+
+def test_synthetic_idf_different_bbox_from_5zone():
+    from wattlab.studio.idf_geometry import parse_idf_geometry
+
+    synth = parse_idf_geometry(_SYNTH_IDF)
+    five = parse_idf_geometry(FIVE_ZONE)
+    assert synth.summary()["bbox_m"]["dx"] == pytest.approx(60.0)
+    assert five.summary()["bbox_m"]["dx"] == pytest.approx(30.5)
+    assert synth.summary()["bbox_m"]["dx"] != five.summary()["bbox_m"]["dx"]
+
+
+def test_publish_copies_model_idf(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from wattlab.studio.ep_viz import find_run_idf, publish_run_for_studio
+
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    src = tmp_path / "artifacts" / "run_src"
+    src.mkdir(parents=True)
+    (src / "baseline.idf").write_text(_SYNTH_IDF, encoding="utf-8")
+    (src / "eplusout.csv").write_text("Date/Time\n", encoding="utf-8")
+    dest = publish_run_for_studio(src, run_id="geo_test", dest_root=tmp_path / "runs" / "geo_test")
+    assert (dest / "model.idf").is_file()
+    assert find_run_idf(dest) == dest / "model.idf"
+    from wattlab.studio.idf_geometry import parse_idf_geometry
+
+    assert parse_idf_geometry(dest / "model.idf").surfaces
+
+
+def test_studio_apptest_twin_no_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip("streamlit")
+    import json
+
+    from streamlit.testing.v1 import AppTest
+
+    from wattlab.studio.bootstrap import build_bootstrap_payload, write_bootstrap
+    from wattlab.studio.ep_viz import publish_run_for_studio
+
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    monkeypatch.delenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", raising=False)
+    (tmp_path / "reports").mkdir(parents=True)
+    answers = {
+        "building_type": "office",
+        "city": "detroit",
+        "floor_area_ft2": 140000,
+        "floors": 6,
+        "lat": 42.33,
+        "lon": -83.04,
+    }
+    (tmp_path / "reports" / "answers.json").write_text(json.dumps(answers), encoding="utf-8")
+
+    src = tmp_path / "art"
+    src.mkdir()
+    if FIVE_ZONE.is_file():
+        (src / "baseline.idf").write_bytes(FIVE_ZONE.read_bytes())
+    else:
+        (src / "baseline.idf").write_text(_SYNTH_IDF, encoding="utf-8")
+    fixture_csv = ROOT / "tests" / "fixtures" / "eplusout" / "eplusout.csv"
+    if fixture_csv.is_file():
+        (src / "eplusout.csv").write_bytes(fixture_csv.read_bytes())
+    else:
+        (src / "eplusout.csv").write_text("Date/Time\n", encoding="utf-8")
+    publish_run_for_studio(src, run_id="apptest_geo", dest_root=tmp_path / "runs" / "apptest_geo")
+
+    write_bootstrap(
+        build_bootstrap_payload(
+            preferred_run_id="apptest_geo",
+            answers_path="reports/answers.json",
+        )
+    )
+    at = AppTest.from_file(str(ROOT / "studio.py"), default_timeout=60)
+    at.run()
+    assert not at.exception
+    at.radio(key="studio_page").set_value("Twin / calibrate").run()
+    assert not at.exception
+    at.radio(key="studio_page").set_value("Fuel dashboard").run()
+    assert not at.exception

--- a/vibe_code_apps_20/tests/test_ui_charts_multiyear.py
+++ b/vibe_code_apps_20/tests/test_ui_charts_multiyear.py
@@ -1,0 +1,128 @@
+"""UI charts tip: EUI bullet, multi-year weather fit, month abbrevs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def test_month_abbrev():
+    from wattlab.studio.eui_charts import MONTH_ABBREV, month_abbrev, month_abbrev_columns
+
+    assert month_abbrev(1) == "Jan"
+    assert month_abbrev("12") == "Dec"
+    assert month_abbrev("07") == "Jul"
+    mat = pd.DataFrame([[1.0] * 12], columns=list(range(1, 13)), index=[2024])
+    renamed = month_abbrev_columns(mat)
+    assert list(renamed.columns) == list(MONTH_ABBREV)
+
+
+def test_eui_peer_bullet_figure_has_band_and_rows():
+    from wattlab.studio.eui_charts import eui_peer_bullet_figure
+
+    fig = eui_peer_bullet_figure(
+        peer_p20=34.0,
+        peer_p50=52.9,
+        peer_p80=71.0,
+        series=[
+            {"label": "Bills (site)", "eui": 66.9, "color": "#1f77b4"},
+            {"label": "Model (prototype)", "eui": 24.0, "color": "#d62728"},
+        ],
+        title="test",
+    )
+    # One rect + one p50 line per series row
+    assert len(fig.layout.shapes) == 4
+    assert any(t.mode and "markers" in str(t.mode) for t in fig.data)
+
+
+def test_fit_window_defaults_to_max_years():
+    from wattlab.benchmarks.fuel_weather import (
+        fit_window_choices,
+        months_for_fit_years,
+    )
+
+    months = [f"{y}-{m:02d}" for y in range(2016, 2026) for m in range(1, 13)]
+    # 10 full years
+    assert len(months) == 120
+    choices = fit_window_choices(months)
+    assert choices["max_years"] == 10
+    assert choices["default_years"] == 10
+    assert months_for_fit_years(months, 10) == 120
+    assert months_for_fit_years(months, 1) == 12
+    assert months_for_fit_years(months, 3, use_all=True) == 120
+
+
+def test_align_fuel_respects_months_window(tmp_path: Path):
+    from wattlab.benchmarks.fuel_weather import align_fuel_and_degree_days
+    from wattlab.benchmarks.meters import BuildingRef, Campus, Meter
+
+    # 24 months of bills
+    months = [f"2023-{m:02d}" for m in range(1, 13)] + [f"2024-{m:02d}" for m in range(1, 13)]
+    bills = pd.DataFrame({"month": months, "usage": [100.0 + i for i in range(24)]})
+    b = BuildingRef(building_id="b1", label="B1", floor_area_ft2=10000.0, property_type="office")
+    m = Meter(
+        meter_id="g1",
+        fuel="gas",
+        unit="mcf",
+        serves=["b1"],
+        bills=bills,
+    )
+    campus = Campus(
+        campus_id="c1",
+        label="C",
+        buildings=[b],
+        meters=[m],
+        lat=42.0,
+        lon=-83.0,
+    )
+    # Hourly OAT covering both years
+    idx = pd.date_range("2023-01-01", periods=24 * 30 * 24, freq="h")
+    oat = pd.Series(
+        35.0 + 30.0 * np.sin(np.arange(len(idx)) / 24 / 365 * 2 * np.pi),
+        index=idx,
+        name="dry_bulb_f",
+    )
+    aligned12, win12 = align_fuel_and_degree_days(campus, oat, months=12)
+    aligned24, win24 = align_fuel_and_degree_days(campus, oat, months=24)
+    assert len(win12) == 12
+    assert len(win24) == 24
+    assert len(win24) > len(win12)
+    assert not aligned24.empty
+
+
+def test_studio_apptest_fuel_twin_no_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip("streamlit")
+    from streamlit.testing.v1 import AppTest
+
+    from wattlab.studio.bootstrap import build_bootstrap_payload, write_bootstrap
+
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    monkeypatch.delenv("WATTLAB_STUDIO_BOOTSTRAP_DISABLE", raising=False)
+    (tmp_path / "reports").mkdir(parents=True)
+    answers = {
+        "building_type": "office",
+        "city": "detroit",
+        "floor_area_ft2": 140000,
+        "floors": 6,
+        "lat": 42.33,
+        "lon": -83.04,
+    }
+    (tmp_path / "reports" / "answers.json").write_text(json.dumps(answers), encoding="utf-8")
+    write_bootstrap(
+        build_bootstrap_payload(
+            preferred_run_id="noop",
+            answers_path="reports/answers.json",
+        )
+    )
+    root = Path(__file__).resolve().parents[1]
+    at = AppTest.from_file(str(root / "studio.py"), default_timeout=60)
+    at.run()
+    assert not at.exception
+    at.radio(key="studio_page").set_value("Fuel dashboard").run()
+    assert not at.exception
+    at.radio(key="studio_page").set_value("Twin / calibrate").run()
+    assert not at.exception

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -172,6 +172,23 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 
 ---
 
+## Site-scale geometry + load dial (any building)
+
+**Do not** expect `answers.floors` / `wwr` / `floor_area_ft2` to rebuild the IDF.
+Default archetype remains 5Zone × `prototype_area_scale` — screening only.
+
+| Tool | CLI | Role |
+| --- | --- | --- |
+| `wattlab.energyplus.geo_idf` | `wattlab geo-idf` | DOE Large Office (or similar) → site-scale massing (stories, WWR, XY scale, lat/lon) |
+| `wattlab.energyplus.dial_loads` | `wattlab dial-loads` | MCP: lights / equip W/m² + infil mult (needs full MCP image) |
+| `wattlab.energyplus.score_monthly` | `wattlab score-monthly` | Last-12 Monthly meters vs bills; `area_scale=1` |
+
+Workflow: **geo-idf → custom_idf + area_scale=1 → DinD sim → score-monthly**. If elec high /
+gas low, dial loads via MCP before more schedule patches. Bills: area-weighted half
+elec once — never double-half. Twin shows IDF 3D massing from published `model.idf`.
+
+---
+
 ## Smoke scripts (before claiming done)
 
 ```powershell

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -5,7 +5,7 @@ LAN box that shares `WATTLAB_STUDIO_WORKSPACE` with Studio.
 
 Studio is only the **browser viewer**. You are the energy-engineering helper.
 You must **actually run several live EnergyPlus simulations**, publish each one
-for the human to see in Twin (APIHelper-08 panes), and iterate with the human —
+for the human to see in Twin (progress, OA, **IDF 3D massing**), and iterate with the human —
 not a single dry-run or fixture replay.
 
 Practice dumps/zips on a test bench are **examples only**. Data-model driven for
@@ -49,7 +49,8 @@ Practice dumps/zips on a test bench are **examples only**. Data-model driven for
 ## MINIMUM LIVE SIM CAMPAIGN (required)
 
 **QA floor:** ≥3 successful live EnergyPlus runs (Docker `energyplus-mcp-dev`),
-each published to a distinct `runs/<run_id>/` with `eplusout.csv`, visible in
+each published to a distinct `runs/<run_id>/` with `eplusout.csv` **and** `model.idf`
+(or another published `*.idf`), visible in
 Twin iteration history.
 
 **Sparse / poorly known building (recommended):** follow the full ladder in
@@ -73,7 +74,8 @@ meets the ≥3 floor — still one hypothesis per run.
 **Between every run:**
 
 1. Publish to workspace `runs/` (`publish_run_for_studio` or easy-button auto-publish).
-2. Tell the human to open Twin → Refresh → confirm 08 panes (OA + floor plan) updated.
+2. Tell the human to open Twin → Refresh → confirm visualizer updated: OA + **IDF 3D massing**
+   (unique footprint per run — not hard-coded 5Zone). Empty massing = missing published IDF.
 3. Compare monthly modeled vs `utility_bills` / campus; log NMBE/CV(RMSE) when windows overlap.
 4. Ask the human what to try next if gates fail or crosscheck is `investigate`.
 
@@ -158,10 +160,12 @@ publish_run_for_studio(Path("…/wattlab_<run_id>"), run_id="<run_id>")
 
 - **EUI index — bills vs peers vs model** (metrics + strip chart). Model EUI is
   prototype-area intensity; call out `prototype_area_scale` (e.g. ≈14× for 140k).
-- After **each** live run: progress/log, OA chart, 5Zone floor plan, growing
+- After **each** live run: progress/log, OA chart, **IDF 3D massing** from published
+  `model.idf` (unique per building), zone colors when CSV maps, growing
   iteration history (ideally with `model_eui_kbtu_ft2` column when `report.json`
   is published).
-- Empty 08 panes = missing publish / `-r` / DinD — check env + sibling stage mounts.
+- Empty visualizer / missing massing = missing publish of `model.idf` and/or `eplusout.csv`
+  / `-r` / DinD — check env + sibling stage mounts.
 
 **Regression (this image):** Twin → **Run EnergyPlus (Docker)** once from Studio
 itself (not only host CLI). Expect `eplusout.csv` without chmod workarounds.
@@ -226,7 +230,7 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 | --- | --- |
 | Fuel | ≥1 real chart + bill EUI + peer p50/p20/p80 visible |
 | Twin EUI index | Bills vs peers vs model strip (model after publish) |
-| Twin UI smoke | 08 panes work (replay ok) |
+| Twin UI smoke | Visualizer works (replay ok); IDF massing when `model.idf` present |
 | **Studio DinD + `-r`** | ≥1 live sim **from Studio button** yields `eplusout.csv` |
 | **Twin calibrate** | **≥3 live** `energyplus-mcp-dev` sims in `runs/`, each with eplusout; human saw updates; G14 attempted **or** honest mismatch logged when bills exist |
 | E+ MCP | ≥1 inspect/validate if MCP available; else document `simulate_only` |

--- a/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
@@ -11,13 +11,15 @@ agent: wattlab twin | calibrate-campaign | easy-button | ecm_scenario.json
         ▼  Docker energyplus-mcp-dev (DinD)
 runs/<id>/progress.json + console.log   ← live while sim runs
 runs/<id>/eplusout.csv                  ← after ReadVars (-r)
+runs/<id>/model.idf                     ← Twin 3D massing (unique per building)
 publish_run_for_studio → CURRENT_RUN + bootstrap preferred_run_id
         │
         ▼
-Human Studio Twin: fragment polls progress; OA/floor charts after CSV
+Human Studio Twin: fragment polls progress; IDF massing + OA after publish
 ```
 
-No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live 08 panes are **file polls**.
+No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live panes are **file polls**.
+Twin massing parses published IDF surfaces (not a hard-coded prototype footprint).
 
 ## Read first
 

--- a/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
@@ -6,7 +6,7 @@ You are inside **`ghcr.io/bbartling/vibe20:latest`** (or vibe19). Work on the sh
 ## Behind the scenes (agent ↔ Studio)
 
 ```text
-agent: wattlab twin | calibrate-campaign | easy-button | ecm_scenario.json
+agent: wattlab twin | calibrate-campaign | geo-idf | dial-loads | score-monthly
         │
         ▼  Docker energyplus-mcp-dev (DinD)
 runs/<id>/progress.json + console.log   ← live while sim runs
@@ -21,16 +21,40 @@ Human Studio Twin: fragment polls progress; IDF massing + OA after publish
 No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live panes are **file polls**.
 Twin massing parses published IDF surfaces (not a hard-coded prototype footprint).
 
+## Geometry gate (before G14 / fuel matching)
+
+Answers `floors` / `wwr` / `floor_area_ft2` do **not** rebuild the IDF. Default remains
+`5ZoneAirCooled` × `prototype_area_scale` — that **cannot** represent a multistory glass
+office for fuel matching.
+
+For site-scale glass / multistory offices (any building):
+
+1. `wattlab geo-idf --src <DOE Large Office>.idf --dst … --target-area-ft2 … --stories … --wwr … --lat … --lon …`
+2. Profile / answers: `custom_idf` → that IDF, **`prototype_area_scale = 1`**
+3. Publish `model.idf` + `eplusout.csv` for Twin 3D massing
+4. Fuel-mix heuristic: high elec + low gas ⇒ excess internal gains — dial Lights/Equip down and
+   infiltration up via **EnergyPlus MCP** (`wattlab dial-loads`), not more fan/DAT schedule
+   patches on a tiny prototype.
+5. Score: `wattlab score-monthly eplusout.csv --bills … --area-ft2 …` (last-12 Monthly meters)
+
+**EnergyPlus MCP:** tip image = `simulate_only`. Full inspect/modify needs
+`third_party/EnergyPlus-MCP` + `energyplus-mcp-dev` docker one-shot (or Cursor MCP).
+Use MCP for load/envelope edits; use WattLab DinD for annual sims. Skip vendor
+`validate_idf` if eppy MSequence errors.
+
+**Bills honesty:** campus area-weighted half elec + per-building gas — never double-half.
+
 ## Read first
 
 | Path | Why |
 | --- | --- |
-| `/app/CONTAINER_AGENT.md` | Root copy of this guide |
-| `/app/vibe20_agent_spec/CONTAINER_AGENT.md` | Same |
+| `/app/CONTAINER_AGENT.md` | This file |
 | `/app/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + DinD + bootstrap |
 | `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS |
 | `/app/vibe20_agent_spec/DATA_CONTRACT.md` | Dump / answers / campus schemas |
 | `/app/vibe20_agent_spec/AGENT_TESTER_PROMPT.md` | Soak checklist |
+| `/app/vibe20_agent_spec/docs/TWIN_LOOP.md` | Twin loop + geometry gate |
+| `/app/vibe20_agent_spec/skills/wattlab-*/SKILL.md` | Procedure skills |
 
 ## Run (preferred)
 
@@ -40,12 +64,21 @@ docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
   wattlab <cmd>
 ```
 
-- `wattlab studio-status --write`
-- `wattlab studio-bootstrap … --ecm-scenario /data/reports/ecm_scenario.json` (merge-safe)
-- Write `reports/ecm_scenario.json` for Easy Buttons
+Useful commands:
+
+- `wattlab studio-status --write` → `reports/session_status.json`
+- `wattlab studio-bootstrap --campus … --dump … --run-id … --answers … --ecm-scenario …`
+  (merges existing keys — does not drop `ecm_scenario_path`)
+- `wattlab geo-idf` / `wattlab dial-loads` / `wattlab score-monthly` — site-scale twin ladder
+- `wattlab calibrate-campaign …` / `wattlab twin …` / `wattlab benchmark …`
+- Write `reports/ecm_scenario.json` → Studio ECMs Easy Buttons after Re-apply
+
+Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**. Twin DinD shows live progress + IDF massing when `model.idf` is published.
 
 ## Do not
 
-- Require git clone for soaks
-- Invent required site facts
+- Require `git clone` / `pip install -e` for production soaks (host contrib only)
+- Invent `building_type` / `city` / `floor_area_ft2` — write `reports/answers*.json`
 - Claim calibrated ROI without G14 stamps
+- Expect answers `floors`/`wwr` alone to rebuild geometry
+- Double-half shared electric that is already area-weighted

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -55,6 +55,26 @@ Do **not** point Schedule:File at absolute `/data/...` host paths (FATAL file no
 
 Helpers: `wattlab.existing_building.schedules` + `wattlab.energyplus.patches.weather_schedules`.
 
+## Site-scale geometry + EnergyPlus MCP (batch)
+
+Tip image EnergyPlus MCP capability is often **`simulate_only`**. Annual sims use
+WattLab DinD (`run_energyplus`). For inspect/modify (lights, equipment, infil):
+
+```bash
+# Host: vendor tree + workspace mounted; run dial script inside MCP image
+docker run --rm \
+  -v "$WATTLAB_HOST_WORKSPACE":/data \
+  -v "$REPO/vibe_code_apps_20/third_party/EnergyPlus-MCP":/workspace \
+  -w /workspace/energyplus-mcp-server \
+  --entrypoint bash energyplus-mcp-dev \
+  -lc 'uv run wattlab dial-loads …'   # or python -m wattlab.energyplus.dial_loads
+```
+
+Geometry ladder (any building; CLI args — not Liberty-hardcoded):
+`wattlab geo-idf` → `custom_idf` + `area_scale=1` → DinD → `wattlab score-monthly`.
+Skip vendor `validate_idf` if eppy MSequence errors. See `CONTAINER_AGENT.md`
+geometry gate + `TWIN_LOOP.md`.
+
 ## G14 calibrate campaign (bill months → Twin)
 
 ```bash

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -11,8 +11,10 @@ E+ iteration so Twin 08 panes appear in the browser
 (`publish_run_for_studio` / `runs/CURRENT_RUN.txt`).
 
 **Live 08:** DinD writes `progress.json` + `console.log` during the sim; Twin polls
-(progress/log live). OA + floor-plan charts update when `eplusout.csv` exists
-(after ReadVars). Not embedded pyenergyplus / not Flask APIHelper.
+(progress/log live). OA charts update when `eplusout.csv` exists (after ReadVars).
+**Building massing** comes from published `model.idf` (BuildingSurface:Detailed) —
+unique per run / site. Zone colors apply when CSV zone names match. Not embedded
+pyenergyplus / not Flask APIHelper / not hard-coded Liberty footprints.
 
 Full paste prompt for QA + calibrate sessions:
 [`../AGENT_TESTER_PROMPT.md`](../AGENT_TESTER_PROMPT.md).
@@ -73,7 +75,8 @@ Studio Twin:
 - Docker run → `runs/<run_id>/` (report, eplusout, manifest); needs
   `WATTLAB_HOST_WORKSPACE` + docker.sock for DinD; `-r` → `eplusout.csv`
 - Demo replay → fixture eplusout labeled replay (UI smoke without E+ image)
-- **08-style panes**: progress + console, outdoor DBT, classic 5Zone floor-plan
+- **Visualizer panes**: progress + console, outdoor DBT, **IDF 3D massing** from
+  `model.idf` (fallback classic 5Zone schematic only when no IDF published)
   heatmap (`wattlab.studio.ep_viz`) — viz patterns only, not host Runtime API
 
 **Order when little is known** (see [`SPARSE_BUILDING_PLAYBOOK.md`](SPARSE_BUILDING_PLAYBOOK.md)):
@@ -125,7 +128,7 @@ Always area-normalize vs the 5ZoneAirCooled prototype footprint
 
 ```
 uploads/dump/  uploads/energy/  uploads/energy/derived/
-runs/<run_id>/eplusout.csv | run_manifest.json | progress.json | report.json
+runs/<run_id>/eplusout.csv | model.idf | run_manifest.json | progress.json | report.json
 reports/utility_bills.csv | last_dry_run_plan.json | BUG_REPORT.md | CALIBRATE_SESSION.md
 ```
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -16,6 +16,19 @@ E+ iteration so Twin 08 panes appear in the browser
 unique per run / site. Zone colors apply when CSV zone names match. Not embedded
 pyenergyplus / not Flask APIHelper / not hard-coded Liberty footprints.
 
+## Geometry gate (site-scale twins)
+
+Answers `floors` / `wwr` / `sqft` do **not** rebuild the IDF. Default = 5Zone ×
+`prototype_area_scale`. For glass multistory offices:
+
+1. `wattlab geo-idf` (DOE Large Office → site-scale; any building via CLI args)
+2. `custom_idf` + **`area_scale = 1`**
+3. Fuel mix: high elec / low gas → `wattlab dial-loads` (EnergyPlus MCP one-shot)
+4. `wattlab score-monthly` — last-12 Monthly meters vs area-weighted bills (never double-half)
+
+Annual simulate = WattLab DinD. MCP = inspect/modify loads only (`simulate_only` tip
+does not ship full MCP tools).
+
 Full paste prompt for QA + calibrate sessions:
 [`../AGENT_TESTER_PROMPT.md`](../AGENT_TESTER_PROMPT.md).
 

--- a/vibe_code_apps_20/wattlab/benchmarks/fuel_weather.py
+++ b/vibe_code_apps_20/wattlab/benchmarks/fuel_weather.py
@@ -24,6 +24,48 @@ from wattlab.weather.degree_days import DD_BASE_F, degree_day_meta, monthly_degr
 MIN_OVERLAP_MONTHS = 6
 
 
+def bill_overlap_months(campus: Campus) -> list[str]:
+    """Sorted YYYY-MM months present on every campus meter."""
+    if not campus.meters:
+        return []
+    common = set.intersection(*(set(m.bills["month"].astype(str)) for m in campus.meters))
+    return sorted(common)
+
+
+def fit_window_choices(available_months: list[str]) -> dict[str, Any]:
+    """UI choices for last-N-years / all-months fit windows.
+
+    Returns ``max_years``, ``default_years``, ``default_months``, ``available_n``.
+    """
+    n = len(available_months)
+    max_years = max(1, n // 12)
+    # Prefer full history when ≥12 months; still allow 1y …
+    default_years = max_years if n >= 12 else 1
+    default_months = min(n, default_years * 12) if n else 12
+    if n and default_months < n and n % 12 != 0:
+        # Allow "all overlapping months" as the max selection via months=n
+        pass
+    return {
+        "available_n": n,
+        "max_years": max_years,
+        "default_years": default_years,
+        "default_months": default_months,
+        "first": available_months[0] if available_months else None,
+        "last": available_months[-1] if available_months else None,
+    }
+
+
+def months_for_fit_years(available_months: list[str], years: int, *, use_all: bool = False) -> int:
+    """Resolve months= argument for align_fuel_and_degree_days from UI years."""
+    n = len(available_months)
+    if n <= 0:
+        return 12
+    if use_all:
+        return n
+    years = max(1, int(years))
+    return min(n, years * 12)
+
+
 @dataclass(frozen=True)
 class FuelFit:
     fuel: str
@@ -250,14 +292,23 @@ def build_fuel_weather_report(
     *,
     base_f: float = DD_BASE_F,
     weather_source: str = "synthetic_or_open_meteo",
+    months: int = 12,
 ) -> dict[str, Any]:
     """Bundle aligned series, fits, and provenance for Studio / tests."""
-    aligned, window = align_fuel_and_degree_days(campus, hourly_oat, base_f=base_f)
+    aligned, window = align_fuel_and_degree_days(
+        campus, hourly_oat, base_f=base_f, months=months
+    )
     fits = fit_weather_responses(aligned, base_f=base_f)
     return {
         "campus_id": campus.campus_id,
         "label": campus.label,
-        "window": {"start": window[0] if window else None, "end": window[-1] if window else None, "months": window},
+        "window": {
+            "start": window[0] if window else None,
+            "end": window[-1] if window else None,
+            "months": window,
+            "n": len(window),
+            "requested_months": int(months),
+        },
         "degree_days": degree_day_meta(base_f=base_f, source=weather_source),
         "fits": [f.as_dict() for f in fits],
         "aligned_rows": int(len(aligned)),
@@ -269,13 +320,16 @@ __all__ = [
     "FuelFit",
     "MIN_OVERLAP_MONTHS",
     "align_fuel_and_degree_days",
+    "bill_overlap_months",
     "build_fuel_weather_report",
     "campus_fuel_totals",
     "demand_heatmap_frame",
     "fit_weather_responses",
+    "fit_window_choices",
     "gas_usage_therms",
     "intensity_heatmap_frame",
     "meter_monthly_long",
+    "months_for_fit_years",
     "ols_fit",
     "residual_frame",
 ]

--- a/vibe_code_apps_20/wattlab/cli.py
+++ b/vibe_code_apps_20/wattlab/cli.py
@@ -29,6 +29,9 @@ def _usage() -> str:
         "               also: wattlab seed import-bills --electric CSV --gas CSV --out utility_bills.csv\n"
         "  studio-bootstrap  Write studio_bootstrap.json for Streamlit auto-load\n"
         "  studio-status     Merge dump/answers/bootstrap/run → session_status.json\n"
+        "  geo-idf          Adapt DOE Large Office IDF → site-scale massing (any building)\n"
+        "  dial-loads       Dial lights/equip/infil via EnergyPlus MCP (full MCP image)\n"
+        "  score-monthly    Score eplusout Monthly vs bills (last-12, area_scale=1)\n"
         "  explore-existing  Existing Building Hypothesis Lab orchestration\n"
         "  hypothesis-lab    Alias for explore-existing\n"
         "  ecm          Canonical ECM catalog (list/describe/package/audit)\n"
@@ -166,6 +169,18 @@ def main(argv: list[str] | None = None) -> int:
         return int(m(rest) or 0)
     if cmd in {"studio-status", "studio_status"}:
         from wattlab.studio.status import main as m
+
+        return int(m(rest) or 0)
+    if cmd in {"geo-idf", "geo_idf"}:
+        from wattlab.energyplus.geo_idf import main as m
+
+        return int(m(rest) or 0)
+    if cmd in {"dial-loads", "dial_loads"}:
+        from wattlab.energyplus.dial_loads import main as m
+
+        return int(m(rest) or 0)
+    if cmd in {"score-monthly", "score_monthly"}:
+        from wattlab.energyplus.score_monthly import main as m
 
         return int(m(rest) or 0)
     if cmd in {"explore-existing", "hypothesis-lab"}:

--- a/vibe_code_apps_20/wattlab/energyplus/dial_loads.py
+++ b/vibe_code_apps_20/wattlab/energyplus/dial_loads.py
@@ -1,0 +1,124 @@
+"""Dial zone lights / electric equipment / infiltration on an existing IDF.
+
+Uses LBNL EnergyPlus-MCP ``EnergyPlusManager`` when available (full MCP tree /
+``energyplus-mcp-dev`` one-shot). Tip GHCR alone is ``simulate_only`` — run this
+inside the MCP docker workspace, then simulate with WattLab DinD.
+
+    wattlab dial-loads --src model.idf --dst dialed.idf --lights 4.5 --equip 4.2 --infil-mult 1.4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def dial_loads_mcp(
+    src_idf: Path,
+    dst_idf: Path,
+    *,
+    lights_w_per_m2: float,
+    equip_w_per_m2: float,
+    infil_mult: float | None = None,
+) -> dict[str, Any]:
+    """Apply Watts/Area lights+equip and optional infiltration multiplier via MCP."""
+    try:
+        from energyplus_mcp_server.energyplus_tools import EnergyPlusManager
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "EnergyPlus MCP not importable. Tip image is simulate_only — run dial-loads "
+            "inside energyplus-mcp-dev with third_party/EnergyPlus-MCP mounted, e.g.\n"
+            "  docker run --rm -v $WORKSPACE:/data -v $REPO/third_party/EnergyPlus-MCP:/workspace "
+            "-w /workspace/energyplus-mcp-server --entrypoint bash energyplus-mcp-dev "
+            "-lc 'uv run wattlab dial-loads …'"
+        ) from exc
+
+    src_idf = Path(src_idf)
+    dst_idf = Path(dst_idf)
+    dst_idf.parent.mkdir(parents=True, exist_ok=True)
+    ep = EnergyPlusManager()
+    tmp = dst_idf.with_name(dst_idf.stem + "_mcp_tmp.idf")
+    if tmp.exists():
+        tmp.unlink()
+    shutil.copy2(src_idf, tmp)
+
+    r1 = ep.modify_lights(
+        str(tmp),
+        [
+            {
+                "target": "all",
+                "field_updates": {
+                    "Design_Level_Calculation_Method": "Watts/Area",
+                    "Watts_per_Floor_Area": float(lights_w_per_m2),
+                },
+            }
+        ],
+        output_path=str(tmp),
+    )
+    r2 = ep.modify_electric_equipment(
+        str(tmp),
+        [
+            {
+                "target": "all",
+                "field_updates": {
+                    "Design_Level_Calculation_Method": "Watts/Area",
+                    "Watts_per_Floor_Area": float(equip_w_per_m2),
+                },
+            }
+        ],
+        output_path=str(tmp),
+    )
+    r3 = None
+    if infil_mult is not None and float(infil_mult) != 1.0:
+        r3 = ep.change_infiltration_by_mult(
+            str(tmp), float(infil_mult), output_path=str(tmp)
+        )
+
+    shutil.copy2(tmp, dst_idf)
+    try:
+        tmp.unlink()
+    except OSError:
+        pass
+    return {
+        "lights": str(r1)[:500],
+        "equip": str(r2)[:500],
+        "infil": None if r3 is None else str(r3)[:500],
+        "lights_w_per_m2": float(lights_w_per_m2),
+        "equip_w_per_m2": float(equip_w_per_m2),
+        "infil_mult": None if infil_mult is None else float(infil_mult),
+        "src": str(src_idf),
+        "dst": str(dst_idf),
+        "hint": "High elec + low gas ⇒ cut internal gains / raise infil — not more 5Zone schedule patches.",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="wattlab dial-loads",
+        description="Dial lights/equip/infiltration via EnergyPlus MCP (any IDF).",
+    )
+    p.add_argument("--src", required=True)
+    p.add_argument("--dst", required=True)
+    p.add_argument("--lights", type=float, required=True, help="Lights W/m²")
+    p.add_argument("--equip", type=float, required=True, help="Electric equipment W/m²")
+    p.add_argument("--infil-mult", type=float, default=None)
+    p.add_argument("--meta-out", default=None)
+    args = p.parse_args(argv)
+    meta = dial_loads_mcp(
+        Path(args.src),
+        Path(args.dst),
+        lights_w_per_m2=args.lights,
+        equip_w_per_m2=args.equip,
+        infil_mult=args.infil_mult,
+    )
+    print(json.dumps(meta, indent=2))
+    if args.meta_out:
+        Path(args.meta_out).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vibe_code_apps_20/wattlab/energyplus/geo_idf.py
+++ b/vibe_code_apps_20/wattlab/energyplus/geo_idf.py
@@ -1,0 +1,384 @@
+"""Adapt a DOE Large Office (or similar) IDF to site-scale massing.
+
+Generalized from the Liberty B100 geometry campaign: mid-floor multipliers,
+XY scale to target conditioned area, fenestration height strip for WWR target,
+optional Site:Location + SHGC patches. No Liberty hardcodes — all via CLI args.
+
+Typical:
+
+    wattlab geo-idf \\
+      --src uploads/prototypes/RefBldgLargeOfficeNew2004_Chicago.idf \\
+      --dst uploads/prototypes/geo_site.idf \\
+      --target-area-ft2 140000 --stories 6 --wwr 0.60 \\
+      --lat 42.33 --lon -83.05 --site-name Detroit_MI
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+# DOE Large Office mid-band zones (bot/mid/top massing). Override with --mid-zones.
+DEFAULT_MID_ZONES = (
+    "Core_mid",
+    "MidFloor_Plenum",
+    "Perimeter_mid_ZN_1",
+    "Perimeter_mid_ZN_2",
+    "Perimeter_mid_ZN_3",
+    "Perimeter_mid_ZN_4",
+)
+
+# Stock DOE Large Office New2004 conditioned floorplate ≈ 38,476 ft² (one story).
+DEFAULT_FLOORPLATE_FT2 = 38476.0
+
+VERT_RE = re.compile(
+    r"^(\s*)(-?[0-9.]+),(-?[0-9.]+),(-?[0-9.]+)[;,]?\s*(!- X,Y,Z ==> Vertex.*)$"
+)
+
+
+def set_zone_multiplier(idf: str, zone_name: str, mult: int) -> str:
+    start = idf.find(f"  Zone,\n    {zone_name},")
+    if start < 0:
+        # tolerate alternate spacing
+        start = idf.find(f"Zone,\n    {zone_name},")
+    if start < 0:
+        raise ValueError(f"missing zone {zone_name}")
+    end = idf.find(";", start)
+    block = idf[start : end + 1]
+    new_block, n = re.subn(
+        r"([0-9.]+)(,\s+!- Multiplier)", rf"{mult}\2", block, count=1
+    )
+    if n != 1:
+        raise ValueError(f"multiplier patch failed for {zone_name}")
+    return idf[:start] + new_block + idf[end + 1 :]
+
+
+def scale_origins(idf: str, scale: float) -> str:
+    out: list[str] = []
+    for line in idf.splitlines(True):
+        if "!- X Origin" in line or "!- Y Origin" in line:
+            m = re.match(
+                r"(\s*)(-?[0-9.eE+]+)(,.*!- [XY] Origin.*)", line.rstrip("\n")
+            )
+            if m:
+                line = f"{m.group(1)}{float(m.group(2)) * scale:.4f}{m.group(3)}\n"
+        out.append(line)
+    return "".join(out)
+
+
+def rewrite_vert_line(line: str, x: float, y: float, z: float) -> str:
+    m = VERT_RE.match(line.rstrip("\n"))
+    if not m:
+        return line
+    comment = m.group(5)
+    nl = "\n" if line.endswith("\n") else ""
+    if ";" in line.split("!")[0]:
+        return f"{m.group(1)}{x:.4f},{y:.4f},{z:.4f};  {comment}{nl}"
+    return f"{m.group(1)}{x:.4f},{y:.4f},{z:.4f},  {comment}{nl}"
+
+
+def scale_block_verts(block: list[str], scale_xy: float, z_xform=None) -> int:
+    n = 0
+    for j, line in enumerate(block):
+        m = VERT_RE.match(line.rstrip("\n"))
+        if not m:
+            continue
+        x = float(m.group(2)) * scale_xy
+        y = float(m.group(3)) * scale_xy
+        z = float(m.group(4))
+        if z_xform is not None:
+            z = z_xform(z)
+        block[j] = rewrite_vert_line(line, x, y, z)
+        n += 1
+    return n
+
+
+def take_object(lines: list[str], i: int) -> tuple[list[str], int]:
+    block = [lines[i]]
+    i += 1
+    while i < len(lines):
+        block.append(lines[i])
+        if ";" in lines[i]:
+            i += 1
+            break
+        i += 1
+    return block, i
+
+
+def wall_z_range(wall_block: list[str]) -> tuple[float, float] | None:
+    zs = []
+    for line in wall_block:
+        m = VERT_RE.match(line.rstrip("\n"))
+        if m:
+            zs.append(float(m.group(4)))
+    if not zs:
+        return None
+    return min(zs), max(zs)
+
+
+def process_geometry(
+    idf: str,
+    *,
+    xy_scale: float,
+    wwr_target: float,
+) -> tuple[str, int, int]:
+    """Scale surfaces, then fenestration height strip toward ``wwr_target``."""
+    lines = idf.splitlines(True)
+    out: list[str] = []
+    i = 0
+    nb = nf = 0
+    walls: dict[str, tuple[float, float]] = {}
+    while i < len(lines):
+        if lines[i].startswith("  BuildingSurface:Detailed,"):
+            block, i = take_object(lines, i)
+            nb += scale_block_verts(block, xy_scale)
+            name = block[1].split(",")[0].strip()
+            surf_type = block[2].split(",")[0].strip()
+            if surf_type == "Wall":
+                zr = wall_z_range(block)
+                if zr:
+                    walls[name] = zr
+            out.extend(block)
+            continue
+        out.append(lines[i])
+        i += 1
+
+    lines = "".join(out).splitlines(True)
+    out = []
+    i = 0
+    while i < len(lines):
+        if lines[i].startswith("  FenestrationSurface:Detailed,"):
+            block, i = take_object(lines, i)
+            parent = block[4].split(",")[0].strip()
+            zr = walls.get(parent)
+            if zr:
+                wz0, wz1 = zr
+                wall_h = wz1 - wz0
+                target_h = min(wwr_target * wall_h, wall_h * 0.92)
+                sill = wz0 + 0.04 * wall_h
+                head = sill + target_h
+                if head > wz1 - 0.02 * wall_h:
+                    head = wz1 - 0.02 * wall_h
+                    sill = head - target_h
+                zs = []
+                for line in block:
+                    m = VERT_RE.match(line.rstrip("\n"))
+                    if m:
+                        zs.append(float(m.group(4)))
+                if zs:
+                    zmin, zmax = min(zs), max(zs)
+
+                    def zx(
+                        z: float,
+                        zmin: float = zmin,
+                        zmax: float = zmax,
+                        sill: float = sill,
+                        head: float = head,
+                    ) -> float:
+                        if abs(zmax - zmin) < 1e-9:
+                            return sill
+                        if abs(z - zmax) < 1e-9:
+                            return head
+                        if abs(z - zmin) < 1e-9:
+                            return sill
+                        frac = (z - zmin) / (zmax - zmin)
+                        return sill + frac * (head - sill)
+
+                    nf += scale_block_verts(block, xy_scale, zx)
+                else:
+                    nf += scale_block_verts(block, xy_scale)
+            else:
+                nf += scale_block_verts(block, xy_scale)
+            out.extend(block)
+            continue
+        out.append(lines[i])
+        i += 1
+    return "".join(out), nb, nf
+
+
+def build_site_scale_idf(
+    src: Path,
+    dst: Path,
+    *,
+    target_area_ft2: float,
+    stories: int = 6,
+    floorplate_ft2: float = DEFAULT_FLOORPLATE_FT2,
+    wwr: float = 0.60,
+    mid_zones: list[str] | None = None,
+    lat: float | None = None,
+    lon: float | None = None,
+    elevation_m: float = 190.0,
+    tz_hr: float = -5.0,
+    site_name: str | None = None,
+    building_name: str | None = None,
+    shgc: float | None = 0.45,
+    enable_weather_run: bool = True,
+    header_note: str | None = None,
+) -> dict[str, Any]:
+    """Build a site-scale IDF; write ``dst``; return provenance meta."""
+    if stories < 2:
+        raise ValueError("stories must be >= 2 for bot/mid/top massing")
+    mid_mult = max(1, int(stories) - 2)
+    xy_scale = math.sqrt(float(target_area_ft2) / (float(floorplate_ft2) * float(stories)))
+    zones = list(mid_zones) if mid_zones else list(DEFAULT_MID_ZONES)
+
+    text = Path(src).read_text(encoding="utf-8", errors="replace")
+    for z in zones:
+        try:
+            text = set_zone_multiplier(text, z, mid_mult)
+        except ValueError:
+            # Skip missing zones (prototype variants)
+            continue
+
+    text = scale_origins(text, xy_scale)
+    text, nb, nf = process_geometry(text, xy_scale=xy_scale, wwr_target=float(wwr))
+
+    n_shgc = 0
+    if shgc is not None:
+        text2, n_shgc = re.subn(
+            r"(WindowMaterial:SimpleGlazingSystem,[^\n]*\n"
+            r"\s+[^\n]*!- Name\n"
+            r"\s+[0-9.]+,\s+!- U-Factor[^\n]*\n"
+            r"\s+)[0-9.]+;",
+            rf"\g<1>{float(shgc)};",
+            text,
+            count=1,
+            flags=re.M,
+        )
+        if n_shgc:
+            text = text2
+        else:
+            # DOE Large Office NonRes Fixed Assembly Window pattern
+            text2, n_shgc = re.subn(
+                r"(NonRes Fixed Assembly Window,  !- Name\n"
+                r"    [0-9.]+,                 !- U-Factor \{W/m2-K\}\n"
+                r"    )[0-9.]+;",
+                rf"\g<1>{float(shgc)};",
+                text,
+                count=1,
+            )
+            if n_shgc:
+                text = text2
+
+    if enable_weather_run:
+        text = text.replace(
+            "NO,                      !- Run Simulation for Weather File Run Periods",
+            "YES,                     !- Run Simulation for Weather File Run Periods",
+            1,
+        )
+
+    if lat is not None and lon is not None:
+        name = site_name or f"Site_{lat}_{lon}"
+        text = re.sub(
+            r"  Site:Location,\n    [^;]+;",
+            f"""  Site:Location,
+    {name},  !- Name
+    {float(lat):.4f},                   !- Latitude {{deg}}
+    {float(lon):.4f},                  !- Longitude {{deg}}
+    {float(tz_hr):.2f},                   !- Time Zone {{hr}}
+    {float(elevation_m):.2f};                  !- Elevation {{m}}""",
+            text,
+            count=1,
+            flags=re.M,
+        )
+
+    if building_name:
+        text = re.sub(
+            r"(  Building,\n    )[^,]+,",
+            rf"\g<1>{building_name},",
+            text,
+            count=1,
+        )
+
+    note = header_note or (
+        f"! Site-scale geo-idf: stories={stories} mid×{mid_mult}, "
+        f"target={target_area_ft2:g} ft², WWR~{wwr}, xy_scale={xy_scale:.4f}\n!\n"
+    )
+    if not text.lstrip().startswith("!"):
+        text = note + text
+    else:
+        text = note + text
+
+    if "Output:Meter,Electricity:Facility,Monthly" not in text:
+        text += (
+            "\n  Output:Meter,Electricity:Facility,Monthly;\n"
+            "  Output:Meter,NaturalGas:Facility,Monthly;\n"
+        )
+
+    dst = Path(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(text, encoding="utf-8")
+
+    return {
+        "source": str(src),
+        "idf": str(dst),
+        "xy_scale": round(xy_scale, 6),
+        "mid_multiplier": mid_mult,
+        "stories_above_grade": int(stories),
+        "target_area_ft2": float(target_area_ft2),
+        "floorplate_ft2": float(floorplate_ft2),
+        "wwr_target": float(wwr),
+        "building_verts_scaled": nb,
+        "fen_verts_scaled": nf,
+        "shgc_patched": int(n_shgc),
+        "chiller_electric_mentions": text.count("Chiller:Electric"),
+        "cooling_tower_mentions": text.count("CoolingTower"),
+        "area_scale_hint": 1.0,
+        "note": "Use custom_idf + prototype_area_scale=1 for Twin/G14; do not 5Zone×scale.",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="wattlab geo-idf",
+        description="Adapt DOE Large Office IDF to site-scale massing (any building).",
+    )
+    p.add_argument("--src", required=True, help="Source prototype IDF (e.g. DOE Large Office)")
+    p.add_argument("--dst", required=True, help="Output site-scale IDF path")
+    p.add_argument("--target-area-ft2", type=float, required=True)
+    p.add_argument("--stories", type=int, default=6)
+    p.add_argument(
+        "--floorplate-ft2",
+        type=float,
+        default=DEFAULT_FLOORPLATE_FT2,
+        help="Source conditioned floorplate ft² (DOE Large Office ≈ 38476)",
+    )
+    p.add_argument("--wwr", type=float, default=0.60)
+    p.add_argument("--lat", type=float, default=None)
+    p.add_argument("--lon", type=float, default=None)
+    p.add_argument("--tz", type=float, default=-5.0)
+    p.add_argument("--elevation-m", type=float, default=190.0)
+    p.add_argument("--site-name", default=None)
+    p.add_argument("--building-name", default=None)
+    p.add_argument("--shgc", type=float, default=0.45)
+    p.add_argument("--no-shgc", action="store_true")
+    p.add_argument("--meta-out", default=None, help="Write provenance JSON")
+    args = p.parse_args(argv)
+
+    meta = build_site_scale_idf(
+        Path(args.src),
+        Path(args.dst),
+        target_area_ft2=args.target_area_ft2,
+        stories=args.stories,
+        floorplate_ft2=args.floorplate_ft2,
+        wwr=args.wwr,
+        lat=args.lat,
+        lon=args.lon,
+        elevation_m=args.elevation_m,
+        tz_hr=args.tz,
+        site_name=args.site_name,
+        building_name=args.building_name,
+        shgc=None if args.no_shgc else args.shgc,
+    )
+    print(json.dumps(meta, indent=2))
+    if args.meta_out:
+        Path(args.meta_out).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vibe_code_apps_20/wattlab/energyplus/score_monthly.py
+++ b/vibe_code_apps_20/wattlab/energyplus/score_monthly.py
@@ -1,0 +1,155 @@
+"""Score an EnergyPlus monthly eplusout.csv vs utility bills (area_scale=1).
+
+Skips sizing-period Monthly rows by keeping the last 12 positive calendar months.
+Use after site-scale geometry (``wattlab geo-idf``) — never apply prototype_area_scale.
+
+    wattlab score-monthly runs/<id>/eplusout.csv \\
+      --bills reports/utility_bills.csv --area-ft2 140000
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+J_TO_KWH = 1 / 3.6e6
+J_TO_THERM = 1 / 1.05506e8
+KWH_TO_KBTU = 3.412
+THERM_TO_KBTU = 100.0
+MCF_TO_THERM = 10.37  # approx HHV; override via --therms-per-mcf
+
+
+def last12_monthly(series: pd.Series) -> pd.Series:
+    s = series.dropna().astype(float)
+    s = s[s > 0]
+    if len(s) > 12:
+        s = s.iloc[-12:]
+    return s
+
+
+def _bill_totals(
+    bills_csv: Path,
+    *,
+    therms_per_mcf: float = MCF_TO_THERM,
+) -> tuple[float, float]:
+    """Return (kWh, therms) from a bills CSV (flexible headers)."""
+    with Path(bills_csv).open(encoding="utf-8", newline="") as f:
+        rows = list(csv.DictReader(f))
+    if not rows:
+        raise ValueError(f"empty bills CSV: {bills_csv}")
+    keys = {k.lower(): k for k in rows[0].keys()}
+
+    def col(*names: str) -> str | None:
+        for n in names:
+            if n in keys:
+                return keys[n]
+        return None
+
+    kwh_c = col("kwh", "electricity_kwh", "elec_kwh", "usage_kwh")
+    therm_c = col("therms", "therm", "gas_therms")
+    mcf_c = col("mcf", "gas_mcf")
+    bk = sum(float(r[kwh_c]) for r in rows) if kwh_c else 0.0
+    if therm_c:
+        bt = sum(float(r[therm_c]) for r in rows)
+    elif mcf_c:
+        bt = sum(float(r[mcf_c]) * therms_per_mcf for r in rows)
+    else:
+        raise ValueError("bills CSV needs therms or mcf column")
+    if not kwh_c:
+        raise ValueError("bills CSV needs kwh column")
+    return bk, bt
+
+
+def score_monthly_run(
+    eplusout_csv: Path,
+    bills_csv: Path,
+    *,
+    area_ft2: float,
+    run_id: str | None = None,
+    property_type: str = "office",
+    therms_per_mcf: float = MCF_TO_THERM,
+) -> dict[str, Any]:
+    """Compare last-12 monthly facility meters to bills; area_scale stamped 1.0."""
+    bk, bt = _bill_totals(bills_csv, therms_per_mcf=therms_per_mcf)
+    bill_eui = (bk * KWH_TO_KBTU + bt * THERM_TO_KBTU) / float(area_ft2)
+
+    df = pd.read_csv(eplusout_csv)
+    elec_c = next(
+        (c for c in df.columns if "Electricity:Facility" in c and "Monthly" in c),
+        None,
+    )
+    gas_c = next(
+        (c for c in df.columns if "NaturalGas:Facility" in c and "Monthly" in c),
+        None,
+    )
+    if elec_c is None or gas_c is None:
+        raise ValueError(
+            "eplusout.csv missing Electricity:Facility / NaturalGas:Facility Monthly columns "
+            "(add Output:Meter,…,Monthly in the IDF)"
+        )
+    e = float(last12_monthly(df[elec_c]).sum()) * J_TO_KWH
+    g = float(last12_monthly(df[gas_c]).sum()) * J_TO_THERM
+    eui = (e * KWH_TO_KBTU + g * THERM_TO_KBTU) / float(area_ft2)
+
+    out: dict[str, Any] = {
+        "run_id": run_id or Path(eplusout_csv).parent.name,
+        "area_scale": 1.0,
+        "area_ft2": float(area_ft2),
+        "model_kwh": round(e, 1),
+        "model_therms": round(g, 1),
+        "model_site_eui": round(eui, 1),
+        "bill_kwh": round(bk, 1),
+        "bill_therms": round(bt, 1),
+        "bill_site_eui": round(bill_eui, 1),
+        "elec_delta_pct": round((e - bk) / bk * 100, 1) if bk else None,
+        "gas_delta_pct": round((g - bt) / bt * 100, 1) if bt else None,
+        "eui_delta_pct": round((eui - bill_eui) / bill_eui * 100, 1) if bill_eui else None,
+        "fuel_mix_score": round(abs((e - bk) / bk) + abs((g - bt) / bt), 3)
+        if bk and bt
+        else None,
+        "note": "Last-12 positive Monthly meters; sizing-period rows skipped. area_scale=1.",
+    }
+    try:
+        from wattlab.benchmarks import compare_eui
+
+        out["model_peer"] = compare_eui(eui, property_type)
+    except Exception as exc:  # pragma: no cover
+        out["model_peer_error"] = str(exc)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="wattlab score-monthly",
+        description="Score eplusout Monthly meters vs bills (last 12 mo, area_scale=1).",
+    )
+    p.add_argument("eplusout_csv")
+    p.add_argument("--bills", required=True)
+    p.add_argument("--area-ft2", type=float, required=True)
+    p.add_argument("--run-id", default=None)
+    p.add_argument("--property-type", default="office")
+    p.add_argument("--therms-per-mcf", type=float, default=MCF_TO_THERM)
+    p.add_argument("--out", default=None, help="Write JSON scorecard")
+    args = p.parse_args(argv)
+    sc = score_monthly_run(
+        Path(args.eplusout_csv),
+        Path(args.bills),
+        area_ft2=args.area_ft2,
+        run_id=args.run_id,
+        property_type=args.property_type,
+        therms_per_mcf=args.therms_per_mcf,
+    )
+    text = json.dumps(sc, indent=2) + "\n"
+    print(text)
+    if args.out:
+        Path(args.out).write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vibe_code_apps_20/wattlab/studio/ep_viz.py
+++ b/vibe_code_apps_20/wattlab/studio/ep_viz.py
@@ -361,6 +361,8 @@ def read_run_progress(run_dir: Path) -> dict[str, Any]:
 
 
 def list_iteration_runs(runs_root: Path, limit: int = 20) -> list[dict[str, Any]]:
+    from wattlab.energyplus.timeseries import find_eplusout_csv
+
     root = Path(runs_root)
     if not root.is_dir():
         return []
@@ -370,31 +372,98 @@ def list_iteration_runs(runs_root: Path, limit: int = 20) -> list[dict[str, Any]
             continue
         info = read_run_progress(d)
         info["dir"] = str(d)
-        # Prefer shallow eplusout detection — avoid expensive **/ globs on fat trees
-        if (d / "eplusout.csv").is_file():
-            info["has_eplusout"] = True
-        else:
-            found = False
-            try:
-                for child in d.iterdir():
-                    if child.is_dir() and (child / "eplusout.csv").is_file():
-                        found = True
-                        break
-            except OSError:
-                found = False
-            info["has_eplusout"] = found
+        info["has_eplusout"] = _run_has_eplusout(d, find_eplusout_csv=find_eplusout_csv)
         rows.append(info)
         if len(rows) >= limit:
             break
     return rows
 
 
-def newest_run_with_eplusout(runs_root: Path, *, limit: int = 30) -> Path | None:
-    """Newest ``runs/<id>/`` that has an eplusout.csv (shallow search)."""
-    for row in list_iteration_runs(runs_root, limit=limit):
+def _run_has_eplusout(run_dir: Path, *, find_eplusout_csv) -> bool:
+    """Deterministic eplusout presence: root, sim_baseline/, one-level child."""
+    d = Path(run_dir)
+    if find_eplusout_csv(d) is not None:
+        return True
+    for prefer in ("sim_baseline",):
+        if find_eplusout_csv(d / prefer) is not None:
+            return True
+    try:
+        for child in sorted(d.iterdir(), key=lambda p: p.name):
+            if child.is_dir() and find_eplusout_csv(child) is not None:
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def newest_run_with_eplusout(runs_root: Path, *, limit: int | None = None) -> Path | None:
+    """Newest ``runs/<id>/`` that has an eplusout.csv (newest-first; default scans widely)."""
+    max_scan = limit if limit is not None else 10_000
+    for row in list_iteration_runs(runs_root, limit=max_scan):
         if row.get("has_eplusout") and row.get("dir"):
             return Path(str(row["dir"]))
     return None
+
+
+_IDF_PREFER_NAMES = (
+    "model.idf",
+    "cal_ready.idf",
+    "baseline_hard_size.idf",
+    "baseline.idf",
+    "cal_hard_size.idf",
+    "cal_base.idf",
+    "prototype_prepped.idf",
+    "Building_Baseline.idf",
+)
+
+
+def find_run_idf(run_dir: Path | str) -> Path | None:
+    """Locate a published EnergyPlus IDF for browser geometry (unique per run)."""
+    d = Path(run_dir)
+    if not d.is_dir():
+        return None
+    for name in _IDF_PREFER_NAMES:
+        p = d / name
+        if p.is_file():
+            return p
+    try:
+        root_idfs = sorted(d.glob("*.idf"), key=lambda p: p.name.lower())
+    except OSError:
+        root_idfs = []
+    if root_idfs:
+        return root_idfs[0]
+    # One-level nested (sim_baseline/, etc.)
+    try:
+        for child in sorted(d.iterdir(), key=lambda p: p.name):
+            if not child.is_dir():
+                continue
+            for name in _IDF_PREFER_NAMES:
+                p = child / name
+                if p.is_file():
+                    return p
+            nested = sorted(child.glob("*.idf"), key=lambda p: p.name.lower())
+            if nested:
+                return nested[0]
+    except OSError:
+        return None
+    return None
+
+
+def _pick_source_idf(src: Path) -> Path | None:
+    """Choose best IDF under a publish source tree or file."""
+    if src.is_file() and src.suffix.lower() == ".idf":
+        return src
+    if not src.is_dir():
+        return None
+    for name in _IDF_PREFER_NAMES:
+        p = src / name
+        if p.is_file():
+            return p
+    try:
+        found = sorted(src.rglob("*.idf"), key=lambda p: (len(p.parts), p.name.lower()))
+    except OSError:
+        found = []
+    return found[0] if found else None
 
 
 def publish_run_for_studio(
@@ -406,9 +475,9 @@ def publish_run_for_studio(
 ) -> Path:
     """Copy an EnergyPlus / easy-button artifact tree into Studio ``runs/<id>/``.
 
-    Agents and CLI write here so the human Twin page can render APIHelper-08
-    panes (progress, OA chart, classic 5Zone floor plan) in the browser.
-    Prefers ``sim_baseline/eplusout.csv`` when present.
+    Agents and CLI write here so the human Twin page can render progress, OA,
+    and **IDF-driven 3D massing** in the browser. Prefers ``sim_baseline/eplusout.csv``
+    when present; copies a primary IDF to ``model.idf`` for geometry.
     """
     from wattlab.studio.workspace import runs_dir
 
@@ -432,6 +501,16 @@ def publish_run_for_studio(
         candidates.extend(sorted(src.rglob("eplusout.csv")))
     if candidates:
         shutil.copy2(candidates[0], dest / "eplusout.csv")
+
+    idf_src = _pick_source_idf(src)
+    if idf_src is not None:
+        shutil.copy2(idf_src, dest / "model.idf")
+        # Keep original basename too when different (agent inspectability)
+        if idf_src.name.lower() != "model.idf":
+            try:
+                shutil.copy2(idf_src, dest / idf_src.name)
+            except OSError:
+                pass
 
     for name in ("eplusout.err", "run_manifest.json", "progress.json", "wattlab_report.json"):
         p = src / name if src.is_dir() else None
@@ -501,6 +580,17 @@ def install_demo_replay(run_dir: Path, fixture_csv: Path) -> Path:
         "Demo replay from fixture eplusout.csv — not a live EnergyPlus run.\n",
         encoding="utf-8",
     )
+    # Best-effort: attach prototype IDF so Twin can show massing in demo mode
+    try:
+        from wattlab.config import DEFAULT_PROTOTYPE_IDF, ROOT
+
+        proto = Path(DEFAULT_PROTOTYPE_IDF)
+        if not proto.is_file():
+            proto = ROOT / "examples" / "prototypes" / "5ZoneAirCooled.idf"
+        if proto.is_file():
+            shutil.copy2(proto, run_dir / "model.idf")
+    except Exception:  # noqa: BLE001
+        pass
     (run_dir / "run_manifest.json").write_text(
         json.dumps(
             {
@@ -518,17 +608,24 @@ def install_demo_replay(run_dir: Path, fixture_csv: Path) -> Path:
         encoding="utf-8",
     )
     pointer = run_dir.parent / "CURRENT_RUN.txt"
-    pointer.write_text(str(run_dir.resolve()), encoding="utf-8")
-    return dest
+    try:
+        pointer.write_text(str(run_dir.resolve()), encoding="utf-8")
+    except OSError:
+        pass
+    return run_dir
 
 
 __all__ = [
     "PROTOTYPE_ZONE_ROLES",
     "ZONE_VERTICES",
+    "MULTIFLOOR_HONESTY",
+    "find_run_idf",
     "floor_plan_figure",
     "install_demo_replay",
     "list_iteration_runs",
     "map_zones_to_roles",
+    "multifloor_office_figure",
+    "newest_run_with_eplusout",
     "outdoor_figure",
     "publish_run_for_studio",
     "read_run_progress",

--- a/vibe_code_apps_20/wattlab/studio/ep_viz.py
+++ b/vibe_code_apps_20/wattlab/studio/ep_viz.py
@@ -94,13 +94,21 @@ def floor_plan_figure(role_temps: dict[str, float]):
     """Plotly floor-plan heatmap matching APIHelper 08 zone layout."""
     import plotly.graph_objects as go
 
+    role_labels = {
+        "north": "N",
+        "south": "S",
+        "east": "E",
+        "west": "W",
+        "center": "Core",
+    }
     fig = go.Figure()
     for role, vertices in ZONE_VERTICES.items():
         temp = role_temps.get(role)
         fill = rgb_from_temperature(temp) if temp is not None else "rgb(200,200,200)"
         xs = [v[0] for v in vertices] + [vertices[0][0]]
         ys = [v[1] for v in vertices] + [vertices[0][1]]
-        label = f"{role}: {temp:.1f} C" if temp is not None else f"{role}: n/a"
+        short = role_labels.get(role, role)
+        label = f"{short}: {temp:.1f}°C" if temp is not None else f"{short}: n/a"
         fig.add_trace(
             go.Scatter(
                 x=xs,
@@ -113,12 +121,21 @@ def floor_plan_figure(role_temps: dict[str, float]):
                 hoverinfo="name",
             )
         )
+        cx = sum(v[0] for v in vertices) / len(vertices)
+        cy = sum(v[1] for v in vertices) / len(vertices)
+        fig.add_annotation(
+            x=cx,
+            y=cy,
+            text=f"{short}<br>{temp:.1f}°C" if temp is not None else short,
+            showarrow=False,
+            font={"size": 12, "color": "#111"},
+        )
     fig.update_layout(
-        title="Zone air temperatures (classic 5Zone floor plan)",
+        title="5Zone prototype schematic (not site geometry)",
         xaxis={"visible": False, "scaleanchor": "y"},
         yaxis={"visible": False},
         showlegend=True,
-        height=360,
+        height=400,
         margin={"l": 20, "r": 20, "t": 40, "b": 20},
     )
     return fig
@@ -353,13 +370,31 @@ def list_iteration_runs(runs_root: Path, limit: int = 20) -> list[dict[str, Any]
             continue
         info = read_run_progress(d)
         info["dir"] = str(d)
-        info["has_eplusout"] = (d / "eplusout.csv").is_file() or bool(
-            list(d.glob("**/eplusout.csv"))
-        )
+        # Prefer shallow eplusout detection — avoid expensive **/ globs on fat trees
+        if (d / "eplusout.csv").is_file():
+            info["has_eplusout"] = True
+        else:
+            found = False
+            try:
+                for child in d.iterdir():
+                    if child.is_dir() and (child / "eplusout.csv").is_file():
+                        found = True
+                        break
+            except OSError:
+                found = False
+            info["has_eplusout"] = found
         rows.append(info)
         if len(rows) >= limit:
             break
     return rows
+
+
+def newest_run_with_eplusout(runs_root: Path, *, limit: int = 30) -> Path | None:
+    """Newest ``runs/<id>/`` that has an eplusout.csv (shallow search)."""
+    for row in list_iteration_runs(runs_root, limit=limit):
+        if row.get("has_eplusout") and row.get("dir"):
+            return Path(str(row["dir"]))
+    return None
 
 
 def publish_run_for_studio(

--- a/vibe_code_apps_20/wattlab/studio/eui_charts.py
+++ b/vibe_code_apps_20/wattlab/studio/eui_charts.py
@@ -1,0 +1,156 @@
+"""Shared Plotly charts for Site EUI vs peer bands (Fuel + Twin)."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+
+MONTH_ABBREV = (
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+)
+
+
+def month_abbrev(mm: int | str) -> str:
+    """Map month number (1–12 or '01'–'12') to Jan…Dec."""
+    try:
+        n = int(str(mm).strip())
+    except (TypeError, ValueError):
+        return str(mm)
+    if 1 <= n <= 12:
+        return MONTH_ABBREV[n - 1]
+    return str(mm)
+
+
+def month_abbrev_columns(frame_or_cols: Any) -> Any:
+    """Rename DataFrame columns 1..12 (or '01'..'12') to Jan…Dec; else return as-is."""
+    import pandas as pd
+
+    if isinstance(frame_or_cols, pd.DataFrame):
+        mapping = {}
+        for c in frame_or_cols.columns:
+            n: int | None
+            if isinstance(c, (int, float)) and not isinstance(c, bool):
+                n = int(c)
+            else:
+                s = str(c).strip()
+                if s.isdigit():
+                    n = int(s)
+                else:
+                    continue
+            if 1 <= n <= 12:
+                mapping[c] = month_abbrev(n)
+        return frame_or_cols.rename(columns=mapping) if mapping else frame_or_cols
+    return [month_abbrev(c) for c in frame_or_cols]
+
+
+def eui_peer_bullet_figure(
+    *,
+    peer_p20: float,
+    peer_p50: float,
+    peer_p80: float,
+    series: Sequence[dict[str, Any]],
+    title: str | None = None,
+    height: int | None = None,
+):
+    """Horizontal bullet/box: peer p20–p80 band + p50 tick; one Y row per series.
+
+    Each item in ``series`` needs ``label`` and ``eui`` (kBtu/ft²·yr). Optional
+    ``color`` (hex) and ``symbol`` (plotly marker symbol).
+    """
+    import plotly.graph_objects as go
+
+    rows = [s for s in series if s.get("eui") is not None and s.get("label")]
+    if not rows:
+        rows = [{"label": "Peers only", "eui": peer_p50, "color": "#888", "symbol": "circle"}]
+
+    labels = [str(r["label"]) for r in rows]
+    n = len(labels)
+    fig = go.Figure()
+
+    # One peer band + p50 per category row (boxplot-like horizontal band)
+    for i, label in enumerate(labels):
+        fig.add_shape(
+            type="rect",
+            xref="x",
+            yref="y",
+            x0=float(peer_p20),
+            x1=float(peer_p80),
+            y0=i - 0.35,
+            y1=i + 0.35,
+            fillcolor="rgba(44,160,44,0.22)",
+            line_width=0,
+            layer="below",
+        )
+        fig.add_shape(
+            type="line",
+            xref="x",
+            yref="y",
+            x0=float(peer_p50),
+            x1=float(peer_p50),
+            y0=i - 0.35,
+            y1=i + 0.35,
+            line=dict(color="#2ca02c", width=2, dash="dash"),
+            layer="below",
+        )
+
+    xs = [float(r["eui"]) for r in rows]
+    colors = [str(r.get("color") or "#1f77b4") for r in rows]
+    symbols = [str(r.get("symbol") or "diamond") for r in rows]
+    fig.add_scatter(
+        x=xs,
+        y=labels,
+        mode="markers+text",
+        marker=dict(size=14, color=colors, symbol=symbols, line=dict(width=1, color="#333")),
+        text=[f"{x:.1f}" for x in xs],
+        textposition="middle right",
+        name="Site EUI",
+        hovertemplate="%{y}: %{x:.1f} kBtu/ft²<extra></extra>",
+    )
+
+    # Invisible peer reference for legend clarity
+    fig.add_scatter(
+        x=[None],
+        y=[None],
+        mode="markers",
+        marker=dict(size=12, color="rgba(44,160,44,0.5)", symbol="square"),
+        name=f"Peer p20–p80 ({peer_p20:.0f}–{peer_p80:.0f})",
+    )
+    fig.add_scatter(
+        x=[None],
+        y=[None],
+        mode="lines",
+        line=dict(color="#2ca02c", width=2, dash="dash"),
+        name=f"Peer p50 ({peer_p50:.1f})",
+    )
+
+    h = height or max(160, 56 + 44 * n)
+    fig.update_layout(
+        height=h,
+        margin=dict(l=10, r=80, t=40 if title else 16, b=40),
+        title=title,
+        xaxis_title="Site EUI (kBtu/ft²·yr)",
+        yaxis=dict(
+            categoryorder="array",
+            categoryarray=list(reversed(labels)),
+            automargin=True,
+        ),
+        showlegend=True,
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, x=0),
+        plot_bgcolor="rgba(0,0,0,0)",
+    )
+    xmax = max(float(peer_p80), max(xs) if xs else float(peer_p80)) * 1.15
+    xmin = min(0.0, float(peer_p20) * 0.85, min(xs) if xs else 0.0)
+    fig.update_xaxes(range=[xmin, xmax], showgrid=True, gridcolor="rgba(0,0,0,0.08)")
+    fig.update_yaxes(showgrid=False)
+    return fig

--- a/vibe_code_apps_20/wattlab/studio/idf_geometry.py
+++ b/vibe_code_apps_20/wattlab/studio/idf_geometry.py
@@ -1,0 +1,307 @@
+"""Parse EnergyPlus IDF surfaces into Plotly 3D massing (unique per published run).
+
+No hard-coded building footprints — geometry always comes from
+``BuildingSurface:Detailed`` / ``FenestrationSurface:Detailed`` in the IDF
+agents publish to ``runs/<id>/model.idf``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_M_TO_FT = 3.280839895
+
+_OBJECT_RE = re.compile(
+    r"(?ms)^[ \t]*(BuildingSurface:Detailed|FenestrationSurface:Detailed)[ \t]*,[ \t]*\r?\n"
+    r"(.*?);[^\r\n]*(?:\r?\n|$)"
+)
+
+
+@dataclass
+class IdfSurface:
+    name: str
+    surface_type: str  # WALL, ROOF, FLOOR, CEILING, Window, …
+    zone_name: str
+    object_type: str  # BuildingSurface:Detailed | FenestrationSurface:Detailed
+    vertices: list[tuple[float, float, float]] = field(default_factory=list)
+
+    @property
+    def is_fenestration(self) -> bool:
+        return "Fenestration" in self.object_type or self.surface_type.lower() in {
+            "window",
+            "glassdoor",
+            "door",
+        }
+
+
+@dataclass
+class IdfGeometry:
+    surfaces: list[IdfSurface]
+    source: str | None = None
+
+    @property
+    def zone_names(self) -> list[str]:
+        return sorted({s.zone_name for s in self.surfaces if s.zone_name})
+
+    def bbox_m(self) -> tuple[float, float, float, float, float, float] | None:
+        pts = [v for s in self.surfaces for v in s.vertices]
+        if not pts:
+            return None
+        xs = [p[0] for p in pts]
+        ys = [p[1] for p in pts]
+        zs = [p[2] for p in pts]
+        return min(xs), max(xs), min(ys), max(ys), min(zs), max(zs)
+
+    def summary(self) -> dict[str, Any]:
+        bb = self.bbox_m()
+        out: dict[str, Any] = {
+            "n_surfaces": len(self.surfaces),
+            "n_zones": len(self.zone_names),
+            "zones": self.zone_names,
+            "source": self.source,
+            "n_fenestration": sum(1 for s in self.surfaces if s.is_fenestration),
+        }
+        if bb:
+            xmin, xmax, ymin, ymax, zmin, zmax = bb
+            out["bbox_m"] = {
+                "dx": round(xmax - xmin, 3),
+                "dy": round(ymax - ymin, 3),
+                "dz": round(zmax - zmin, 3),
+            }
+            out["bbox_ft"] = {
+                "dx": round((xmax - xmin) * _M_TO_FT, 1),
+                "dy": round((ymax - ymin) * _M_TO_FT, 1),
+                "dz": round((zmax - zmin) * _M_TO_FT, 1),
+            }
+        return out
+
+
+def _parse_block(object_type: str, body: str) -> IdfSurface | None:
+    """Parse one surface object body (fields after the type line)."""
+    # Split on commas that separate fields; vertices often pack X,Y,Z on one line
+    lines = []
+    for line in body.splitlines():
+        cleaned = line.split("!-")[0].split("!")[0].strip()
+        if cleaned:
+            lines.append(cleaned)
+    text = " ".join(lines)
+    # Field tokens: split by comma, strip
+    tokens: list[str] = []
+    for chunk in text.split(","):
+        t = chunk.strip().rstrip(";").strip()
+        if t:
+            tokens.append(t)
+    if len(tokens) < 5:
+        return None
+    name = tokens[0]
+    surface_type = tokens[1]
+    # Construction = tokens[2]; Zone Name = tokens[3] for both object types
+    # (Fenestration: Building Surface Name is field 4; still zone is on BuildingSurface)
+    zone_name = tokens[3] if object_type.startswith("BuildingSurface") else ""
+    if object_type.startswith("Fenestration"):
+        # FenestrationSurface:Detailed: Name, Type, Construction, Building Surface Name, …
+        # Zone comes from parent — leave empty; filled later or use surface name heuristics
+        zone_name = ""
+        building_surface = tokens[3] if len(tokens) > 3 else ""
+    else:
+        building_surface = ""
+
+    # Find "Number of Vertices" — scan for first integer >= 3 followed by 3*N floats
+    n_vert = None
+    vert_start = None
+    for i, tok in enumerate(tokens):
+        try:
+            n = int(float(tok))
+        except ValueError:
+            continue
+        if 3 <= n <= 120:
+            # Peek: next 3 values look numeric?
+            if i + 3 < len(tokens):
+                try:
+                    float(tokens[i + 1])
+                    float(tokens[i + 2])
+                    float(tokens[i + 3])
+                    n_vert = n
+                    vert_start = i + 1
+                    break
+                except ValueError:
+                    continue
+    vertices: list[tuple[float, float, float]] = []
+    if n_vert is not None and vert_start is not None:
+        nums: list[float] = []
+        for tok in tokens[vert_start:]:
+            try:
+                nums.append(float(tok))
+            except ValueError:
+                break
+        for i in range(0, min(len(nums) // 3, n_vert) * 3, 3):
+            vertices.append((nums[i], nums[i + 1], nums[i + 2]))
+
+    if len(vertices) < 3:
+        return None
+
+    surf = IdfSurface(
+        name=name,
+        surface_type=surface_type,
+        zone_name=zone_name or building_surface,
+        object_type=object_type,
+        vertices=vertices,
+    )
+    return surf
+
+
+def parse_idf_geometry(text_or_path: str | Path) -> IdfGeometry:
+    """Parse IDF text or path into surfaces."""
+    source: str | None = None
+    if isinstance(text_or_path, Path) or (
+        isinstance(text_or_path, str)
+        and len(text_or_path) < 400
+        and Path(text_or_path).is_file()
+    ):
+        path = Path(text_or_path)
+        text = path.read_text(encoding="utf-8", errors="replace")
+        source = str(path)
+    else:
+        text = str(text_or_path)
+
+    surfaces: list[IdfSurface] = []
+    # Map fenestration → zone via building surface name
+    by_name: dict[str, IdfSurface] = {}
+    for m in _OBJECT_RE.finditer(text):
+        obj_type = m.group(1)
+        body = m.group(2)
+        surf = _parse_block(obj_type, body + ";")
+        if surf is None:
+            continue
+        surfaces.append(surf)
+        by_name[surf.name] = surf
+
+    # Resolve fenestration zones: field stored as building surface name
+    for s in surfaces:
+        if s.object_type.startswith("Fenestration") and s.zone_name:
+            parent = by_name.get(s.zone_name)
+            if parent is not None:
+                s.zone_name = parent.zone_name
+
+    return IdfGeometry(surfaces=surfaces, source=source)
+
+
+def zone_mean_temps_by_name(ts: Any) -> dict[str, float]:
+    """Map EnergyPlus zone name → mean °C from an EplusTimeseries."""
+    if ts is None:
+        return {}
+    means = ts.zone_mean_temps() if hasattr(ts, "zone_mean_temps") else None
+    if means is None or getattr(means, "empty", True):
+        return {}
+    out: dict[str, float] = {}
+    for _, row in means.iterrows():
+        out[str(row["zone"])] = float(row["mean_c"])
+    return out
+
+
+def idf_massing_figure(
+    geom: IdfGeometry,
+    *,
+    zone_temps: dict[str, float] | None = None,
+    title: str | None = None,
+):
+    """Plotly 3D massing from parsed IDF surfaces."""
+    import plotly.graph_objects as go
+
+    from wattlab.studio.ep_viz import rgb_from_temperature
+
+    zone_temps = zone_temps or {}
+    fig = go.Figure()
+    if not geom.surfaces:
+        fig.update_layout(title="No BuildingSurface:Detailed found in IDF")
+        return fig
+
+    for surf in geom.surfaces:
+        temp = zone_temps.get(surf.zone_name)
+        if surf.is_fenestration:
+            color = "rgba(120,180,255,0.45)"
+            opacity = 0.45
+        elif temp is not None:
+            color = rgb_from_temperature(temp)
+            opacity = 0.85
+        else:
+            stype = surf.surface_type.upper()
+            if stype in {"ROOF", "CEILING"}:
+                color = "rgba(160,160,160,0.9)"
+            elif stype == "FLOOR":
+                color = "rgba(100,100,100,0.7)"
+            else:
+                color = "rgba(200,200,200,0.75)"
+            opacity = 0.8
+
+        label = surf.name
+        if surf.zone_name:
+            label = f"{surf.zone_name}: {surf.name}"
+        if temp is not None:
+            label = f"{label} ({temp:.1f} C)"
+
+        xs = [v[0] for v in surf.vertices] + [surf.vertices[0][0]]
+        ys = [v[1] for v in surf.vertices] + [surf.vertices[0][1]]
+        zs = [v[2] for v in surf.vertices] + [surf.vertices[0][2]]
+        fig.add_trace(
+            go.Scatter3d(
+                x=xs,
+                y=ys,
+                z=zs,
+                mode="lines",
+                line=dict(color="#333", width=2),
+                name=label,
+                hoverinfo="name",
+                showlegend=False,
+            )
+        )
+        if len(surf.vertices) >= 3:
+            i_idx: list[int] = []
+            j_idx: list[int] = []
+            k_idx: list[int] = []
+            for t in range(1, len(surf.vertices) - 1):
+                i_idx.append(0)
+                j_idx.append(t)
+                k_idx.append(t + 1)
+            vx = [v[0] for v in surf.vertices]
+            vy = [v[1] for v in surf.vertices]
+            vz = [v[2] for v in surf.vertices]
+            mesh_kwargs: dict[str, Any] = {
+                "x": vx,
+                "y": vy,
+                "z": vz,
+                "i": i_idx,
+                "j": j_idx,
+                "k": k_idx,
+                "opacity": opacity,
+                "flatshading": True,
+                "name": label,
+                "hoverinfo": "name",
+                "showlegend": False,
+            }
+            if color.startswith("rgb(") and not color.startswith("rgba"):
+                mesh_kwargs["facecolor"] = [color] * len(i_idx)
+            else:
+                mesh_kwargs["color"] = color
+            fig.add_trace(go.Mesh3d(**mesh_kwargs))
+
+    summary = geom.summary()
+    bb = summary.get("bbox_ft") or {}
+    t = title or "IDF massing (published model)"
+    if bb:
+        t = f"{t} — ~{bb.get('dx')}x{bb.get('dy')}x{bb.get('dz')} ft bbox"
+    fig.update_layout(
+        title=t,
+        height=520,
+        margin=dict(l=0, r=0, t=50, b=0),
+        scene=dict(
+            aspectmode="data",
+            xaxis_title="X (m)",
+            yaxis_title="Y (m)",
+            zaxis_title="Z (m)",
+        ),
+    )
+    return fig

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
@@ -323,15 +323,19 @@ def _render_weather(campus: Campus, px, go) -> None:
                 value=True,
                 key="fuel_dash_fit_all",
             )
-        years_fit = st.slider(
-            "Fit window: last N years",
-            min_value=1,
-            max_value=max_y,
-            value=int(choices["default_years"]),
-            key="fuel_dash_fit_years",
-            disabled=use_all and choices["available_n"] > max_y * 12,
-            help="OLS gas×HDD / elec×CDD uses the latest N×12 months (or all overlap).",
-        )
+        if max_y <= 1:
+            years_fit = 1
+            st.caption("Fit window: last 1 year (only one full year of overlapping bills).")
+        else:
+            years_fit = st.slider(
+                "Fit window: last N years",
+                min_value=1,
+                max_value=max_y,
+                value=min(int(choices["default_years"]), max_y),
+                key="fuel_dash_fit_years",
+                disabled=use_all and choices["available_n"] > max_y * 12,
+                help="OLS gas x HDD / elec x CDD uses the latest N x 12 months (or all overlap).",
+            )
         fit_months = months_for_fit_years(available, years_fit, use_all=use_all)
     else:
         fit_months = 12

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
@@ -147,36 +147,27 @@ def _render_portfolio(summary: dict[str, Any], campus: Campus, px, go) -> None:
         help="Percent vs peer p50 and band label (efficient / typical / high).",
     )
 
-    fig_peer = go.Figure()
-    p20 = float(dfb["peer_p20"].iloc[0])
-    p50 = float(dfb["peer_p50"].iloc[0])
-    p80 = float(dfb["peer_p80"].iloc[0])
-    fig_peer.add_shape(
-        type="rect",
-        x0=p20,
-        x1=p80,
-        y0=-0.5,
-        y1=0.5,
-        fillcolor="rgba(44,160,44,0.18)",
-        line_width=0,
-    )
-    fig_peer.add_vline(x=p50, line_dash="dash", line_color="#2ca02c")
+    from wattlab.studio.eui_charts import eui_peer_bullet_figure
+
+    # One band per property type when mixed; else shared band + one row per building
+    series = []
     for _, r in dfb.iterrows():
-        fig_peer.add_scatter(
-            x=[r["site_eui_kbtu_ft2"]],
-            y=[0],
-            mode="markers+text",
-            marker=dict(symbol="diamond", size=16),
-            text=[r["label"]],
-            textposition="top center",
-            name=r["label"],
+        series.append(
+            {
+                "label": str(r["label"]),
+                "eui": float(r["site_eui_kbtu_ft2"]),
+                "color": "#1f77b4",
+                "symbol": "diamond",
+            }
         )
-    fig_peer.update_layout(
-        height=180,
-        margin=dict(l=10, r=10, t=10, b=10),
-        yaxis=dict(visible=False),
-        xaxis_title="Site EUI (kBtu/ft²-yr)",
-        showlegend=False,
+    # Use first building's peers as the screening band (same-type campuses);
+    # per-building bands still show in the metrics / attention table.
+    fig_peer = eui_peer_bullet_figure(
+        peer_p20=float(dfb["peer_p20"].iloc[0]),
+        peer_p50=float(dfb["peer_p50"].iloc[0]),
+        peer_p80=float(dfb["peer_p80"].iloc[0]),
+        series=series,
+        title="Site EUI vs peer p20–p80 band",
     )
     st.plotly_chart(fig_peer, width="stretch", key="fuel_peer_eui_chart")
 
@@ -277,26 +268,75 @@ def _render_monthly(campus: Campus, summary: dict[str, Any], go) -> None:
 
     years = sorted({m[:4] for m in months})
     if len(years) >= 2:
+        from wattlab.studio.eui_charts import month_abbrev
+
         st.caption(f"YoY available across bill years {years[0]}…{years[-1]}.")
         yoy = totals.copy()
         yoy["year"] = yoy["month"].astype(str).str[:4]
-        yoy["mm"] = yoy["month"].astype(str).str[5:7]
+        yoy["mm"] = yoy["month"].astype(str).str[5:7].map(month_abbrev)
         pivot = yoy.pivot_table(
             index="mm", columns="year", values="kbtu", aggfunc="sum"
         )
+        # Keep calendar order Jan…Dec
+        from wattlab.studio.eui_charts import MONTH_ABBREV
+
+        pivot = pivot.reindex([m for m in MONTH_ABBREV if m in pivot.index])
         st.dataframe(pivot, width="stretch")
     else:
         st.caption("YoY compare: **NEEDS_INPUT** — need ≥2 calendar years of bills.")
 
     with st.expander("Year × month usage matrices", expanded=False):
+        from wattlab.studio.eui_charts import month_abbrev_columns
+
         for m in campus.meters:
             st.markdown(f"**{m.meter_id}** ({m.fuel})")
-            st.dataframe(year_month_matrix(m.bills), width="stretch")
+            mat = year_month_matrix(m.bills)
+            st.dataframe(month_abbrev_columns(mat), width="stretch")
 
 
 def _render_weather(campus: Campus, px, go) -> None:
+    from wattlab.benchmarks.fuel_weather import (
+        bill_overlap_months,
+        fit_window_choices,
+        months_for_fit_years,
+    )
+    from wattlab.studio.eui_charts import month_abbrev_columns
+
     st.subheader("Weather & baseline analytics")
-    st.caption(f"HDD/CDD base {DD_BASE_F:g}°F. Prefer Open-Meteo over synthetic OAT.")
+    st.caption(
+        f"HDD/CDD base {DD_BASE_F:g}°F. Prefer Open-Meteo over synthetic OAT. "
+        "Open-Meteo fetches **all** overlapping bill years; the fit window below "
+        "only changes how many trailing months feed the OLS model."
+    )
+    available = bill_overlap_months(campus)
+    choices = fit_window_choices(available)
+    if available:
+        st.caption(
+            f"Bills overlap {choices['first']} → {choices['last']} "
+            f"({choices['available_n']} months, up to {choices['max_years']} full year(s))."
+        )
+        max_y = max(1, int(choices["max_years"]))
+        use_all = False
+        if choices["available_n"] > max_y * 12:
+            use_all = st.checkbox(
+                f"Use all {choices['available_n']} overlapping months (not just full years)",
+                value=True,
+                key="fuel_dash_fit_all",
+            )
+        years_fit = st.slider(
+            "Fit window: last N years",
+            min_value=1,
+            max_value=max_y,
+            value=int(choices["default_years"]),
+            key="fuel_dash_fit_years",
+            disabled=use_all and choices["available_n"] > max_y * 12,
+            help="OLS gas×HDD / elec×CDD uses the latest N×12 months (or all overlap).",
+        )
+        fit_months = months_for_fit_years(available, years_fit, use_all=use_all)
+    else:
+        fit_months = 12
+        st.warning("No overlapping bill months across meters — cannot fit weather responses.")
+
     lat = campus.lat
     lon = campus.lon
     lat_s = st.text_input("Latitude", value="" if lat is None else str(lat), key="fuel_dash_lat")
@@ -309,11 +349,11 @@ def _render_weather(campus: Campus, px, go) -> None:
             if lat_u is None or lon_u is None:
                 st.error("lat/lon required on campus.json or form.")
             else:
-                with st.spinner("Open-Meteo…"):
+                with st.spinner("Open-Meteo (full bill span)…"):
                     df, meta = _fetch_open_meteo(campus, lat_u, lon_u)
                 st.session_state["fuel_dash_hourly"] = df
                 st.session_state["fuel_dash_meta"] = meta
-                st.success(f"Open-Meteo OK — {meta.get('rows')} rows")
+                st.success(f"Open-Meteo OK — {meta.get('rows')} rows (all bill years)")
         except Exception as exc:
             st.error(f"Open-Meteo failed: {exc}")
     if w2.button("Synthetic seasonal OAT (offline)", key="fuel_dash_synth"):
@@ -328,11 +368,14 @@ def _render_weather(campus: Campus, px, go) -> None:
         st.info("Fetch Open-Meteo or use synthetic OAT for degree-day fits.")
         return
 
-    aligned, window = align_fuel_and_degree_days(campus, hourly)
+    aligned, window = align_fuel_and_degree_days(campus, hourly, months=fit_months)
     if not window:
         st.warning("No overlapping months between bills and weather.")
         return
-    st.caption(f"Analysis window {window[0]} → {window[-1]} · weather={meta.get('source', '?')}")
+    st.caption(
+        f"Fit window {window[0]} → {window[-1]} ({len(window)} mo) · "
+        f"weather={meta.get('source', '?')}"
+    )
     fits = fit_weather_responses(aligned)
     if not fits:
         st.warning("Need ≥6 overlapping months for R².")
@@ -356,7 +399,7 @@ def _render_weather(campus: Campus, px, go) -> None:
             x=xs, y=fit.slope * xs + fit.intercept, mode="lines", name=f"R²={fit.r2:.3f}"
         )
         fig.update_layout(
-            title=f"{fit.fuel} vs {fit.x_name.upper()}",
+            title=f"{fit.fuel} vs {fit.x_name.upper()} ({len(sub)} mo)",
             height=340,
             margin=dict(l=10, r=10, t=40, b=10),
             xaxis_title=fit.x_name.upper(),
@@ -371,15 +414,17 @@ def _render_weather(campus: Campus, px, go) -> None:
         )
 
     report = build_fuel_weather_report(
-        campus, hourly, weather_source=str(meta.get("source") or "unknown")
+        campus, hourly, weather_source=str(meta.get("source") or "unknown"), months=fit_months
     )
     with st.expander("Fuel weather report JSON"):
         st.json(report)
 
 
 def _render_demand(campus: Campus, px) -> None:
+    from wattlab.studio.eui_charts import month_abbrev_columns
+
     st.subheader("Demand & peak analysis")
-    mat = demand_heatmap_frame(campus)
+    mat = month_abbrev_columns(demand_heatmap_frame(campus))
     if mat.empty:
         st.info(
             "NEEDS_INPUT: no `demand_kw` column in electric bills — peak/demand charts unavailable."
@@ -396,8 +441,8 @@ def _render_demand(campus: Campus, px) -> None:
         fig = px.bar(
             x=peaks.index.astype(str),
             y=peaks.values,
-            labels={"x": "month", "y": "peak_kw"},
-            title="Monthly peak demand (from bill demand_kw)",
+            labels={"x": "year", "y": "peak_kw"},
+            title="Peak demand by year (from bill demand_kw)",
         )
         st.plotly_chart(fig, width="stretch", key="fuel_monthly_peak")
 
@@ -424,9 +469,15 @@ def _render_data_quality(campus: Campus, summary: dict[str, Any]) -> None:
         mat = intensity_heatmap_frame(campus, fuel="electricity")
         if not mat.empty:
             import plotly.express as px
+            from wattlab.studio.eui_charts import month_abbrev_columns
 
             st.plotly_chart(
-                px.imshow(mat, aspect="auto", color_continuous_scale="YlOrRd", title="Elec kBtu/ft²"),
+                px.imshow(
+                    month_abbrev_columns(mat),
+                    aspect="auto",
+                    color_continuous_scale="YlOrRd",
+                    title="Elec kBtu/ft²",
+                ),
                 width="stretch",
                 key="fuel_heat_elec",
             )
@@ -434,9 +485,15 @@ def _render_data_quality(campus: Campus, summary: dict[str, Any]) -> None:
         mat = intensity_heatmap_frame(campus, fuel="gas")
         if not mat.empty:
             import plotly.express as px
+            from wattlab.studio.eui_charts import month_abbrev_columns
 
             st.plotly_chart(
-                px.imshow(mat, aspect="auto", color_continuous_scale="Blues", title="Gas kBtu/ft²"),
+                px.imshow(
+                    month_abbrev_columns(mat),
+                    aspect="auto",
+                    color_continuous_scale="Blues",
+                    title="Gas kBtu/ft²",
+                ),
                 width="stretch",
                 key="fuel_heat_gas",
             )

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_weather.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_weather.py
@@ -325,14 +325,18 @@ def render(*, campus: Campus | None = None) -> None:
                 value=True,
                 key="fuel_weather_fit_all",
             )
-        years_fit = st.slider(
-            "Fit window: last N years",
-            min_value=1,
-            max_value=max_y,
-            value=int(choices["default_years"]),
-            key="fuel_weather_fit_years",
-            disabled=bool(use_all and choices["available_n"] > max_y * 12),
-        )
+        if max_y <= 1:
+            years_fit = 1
+            st.caption("Fit window: last 1 year (only one full year of overlapping bills).")
+        else:
+            years_fit = st.slider(
+                "Fit window: last N years",
+                min_value=1,
+                max_value=max_y,
+                value=min(int(choices["default_years"]), max_y),
+                key="fuel_weather_fit_years",
+                disabled=bool(use_all and choices["available_n"] > max_y * 12),
+            )
     fit_months = months_for_fit_years(available, years_fit, use_all=use_all)
 
     if hourly is None:

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_weather.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_weather.py
@@ -17,12 +17,15 @@ import streamlit as st
 
 from wattlab.benchmarks.fuel_weather import (
     align_fuel_and_degree_days,
+    bill_overlap_months,
     build_fuel_weather_report,
     campus_fuel_totals,
     demand_heatmap_frame,
     fit_weather_responses,
+    fit_window_choices,
     intensity_heatmap_frame,
     meter_monthly_long,
+    months_for_fit_years,
     residual_frame,
 )
 from wattlab.benchmarks.meters import Campus
@@ -268,9 +271,11 @@ def render(*, campus: Campus | None = None) -> None:
             st.plotly_chart(fig_d, width="stretch")
 
     st.subheader("Intensity & demand heatmaps")
+    from wattlab.studio.eui_charts import month_abbrev_columns
+
     h1, h2, h3 = st.columns(3)
     with h1:
-        mat_e = intensity_heatmap_frame(campus, fuel="electricity")
+        mat_e = month_abbrev_columns(intensity_heatmap_frame(campus, fuel="electricity"))
         if not mat_e.empty:
             fig = px.imshow(
                 mat_e, aspect="auto", color_continuous_scale="YlOrRd",
@@ -281,7 +286,7 @@ def render(*, campus: Campus | None = None) -> None:
         else:
             st.caption("No electric intensity matrix.")
     with h2:
-        mat_g = intensity_heatmap_frame(campus, fuel="gas")
+        mat_g = month_abbrev_columns(intensity_heatmap_frame(campus, fuel="gas"))
         if not mat_g.empty:
             fig = px.imshow(
                 mat_g, aspect="auto", color_continuous_scale="Blues",
@@ -292,7 +297,7 @@ def render(*, campus: Campus | None = None) -> None:
         else:
             st.caption("No gas intensity matrix.")
     with h3:
-        mat_d = demand_heatmap_frame(campus)
+        mat_d = month_abbrev_columns(demand_heatmap_frame(campus))
         if not mat_d.empty:
             fig = px.imshow(
                 mat_d, aspect="auto", color_continuous_scale="Viridis",
@@ -304,6 +309,32 @@ def render(*, campus: Campus | None = None) -> None:
             st.caption("No demand_kw in bill CSVs.")
 
     st.subheader("Weather response (HDD / CDD)")
+    available = bill_overlap_months(campus)
+    choices = fit_window_choices(available)
+    use_all = False
+    years_fit = int(choices["default_years"]) or 1
+    if available:
+        st.caption(
+            f"Open-Meteo pulls all bill years ({choices['first']}→{choices['last']}). "
+            "Fit window only changes the OLS months."
+        )
+        max_y = max(1, int(choices["max_years"]))
+        if choices["available_n"] > max_y * 12:
+            use_all = st.checkbox(
+                f"Use all {choices['available_n']} overlapping months",
+                value=True,
+                key="fuel_weather_fit_all",
+            )
+        years_fit = st.slider(
+            "Fit window: last N years",
+            min_value=1,
+            max_value=max_y,
+            value=int(choices["default_years"]),
+            key="fuel_weather_fit_years",
+            disabled=bool(use_all and choices["available_n"] > max_y * 12),
+        )
+    fit_months = months_for_fit_years(available, years_fit, use_all=use_all)
+
     if hourly is None:
         st.info("Fetch Open-Meteo or use synthetic OAT to compute HDD/CDD regressions.")
         return
@@ -314,11 +345,11 @@ def render(*, campus: Campus | None = None) -> None:
             f"base {DD_BASE_F:g}°F"
         )
 
-    aligned, window = align_fuel_and_degree_days(campus, hourly)
+    aligned, window = align_fuel_and_degree_days(campus, hourly, months=fit_months)
     if not window:
         st.warning("No overlapping months between bills and weather.")
         return
-    st.caption(f"Analysis window: {window[0]} → {window[-1]} ({len(window)} months)")
+    st.caption(f"Fit window: {window[0]} → {window[-1]} ({len(window)} months)")
 
     fits = fit_weather_responses(aligned)
     if not fits:
@@ -362,6 +393,7 @@ def render(*, campus: Campus | None = None) -> None:
     report = build_fuel_weather_report(
         campus, hourly,
         weather_source=str(meta.get("source") or "unknown"),
+        months=fit_months,
     )
     with st.expander("Fuel weather report JSON"):
         st.json(report)

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -19,11 +19,13 @@ from wattlab.studio.ep_viz import (
     install_demo_replay,
     list_iteration_runs,
     multifloor_office_figure,
+    newest_run_with_eplusout,
     outdoor_figure,
     publish_run_for_studio,
     read_run_progress,
     zone_mean_by_role,
 )
+from wattlab.studio.eui_charts import eui_peer_bullet_figure, month_abbrev
 from wattlab.studio.eui_compare import build_eui_index, load_model_eui_from_run
 from wattlab.studio.workspace import reports_dir, runs_dir
 
@@ -43,8 +45,6 @@ def _render_eui_index(
     chart_key: str = "twin_eui_index",
 ) -> None:
     """Bills vs peer typical EUI vs EnergyPlus model — always visible when data exists."""
-    import plotly.graph_objects as go
-
     st.subheader("EUI index — bills vs peers vs model")
     st.caption(
         "**Bills** = your campus annualized site EUI. "
@@ -128,38 +128,31 @@ def _render_eui_index(
     df = pd.DataFrame(idx["rows"])
     st.dataframe(df, width="stretch", hide_index=True)
 
-    fig = go.Figure()
-    fig.add_shape(
-        type="rect",
-        x0=idx["peer_p20"],
-        x1=idx["peer_p80"],
-        y0=-0.5,
-        y1=0.5,
-        fillcolor="rgba(44,160,44,0.18)",
-        line_width=0,
-    )
-    fig.add_vline(x=idx["peer_p50"], line_dash="dash", line_color="#2ca02c")
-    colors = {"Bills (site)": "#1f77b4", "Model (prototype EUI)": "#d62728"}
-    for _, r in df.iterrows():
-        series = str(r["series"])
-        if series.startswith("Peer"):
-            continue
-        fig.add_scatter(
-            x=[r["site_eui_kbtu_ft2"]],
-            y=[0],
-            mode="markers+text",
-            marker=dict(symbol="diamond", size=16, color=colors.get(series, "#333")),
-            text=[series],
-            textposition="top center",
-            name=series,
+    series = []
+    if idx.get("bill_eui_kbtu_ft2") is not None:
+        series.append(
+            {
+                "label": "Bills (site)",
+                "eui": float(idx["bill_eui_kbtu_ft2"]),
+                "color": "#1f77b4",
+                "symbol": "diamond",
+            }
         )
-    fig.update_layout(
-        height=200,
-        margin=dict(l=10, r=10, t=20, b=10),
-        yaxis=dict(visible=False),
-        xaxis_title="Site EUI (kBtu/ft²-yr)",
-        showlegend=False,
-        title=f"{idx.get('benchmark_name') or idx['property_type']} peers",
+    if idx.get("model_eui_kbtu_ft2") is not None:
+        series.append(
+            {
+                "label": "Model (prototype)",
+                "eui": float(idx["model_eui_kbtu_ft2"]),
+                "color": "#d62728",
+                "symbol": "circle",
+            }
+        )
+    fig = eui_peer_bullet_figure(
+        peer_p20=float(idx["peer_p20"]),
+        peer_p50=float(idx["peer_p50"]),
+        peer_p80=float(idx["peer_p80"]),
+        series=series,
+        title=f"{idx.get('benchmark_name') or idx['property_type']} — bills vs peers vs model",
     )
     st.plotly_chart(fig, width="stretch", key=chart_key)
     if scale and float(scale) > 1.05:
@@ -196,6 +189,33 @@ def _resolve_active_run() -> Path | None:
     return None
 
 
+def _resolve_viz_run(preferred: Path | None = None) -> tuple[Path | None, str | None]:
+    """Prefer a run that has eplusout.csv for 08 panes; caption when falling back."""
+    candidates: list[Path] = []
+    for p in (preferred, _resolve_active_run()):
+        if p is not None and p.is_dir():
+            candidates.append(p)
+    for h in list_iteration_runs(runs_dir(), limit=20):
+        if h.get("dir"):
+            candidates.append(Path(str(h["dir"])))
+    seen: set[str] = set()
+    for c in candidates:
+        key = str(c.resolve()) if c.exists() else str(c)
+        if key in seen:
+            continue
+        seen.add(key)
+        if (c / "eplusout.csv").is_file() or find_eplusout_csv(c) is not None:
+            note = None
+            if preferred is not None and c.resolve() != preferred.resolve():
+                note = (
+                    f"Active run `{preferred.name}` has no eplusout.csv — "
+                    f"showing floor plan from `{c.name}`."
+                )
+            return c, note
+    fallback = preferred or _resolve_active_run() or newest_run_with_eplusout(runs_dir())
+    return fallback, None
+
+
 def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
     st.subheader("EnergyPlus visualizer (APIHelper 08 — browser)")
     st.caption(
@@ -204,6 +224,14 @@ def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
         "OA / floor charts appear after `eplusout.csv` is published. "
         "Agents: publish to `runs/<id>/`; human: Refresh or watch live while Studio DinD runs."
     )
+
+    viz_dir, viz_note = _resolve_viz_run(run_dir)
+    if viz_dir is None:
+        st.warning("No published Twin runs with `eplusout.csv` yet.")
+        return
+    if viz_note:
+        st.info(viz_note)
+    run_dir = viz_dir
 
     live = False
     try:
@@ -227,7 +255,7 @@ def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
                 "EnergyPlus output",
                 value=log,
                 height=220,
-                key=f"twin_ep_log_{run_dir.name}_{info.get('progress')}",
+                key=f"twin_ep_log_{run_dir.name}",
             )
         with right:
             ts = load_sim_timeseries(run_dir)
@@ -241,15 +269,12 @@ def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
                     key=f"twin_oa_{run_dir.name}",
                 )
             else:
-                st.caption("No outdoor timeseries yet (need eplusout.csv in this run folder).")
+                st.warning(
+                    f"No outdoor timeseries — missing `eplusout.csv` under `runs/{run_dir.name}/`."
+                )
 
-        ts2 = load_sim_timeseries(run_dir)
-        if ts2 is None:
-            nested = find_eplusout_csv(run_dir)
-            if nested:
-                ts2 = load_sim_timeseries(nested.parent)
-        if ts2 is not None:
-            roles = zone_mean_by_role(ts2)
+        if ts is not None:
+            roles = zone_mean_by_role(ts)
             if roles:
                 floors = int(n_floors or 1)
                 profile = _profile() or {}
@@ -261,7 +286,7 @@ def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
                         or 1
                     )
                 btype = str(profile.get("building_type") or profile.get("property_type") or "").lower()
-                use_multi = floors >= 2 or ("office" in btype and floors >= 2)
+                use_multi = floors >= 2 and ("office" in btype or floors >= 2)
                 if use_multi and floors >= 2:
                     highlight = None
                     if floors > 8:
@@ -285,23 +310,30 @@ def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
                         width="stretch",
                         key=f"twin_floor_{run_dir.name}",
                     )
-            means = ts2.zone_mean_temps()
+            else:
+                st.warning(
+                    "eplusout.csv loaded but no zone mean temps mapped — "
+                    "check Output:Variable Zone Mean Air Temperature."
+                )
+            means = ts.zone_mean_temps()
             if not means.empty:
                 st.dataframe(means, width="stretch", hide_index=True)
+        elif (run_dir / "eplusout.csv").is_file() is False and find_eplusout_csv(run_dir) is None:
+            st.error(f"no eplusout.csv under runs/{run_dir.name}/")
 
     if live:
         try:
             from datetime import timedelta
 
             @st.fragment(run_every=timedelta(seconds=2))
-            def _live_fragment() -> None:
+            def _live_draw() -> None:
                 _draw()
 
-            _live_fragment()
-            return
+            _live_draw()
         except Exception:
-            pass
-    _draw()
+            _draw()
+    else:
+        _draw()
 
 
 def render() -> None:
@@ -644,12 +676,6 @@ def render() -> None:
     active = _resolve_active_run()
     if active is not None:
         st.session_state["studio_active_run"] = str(active)
-        _render_08_panes(active)
-    else:
-        st.info(
-            "No published Twin runs yet. An AI agent should write `runs/<id>/eplusout.csv` "
-            "(or click demo replay / Docker run). See AGENT_TESTER_PROMPT.md."
-        )
 
     st.subheader("Modeled vs actual fuel")
     ub_path = st.session_state.get("studio_utility_bills_path")
@@ -718,10 +744,49 @@ def render() -> None:
         st.dataframe(ub.head(24), width="stretch", hide_index=True)
 
     if bills_rows:
+        import plotly.graph_objects as go
+
         bdf = pd.DataFrame(bills_rows)
         st.dataframe(bdf, width="stretch", hide_index=True)
         if "observed_kwh" in bdf.columns and "modeled_kwh" in bdf.columns:
-            st.line_chart(bdf.set_index("month")[["observed_kwh", "modeled_kwh"]])
+            plot_df = bdf.copy()
+            if "month" in plot_df.columns:
+                # Prefer Jan…Dec labels when values look like month numbers / MM
+                mo = plot_df["month"].astype(str)
+                if mo.str.fullmatch(r"\d{1,2}").all() or mo.str.fullmatch(r"\d{4}-\d{2}").all():
+                    if mo.str.fullmatch(r"\d{1,2}").all():
+                        x_labels = [month_abbrev(m) for m in mo]
+                    else:
+                        x_labels = [
+                            f"{m[:4]}-{month_abbrev(m[5:7])}" if len(m) >= 7 else m for m in mo
+                        ]
+                else:
+                    x_labels = mo.tolist()
+            else:
+                x_labels = list(range(len(plot_df)))
+            fig_cal = go.Figure()
+            fig_cal.add_scatter(
+                x=x_labels,
+                y=plot_df["observed_kwh"],
+                mode="lines+markers",
+                name="Bills (observed)",
+                line=dict(color="#1f77b4"),
+            )
+            fig_cal.add_scatter(
+                x=x_labels,
+                y=plot_df["modeled_kwh"],
+                mode="lines+markers",
+                name="Model (calibrated)",
+                line=dict(color="#d62728"),
+            )
+            fig_cal.update_layout(
+                title="Monthly electricity — bills vs model",
+                height=360,
+                margin=dict(l=10, r=10, t=40, b=10),
+                yaxis_title="kWh",
+                legend=dict(orientation="h", y=1.12),
+            )
+            st.plotly_chart(fig_cal, width="stretch", key="twin_cal_overlay")
         ubills = scorecard.get("utility_bills") or {}
         stats = ubills.get("stats_electricity") or ubills.get("stats") or {}
         if stats:
@@ -915,10 +980,13 @@ def render() -> None:
         if pick and st.button("Show 08 panes for selection", key="twin_show_iter"):
             st.session_state["studio_active_run"] = pick
             st.rerun()
-        if pick and Path(str(pick)).is_dir():
-            st.markdown(f"**EUI index for** `{Path(str(pick)).name}`")
-            _render_eui_index(
-                profile=profile,
-                run_dir=Path(str(pick)),
-                chart_key=f"twin_eui_index_hist_{Path(str(pick)).name}",
-            )
+
+    # EnergyPlus visualizer last — APIHelper-08 floor plan / OA / progress
+    viz_run = _resolve_active_run()
+    if viz_run is not None:
+        _render_08_panes(viz_run)
+    else:
+        st.info(
+            "No published Twin runs yet. An AI agent should write `runs/<id>/eplusout.csv` "
+            "(or click demo replay / Docker run). See AGENT_TESTER_PROMPT.md."
+        )

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -15,6 +15,7 @@ from wattlab.energyplus.timeseries import find_eplusout_csv, load_sim_timeseries
 from wattlab.seed import gap_report
 from wattlab.studio.ep_viz import (
     MULTIFLOOR_HONESTY,
+    find_run_idf,
     floor_plan_figure,
     install_demo_replay,
     list_iteration_runs,
@@ -27,6 +28,11 @@ from wattlab.studio.ep_viz import (
 )
 from wattlab.studio.eui_charts import eui_peer_bullet_figure, month_abbrev
 from wattlab.studio.eui_compare import build_eui_index, load_model_eui_from_run
+from wattlab.studio.idf_geometry import (
+    idf_massing_figure,
+    parse_idf_geometry,
+    zone_mean_temps_by_name,
+)
 from wattlab.studio.workspace import reports_dir, runs_dir
 
 
@@ -190,7 +196,7 @@ def _resolve_active_run() -> Path | None:
 
 
 def _resolve_viz_run(preferred: Path | None = None) -> tuple[Path | None, str | None]:
-    """Prefer a run that has eplusout.csv for 08 panes; caption when falling back."""
+    """Prefer a run that has eplusout.csv and/or model.idf for Twin panes."""
     candidates: list[Path] = []
     for p in (preferred, _resolve_active_run()):
         if p is not None and p.is_dir():
@@ -199,35 +205,55 @@ def _resolve_viz_run(preferred: Path | None = None) -> tuple[Path | None, str | 
         if h.get("dir"):
             candidates.append(Path(str(h["dir"])))
     seen: set[str] = set()
+
+    def _key(c: Path) -> str:
+        try:
+            return str(c.resolve())
+        except OSError:
+            return str(c)
+
+    # Pass 1: has eplusout
     for c in candidates:
-        key = str(c.resolve()) if c.exists() else str(c)
+        key = _key(c)
         if key in seen:
             continue
         seen.add(key)
         if (c / "eplusout.csv").is_file() or find_eplusout_csv(c) is not None:
             note = None
-            if preferred is not None and c.resolve() != preferred.resolve():
+            if preferred is not None and _key(c) != _key(preferred):
                 note = (
                     f"Active run `{preferred.name}` has no eplusout.csv — "
-                    f"showing floor plan from `{c.name}`."
+                    f"showing panes from `{c.name}`."
                 )
+            return c, note
+    # Pass 2: IDF-only (geometry without sim yet)
+    seen.clear()
+    for c in candidates:
+        key = _key(c)
+        if key in seen:
+            continue
+        seen.add(key)
+        if find_run_idf(c) is not None:
+            note = None
+            if preferred is not None and _key(c) != _key(preferred):
+                note = f"Showing IDF geometry from `{c.name}` (no eplusout yet)."
             return c, note
     fallback = preferred or _resolve_active_run() or newest_run_with_eplusout(runs_dir())
     return fallback, None
 
 
 def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
-    st.subheader("EnergyPlus visualizer (APIHelper 08 — browser)")
+    st.subheader("EnergyPlus visualizer (browser)")
     st.caption(
-        "Live progress from DinD console → `progress.json` / `console.log` "
-        "(APIHelper-08 style; not embedded pyenergyplus). "
-        "OA / floor charts appear after `eplusout.csv` is published. "
-        "Agents: publish to `runs/<id>/`; human: Refresh or watch live while Studio DinD runs."
+        "Live progress from DinD → `progress.json` / console. "
+        "**Building massing** comes from the published IDF (`model.idf`) — unique per run, "
+        "not a hard-coded prototype. Zone colors appear when `eplusout.csv` maps by zone name. "
+        "Agents: publish IDF + CSV to `runs/<id>/`."
     )
 
     viz_dir, viz_note = _resolve_viz_run(run_dir)
     if viz_dir is None:
-        st.warning("No published Twin runs with `eplusout.csv` yet.")
+        st.warning("No published Twin runs yet (need `model.idf` and/or `eplusout.csv`).")
         return
     if viz_note:
         st.info(viz_note)
@@ -269,57 +295,82 @@ def _render_08_panes(run_dir: Path, *, n_floors: int | None = None) -> None:
                     key=f"twin_oa_{run_dir.name}",
                 )
             else:
-                st.warning(
-                    f"No outdoor timeseries — missing `eplusout.csv` under `runs/{run_dir.name}/`."
+                st.caption(
+                    f"No outdoor timeseries yet — publish `eplusout.csv` under `runs/{run_dir.name}/`."
                 )
 
-        if ts is not None:
-            roles = zone_mean_by_role(ts)
-            if roles:
-                floors = int(n_floors or 1)
-                profile = _profile() or {}
-                if floors < 2:
-                    floors = int(
-                        profile.get("number_of_floors")
-                        or profile.get("floors")
-                        or st.session_state.get("twin_floors")
-                        or 1
-                    )
-                btype = str(profile.get("building_type") or profile.get("property_type") or "").lower()
-                use_multi = floors >= 2 and ("office" in btype or floors >= 2)
-                if use_multi and floors >= 2:
-                    highlight = None
-                    if floors > 8:
-                        highlight = int(
-                            st.selectbox(
-                                "Highlight floor",
-                                options=list(range(1, floors + 1)),
-                                index=floors - 1,
-                                key=f"twin_floor_sel_{run_dir.name}",
-                            )
-                        )
-                    st.plotly_chart(
-                        multifloor_office_figure(roles, n_floors=floors, highlight_floor=highlight),
-                        width="stretch",
-                        key=f"twin_multifloor_{run_dir.name}",
-                    )
-                    st.caption(MULTIFLOOR_HONESTY.replace("N-story", f"{floors}-story"))
-                else:
-                    st.plotly_chart(
-                        floor_plan_figure(roles),
-                        width="stretch",
-                        key=f"twin_floor_{run_dir.name}",
-                    )
-            else:
-                st.warning(
-                    "eplusout.csv loaded but no zone mean temps mapped — "
-                    "check Output:Variable Zone Mean Air Temperature."
+        # IDF-driven 3D massing (unique per building / run)
+        idf_path = find_run_idf(run_dir)
+        zone_temps = zone_mean_temps_by_name(ts) if ts is not None else {}
+        if idf_path is not None:
+            try:
+                geom = parse_idf_geometry(idf_path)
+                summary = geom.summary()
+                st.markdown("**Building geometry (from published IDF)**")
+                st.caption(
+                    "Geometry from published IDF surfaces (not Map-traced CAD). "
+                    "Units: EnergyPlus meters. "
+                    f"Surfaces={summary.get('n_surfaces')} · zones={summary.get('n_zones')} · "
+                    f"file=`{idf_path.name}`."
                 )
+                if geom.surfaces:
+                    st.plotly_chart(
+                        idf_massing_figure(
+                            geom,
+                            zone_temps=zone_temps or None,
+                            title=f"IDF massing — {run_dir.name}",
+                        ),
+                        width="stretch",
+                        key=f"twin_idf_3d_{run_dir.name}",
+                    )
+                    if zone_temps:
+                        st.caption("Surfaces colored by zone mean air temp from eplusout.csv.")
+                    else:
+                        st.caption("Neutral massing — publish eplusout.csv to color by zone temp.")
+                else:
+                    st.warning(f"IDF `{idf_path.name}` has no BuildingSurface:Detailed objects.")
+            except Exception as exc:
+                st.error(f"IDF geometry parse failed: {exc}")
+        else:
+            st.warning(
+                f"No `model.idf` under `runs/{run_dir.name}/` — publish the EnergyPlus IDF "
+                "with the run to see this building's massing (unique per site)."
+            )
+            # Legacy fallback schematic — never claim it is site geometry
+            if ts is not None:
+                roles = zone_mean_by_role(ts)
+                if roles:
+                    st.caption(
+                        "Fallback: classic 5Zone prototype schematic only — "
+                        "not this building's IDF. Publish model.idf for real massing."
+                    )
+                    floors = int(n_floors or 1)
+                    profile = _profile() or {}
+                    if floors < 2:
+                        floors = int(
+                            profile.get("number_of_floors")
+                            or profile.get("floors")
+                            or st.session_state.get("twin_floors")
+                            or 1
+                        )
+                    if floors >= 2:
+                        st.plotly_chart(
+                            multifloor_office_figure(roles, n_floors=floors),
+                            width="stretch",
+                            key=f"twin_multifloor_{run_dir.name}",
+                        )
+                        st.caption(MULTIFLOOR_HONESTY.replace("N-story", f"{floors}-story"))
+                    else:
+                        st.plotly_chart(
+                            floor_plan_figure(roles),
+                            width="stretch",
+                            key=f"twin_floor_{run_dir.name}",
+                        )
+
+        if ts is not None:
             means = ts.zone_mean_temps()
             if not means.empty:
                 st.dataframe(means, width="stretch", hide_index=True)
-        elif (run_dir / "eplusout.csv").is_file() is False and find_eplusout_csv(run_dir) is None:
-            st.error(f"no eplusout.csv under runs/{run_dir.name}/")
 
     if live:
         try:


### PR DESCRIPTION
## Summary
- Shared horizontal EUI bullet/box chart (Fuel Portfolio + Twin); removed duplicate Twin EUI under iteration history.
- Weather & Baseline: Open-Meteo still fetches full bill span; fit-window slider/checkbox for last N years / all months (default = max available).
- Month labels Jan…Dec on heatmaps/YoY; Twin calibrated overlay Plotly dual series.
- APIHelper-08 visualizer moved to Twin bottom; prefers runs with eplusout.csv; labeled 5Zone schematic.

## Test plan
- [x] `pytest tests/test_ui_charts_multiyear.py` green
- [ ] Local Studio: Fuel peer chart + Weather years slider with ~10y gas
- [ ] Twin: single EUI bullet; floor plan at bottom after agent publishes

**Do not merge for GHCR yet** — commit-only tip per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer-band EUI charts with clearer site markers and month labels.
  * Added selectable weather-fitting windows, including recent years or all available overlapping months.
  * Improved EnergyPlus visualizer run selection and fallback handling.
  * Enhanced floor-plan annotations with compact zone labels and temperatures.
  * Updated fuel, demand, weather, and data-quality charts for clearer year and month presentation.

* **Bug Fixes**
  * Improved handling and messaging when visualizer files or outdoor weather data are unavailable.
  * Added validation covering chart rendering, multi-year fitting, month alignment, and studio navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->