### PR TITLE
feat(vibe20): full EnergyPlus MCP default + Twin G14 epoch UX

### DIFF
--- a/vibe_code_apps_20/AGENTS.md
+++ b/vibe_code_apps_20/AGENTS.md
@@ -268,14 +268,14 @@ simulation**. Before any capital plan or ROI narrative is emitted:
 | **Easy button** | Demo / default ECM screen | `python easy_button.py --building ...` or `--minimal '{...}' --measure-set best` |
 | **Defaults only** | Form preview / UI | `python wattlab_defaults.py --type office --city madison` |
 | **vibe19 bridge** | Auto-suggest ECMs from FDD export | `python vibe19_bridge.py <export_dir>` |
-| **Full EnergyPlus-MCP** | Inspect loops, plots, custom run periods, validate IDF | Cursor MCP → Docker `energyplus-mcp-dev` (see `third_party/README.md`) |
+| **Full EnergyPlus-MCP** | Inspect loops, plots, custom run periods, validate/modify IDF | `wattlab energyplus-ensure` → `ready`; then `wattlab mcp-exec` / `dial-loads` or Cursor MCP (`third_party/README.md`) |
 | **WattLab twin** | Dump → gaps → profile → optional Open-Meteo AMY + calibrate | `wattlab twin <dump.zip> --inputs answers.json` |
 
 ### Archetype screening vs human-supplied IDF
 
 - **Default:** archetype-scaled `5ZoneAirCooled.idf` (or archetype `prototype_idf`) — geometry is a **screening surrogate**, not the real building. Keep `NEEDS_INPUT` / conceptual disclaimers honest.
 - **Bring your own IDF:** pass `custom_idf` or `prototype_idf` in twin `--inputs` / Studio Model — advanced modelers are first-class. Resolve_profile / easy-button use that path instead of the archetype file.
-- **Roles:** WattLab owns weather (Open-Meteo AMY / weather_observed), bills + dual-fuel G14, ECM patches, scorecards, Studio **EP Results** viz. Cursor MCP against a cloned vendor tree (`third_party/README.md`) owns deep IDF inspect/modify/plot. In-package MCP helpers are **simulate-via-Docker**; check `wattlab.energyplus.mcp.capability_status()`.
+- **Roles:** WattLab owns weather (Open-Meteo AMY / weather_observed), bills + dual-fuel G14, ECM patches, scorecards, Studio **EP Results** viz. EnergyPlus-MCP (via `energyplus-ensure` + `mcp-exec` / Cursor) owns deep IDF inspect/modify/plot. Check `wattlab.energyplus.mcp.capability_status()` — production target is **`ready`**.
 
 ### Actual weather + bills
 

--- a/vibe_code_apps_20/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/CONTAINER_AGENT.md
@@ -6,9 +6,9 @@ You are inside **`ghcr.io/bbartling/vibe20:latest`** (or vibe19). Work on the sh
 ## Behind the scenes (agent ↔ Studio)
 
 ```text
-agent: wattlab twin | calibrate-campaign | geo-idf | dial-loads | score-monthly
+agent: wattlab energyplus-ensure | geo-idf | dial-loads | mcp-exec | twin | calibrate-campaign
         │
-        ▼  Docker energyplus-mcp-dev (DinD)
+        ▼  Docker energyplus-mcp-dev (DinD + MCP surgery)
 runs/<id>/progress.json + console.log   ← live while sim runs
 runs/<id>/eplusout.csv                  ← after ReadVars (-r)
 runs/<id>/model.idf                     ← Twin 3D massing (unique per building)
@@ -21,6 +21,23 @@ Human Studio Twin: fragment polls progress; IDF massing + OA after publish
 No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live panes are **file polls**.
 Twin massing parses published IDF surfaces (not a hard-coded prototype footprint).
 
+## EnergyPlus MCP (required — same stack as a human)
+
+Production agents **must** reach capability ``ready`` before load/envelope dials:
+
+```bash
+wattlab energyplus-ensure   # once per host: clone pin → /data/third_party/EnergyPlus-MCP + build image
+python -c "from wattlab.energyplus.mcp import capability_status; print(capability_status())"
+# expect capability == "ready"
+```
+
+- **IDF surgery** (inspect/modify lights, equipment, infil, loops): `wattlab dial-loads` /
+  `wattlab mcp-exec -- …` (auto uses `energyplus-mcp-dev`)
+- **Annual simulate**: WattLab DinD (`run_energyplus` / Studio Easy Buttons)
+- Skip vendor `validate_idf` if eppy MSequence errors
+
+Never treat “image present but no MCP” as an acceptable soak outcome.
+
 ## Geometry gate (before G14 / fuel matching)
 
 Answers `floors` / `wwr` / `floor_area_ft2` do **not** rebuild the IDF. Default remains
@@ -29,7 +46,7 @@ office for fuel matching.
 
 For site-scale glass / multistory offices (any building):
 
-1. `wattlab geo-idf --src <DOE Large Office>.idf --dst … --target-area-ft2 … --stories … --wwr … --lat … --lon …`
+1. `wattlab geo-idf --src <DOE Large Office>.idf --dst … --target-area-ft2 … --stories … --wwr … [--lat … --lon …]`
 2. Profile / answers: `custom_idf` → that IDF, **`prototype_area_scale = 1`**
 3. Publish `model.idf` + `eplusout.csv` for Twin 3D massing
 4. Fuel-mix heuristic: high elec + low gas ⇒ excess internal gains — dial Lights/Equip down and
@@ -37,19 +54,17 @@ For site-scale glass / multistory offices (any building):
    patches on a tiny prototype.
 5. Score: `wattlab score-monthly eplusout.csv --bills … --area-ft2 …` (last-12 Monthly meters)
 
-**EnergyPlus MCP:** tip image = `simulate_only`. Full inspect/modify needs
-`third_party/EnergyPlus-MCP` + `energyplus-mcp-dev` docker one-shot (or Cursor MCP).
-Use MCP for load/envelope edits; use WattLab DinD for annual sims. Skip vendor
-`validate_idf` if eppy MSequence errors.
-
 **Bills honesty:** campus area-weighted half elec + per-building gas — never double-half.
+
+Practice evidence (Liberty B100 / B50) may appear in docs as labeled rehearsal only —
+never bake building ids into discovery defaults or silent CLI defaults.
 
 ## Read first
 
 | Path | Why |
 | --- | --- |
 | `/app/CONTAINER_AGENT.md` | This file |
-| `/app/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + DinD + bootstrap |
+| `/app/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + DinD + ensure |
 | `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS |
 | `/app/vibe20_agent_spec/DATA_CONTRACT.md` | Dump / answers / campus schemas |
 | `/app/vibe20_agent_spec/AGENT_TESTER_PROMPT.md` | Soak checklist |
@@ -66,6 +81,8 @@ docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
 
 Useful commands:
 
+- `wattlab energyplus-ensure` — vendor + `energyplus-mcp-dev` (required once)
+- `wattlab mcp-exec -- python -c '…'` — raw MCP one-shot
 - `wattlab studio-status --write` → `reports/session_status.json`
 - `wattlab studio-bootstrap --campus … --dump … --run-id … --answers … --ecm-scenario …`
   (merges existing keys — does not drop `ecm_scenario_path`)
@@ -82,3 +99,4 @@ Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**. Twin DinD 
 - Claim calibrated ROI without G14 stamps
 - Expect answers `floors`/`wwr` alone to rebuild geometry
 - Double-half shared electric that is already area-weighted
+- Soft-fall past missing MCP (“sim only”) — ensure until `capability == ready`

--- a/vibe_code_apps_20/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/CONTAINER_AGENT.md
@@ -56,7 +56,7 @@ For site-scale glass / multistory offices (any building):
 
 **Bills honesty:** campus area-weighted half elec + per-building gas — never double-half.
 
-Practice evidence (Liberty B100 / B50) may appear in docs as labeled rehearsal only —
+Practice evidence may appear in docs as labeled rehearsal only —
 never bake building ids into discovery defaults or silent CLI defaults.
 
 ## Read first

--- a/vibe_code_apps_20/tests/test_full_mcp_default.py
+++ b/vibe_code_apps_20/tests/test_full_mcp_default.py
@@ -42,10 +42,10 @@ def test_dial_loads_routes_via_docker_when_no_local_mcp(tmp_path: Path):
 
     real_import = builtins.__import__
 
-    def _imp(name, globals=None, locals=None, fromlist=(), level=0):
+    def _imp(name, globals_=None, locals_=None, fromlist=(), level=0):
         if name == "energyplus_mcp_server" or name.startswith("energyplus_mcp_server."):
             raise ImportError("forced missing MCP")
-        return real_import(name, globals, locals, fromlist, level)
+        return real_import(name, globals_, locals_, fromlist, level)
 
     with patch("builtins.__import__", side_effect=_imp):
         with patch(
@@ -73,7 +73,7 @@ def test_answers_discovery_answers_json_wins(tmp_path: Path):
     assert str(out["paths"]["answers"]).endswith("answers.json")
 
 
-def test_answers_discovery_glob_sorted_without_100_50_prefer(tmp_path: Path):
+def test_answers_discovery_glob_single_only(tmp_path: Path):
     from wattlab.studio.status import build_session_status
 
     reports = tmp_path / "reports"
@@ -81,5 +81,9 @@ def test_answers_discovery_glob_sorted_without_100_50_prefer(tmp_path: Path):
     (reports / "answers_building_100.json").write_text('{"id": "100"}', encoding="utf-8")
     (reports / "answers_building_50.json").write_text('{"id": "50"}', encoding="utf-8")
     out = build_session_status(workspace=tmp_path)
-    # Sorted: answers_building_100.json before answers_building_50.json
-    assert str(out["paths"]["answers"]).endswith("answers_building_100.json")
+    # Ambiguous multi-site answers → leave unset (NEEDS_INPUT)
+    assert out["paths"]["answers"] is None
+
+    (reports / "answers_building_50.json").unlink()
+    out2 = build_session_status(workspace=tmp_path)
+    assert str(out2["paths"]["answers"]).endswith("answers_building_100.json")

--- a/vibe_code_apps_20/tests/test_full_mcp_default.py
+++ b/vibe_code_apps_20/tests/test_full_mcp_default.py
@@ -1,0 +1,85 @@
+"""Tests for energyplus-ensure / dial-loads docker route + geo CLI + answers discovery."""
+
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from wattlab.energyplus.geo_idf import main as geo_main
+from wattlab.energyplus.mcp_runtime import parse_version_pin
+
+
+def test_parse_version_pin():
+    pin = parse_version_pin()
+    assert "LBNL-ETA/EnergyPlus-MCP" in pin["repo"]
+    assert pin["commit"]
+    assert pin["image"]
+
+
+def test_geo_idf_requires_stories_wwr():
+    with pytest.raises(SystemExit):
+        geo_main(["--src", "x.idf", "--dst", "y.idf", "--target-area-ft2", "10000"])
+
+
+def test_dial_loads_routes_via_docker_when_no_local_mcp(tmp_path: Path):
+    from wattlab.energyplus import dial_loads as dl
+
+    src = tmp_path / "in.idf"
+    dst = tmp_path / "out.idf"
+    src.write_text("Building,\n  X,\n", encoding="utf-8")
+    fake_meta = {
+        "via": "mcp-exec",
+        "src": str(src),
+        "dst": str(dst),
+        "lights_w_per_m2": 4.5,
+        "equip_w_per_m2": 4.2,
+        "infil_mult": 1.4,
+        "hint": "x",
+    }
+
+    real_import = builtins.__import__
+
+    def _imp(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "energyplus_mcp_server" or name.startswith("energyplus_mcp_server."):
+            raise ImportError("forced missing MCP")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=_imp):
+        with patch(
+            "wattlab.energyplus.mcp_runtime.dial_loads_via_docker",
+            return_value=fake_meta,
+        ) as mock_docker:
+            meta = dl.dial_loads_mcp(
+                src, dst, lights_w_per_m2=4.5, equip_w_per_m2=4.2, infil_mult=1.4
+            )
+    assert meta["via"] == "mcp-exec"
+    mock_docker.assert_called_once()
+
+
+def test_answers_discovery_answers_json_wins(tmp_path: Path):
+    from wattlab.studio.status import build_session_status
+
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / "answers_building_z.json").write_text('{"z": 1}', encoding="utf-8")
+    (reports / "answers.json").write_text(
+        '{"building_type": "office", "floor_area_ft2": 10000, "city": "x"}',
+        encoding="utf-8",
+    )
+    out = build_session_status(workspace=tmp_path)
+    assert str(out["paths"]["answers"]).endswith("answers.json")
+
+
+def test_answers_discovery_glob_sorted_without_100_50_prefer(tmp_path: Path):
+    from wattlab.studio.status import build_session_status
+
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / "answers_building_100.json").write_text('{"id": "100"}', encoding="utf-8")
+    (reports / "answers_building_50.json").write_text('{"id": "50"}', encoding="utf-8")
+    out = build_session_status(workspace=tmp_path)
+    # Sorted: answers_building_100.json before answers_building_50.json
+    assert str(out["paths"]["answers"]).endswith("answers_building_100.json")

--- a/vibe_code_apps_20/tests/test_mcp_status.py
+++ b/vibe_code_apps_20/tests/test_mcp_status.py
@@ -11,13 +11,16 @@ def test_capability_status_shape():
     assert "vendor_present" in status
     assert status["vendor_present"] is mcp_vendor_ready()
     assert status["capability"] in {
-        "full_mcp_available",
-        "simulate_only",
-        "vendor_only_no_image",
+        "ready",
+        "image_missing",
+        "vendor_missing",
         "unavailable",
     }
+    assert "simulate_only" not in status["capability"]
+    assert "full_mcp_available" not in status["capability"]
     assert "apihelper_note" in status
     assert "pyenergyplus" in status["apihelper_note"].lower() or "Runtime" in status["apihelper_note"]
     # Without docker probe, image_present stays False
     assert status["image_present"] is False
     assert status["simulate_via_docker"] is False
+    assert status["capability"] in {"unavailable", "vendor_missing", "image_missing"}

--- a/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
+++ b/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
@@ -1,0 +1,119 @@
+"""G14 epoch history + model summary + envelope ratios."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wattlab.studio.g14_history import g14_epoch_figure, iter_g14_history
+from wattlab.studio.idf_geometry import parse_idf_geometry
+from wattlab.studio.model_summary import build_model_summary
+
+
+def _wall_idf() -> str:
+    return """  BuildingSurface:Detailed,
+    WallA,                   !- Name
+    Wall,                    !- Surface Type
+    Const,                   !- Construction Name
+    ZoneA,                   !- Zone Name
+    ,                        !- Space Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    0.5,                     !- View Factor to Ground
+    4,                       !- Number of Vertices
+    0.0,0.0,0.0,  !- X,Y,Z ==> Vertex 1 {m}
+    10.0,0.0,0.0,  !- X,Y,Z ==> Vertex 2 {m}
+    10.0,0.0,3.0,  !- X,Y,Z ==> Vertex 3 {m}
+    0.0,0.0,3.0;  !- X,Y,Z ==> Vertex 4 {m}
+
+  FenestrationSurface:Detailed,
+    WinA,                    !- Name
+    Window,                  !- Surface Type
+    Glass,                   !- Construction Name
+    WallA,                   !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    1,                       !- Multiplier
+    4,                       !- Number of Vertices
+    2.0,0.0,0.5,  !- X,Y,Z ==> Vertex 1 {m}
+    5.0,0.0,0.5,  !- X,Y,Z ==> Vertex 2 {m}
+    5.0,0.0,2.0,  !- X,Y,Z ==> Vertex 3 {m}
+    2.0,0.0,2.0;  !- X,Y,Z ==> Vertex 4 {m}
+
+"""
+
+
+def test_envelope_ratios_wwr():
+    geom = parse_idf_geometry(_wall_idf())
+    ratios = geom.envelope_ratios()
+    assert ratios["wall_area_m2"] > 0
+    assert ratios["window_area_m2"] > 0
+    assert ratios["wwr"] is not None
+    assert 0 < float(ratios["wwr"]) < 1
+    assert ratios["wwr_pct"] == round(100.0 * float(ratios["wwr"]), 1)
+
+
+def test_iter_g14_history_and_epoch(tmp_path: Path):
+    runs = tmp_path / "runs"
+    for i, nmbe in enumerate((20.0, 8.0, 3.0), start=1):
+        d = runs / f"run_{i}"
+        d.mkdir(parents=True)
+        (d / "run_manifest.json").write_text(
+            json.dumps(
+                {
+                    "run_id": f"run_{i}",
+                    "status": "ok",
+                    "started_at": f"2026-07-0{i}T12:00:00Z",
+                    "finished_at": f"2026-07-0{i}T12:30:00Z",
+                    "hypothesis": f"iter {i}",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (d / "calibration_scorecard.json").write_text(
+            json.dumps(
+                {
+                    "utility_bills": {
+                        "pass_fail": "PASS" if nmbe <= 5 else "FAIL",
+                        "stats_electricity": {"nmbe_pct": nmbe, "cvrmse_pct": nmbe + 5},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+    rows = iter_g14_history(runs, limit=10)
+    assert len(rows) == 3
+    assert rows[0]["run_id"] == "run_1"
+    assert rows[-1]["nmbe_elec_pct"] == 3.0
+    fig = g14_epoch_figure(rows)
+    assert len(fig.data) >= 2
+    assert fig.layout.height >= 400
+
+
+def test_build_model_summary(tmp_path: Path):
+    run = tmp_path / "geo_dial"
+    run.mkdir()
+    (run / "model.idf").write_text(_wall_idf(), encoding="utf-8")
+    (run / "dial_meta.json").write_text(
+        json.dumps({"lights_w_per_m2": 4.5, "equip_w_per_m2": 4.2, "infil_mult": 1.4}),
+        encoding="utf-8",
+    )
+    (run / "run_manifest.json").write_text(
+        json.dumps({"run_id": "geo_dial", "status": "ok"}), encoding="utf-8"
+    )
+    answers = {
+        "building_type": "office",
+        "city": "detroit",
+        "floor_area_ft2": 140000,
+        "floors": 6,
+        "utility": {"elec_usd_per_kwh": 0.12},
+    }
+    summary = build_model_summary(answers, run)
+    assert summary["project"]["city"] == "detroit"
+    assert summary["geometry"]["floor_area_ft2"] == 140000
+    assert summary["loads"]["lights_w_per_m2"] == 4.5
+    assert summary["geometry"]["n_zones"] == 1
+    assert summary["geometry"]["wwr_from_idf_pct"] is not None

--- a/vibe_code_apps_20/tests/test_ui_charts_multiyear.py
+++ b/vibe_code_apps_20/tests/test_ui_charts_multiyear.py
@@ -33,10 +33,14 @@ def test_eui_peer_bullet_figure_has_band_and_rows():
             {"label": "Model (prototype)", "eui": 24.0, "color": "#d62728"},
         ],
         title="test",
+        height=420,
     )
-    # One rect + one p50 line per series row
+    # One upright rect + one p50 line per series row
     assert len(fig.layout.shapes) == 4
     assert any(t.mode and "markers" in str(t.mode) for t in fig.data)
+    assert fig.layout.height >= 420
+    # Y is EUI (upright); X is category labels
+    assert fig.layout.yaxis.title.text and "EUI" in str(fig.layout.yaxis.title.text)
 
 
 def test_fit_window_defaults_to_max_years():

--- a/vibe_code_apps_20/third_party/README.md
+++ b/vibe_code_apps_20/third_party/README.md
@@ -2,8 +2,16 @@
 
 OpenFDD WattLab uses the [LBNL-ETA/EnergyPlus-MCP](https://github.com/LBNL-ETA/EnergyPlus-MCP) Docker image for EnergyPlus 26.1.0.
 
+**Preferred (tip agents / bensbench):**
+
+```bash
+wattlab energyplus-ensure
+# clones pin → $WATTLAB_STUDIO_WORKSPACE/third_party/EnergyPlus-MCP
+# builds energyplus-mcp-dev once; capability_status() → ready
+```
+
 - Pin: see `VERSION.txt`
-- Local clone: `EnergyPlus-MCP/` (gitignored; re-clone from VERSION.txt)
+- Local clone: `EnergyPlus-MCP/` (gitignored; re-clone from VERSION.txt) **or** workspace `/data/third_party/EnergyPlus-MCP`
 - Image tag: `energyplus-mcp-dev`
 
 ## Build (required build-arg)

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -188,7 +188,7 @@ Default archetype remains 5Zone × `prototype_area_scale` — screening only.
 Workflow: **ensure → geo-idf → custom_idf + area_scale=1 → DinD sim → score-monthly**.
 If elec high / gas low, dial loads via MCP before more schedule patches. Bills:
 area-weighted half elec once — never double-half. Twin shows IDF 3D massing from
-published `model.idf`. Liberty B100/B50 = labeled practice only.
+published `model.idf`. Practice campus dumps = labeled rehearsal only.
 
 ---
 

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -179,13 +179,16 @@ Default archetype remains 5Zone × `prototype_area_scale` — screening only.
 
 | Tool | CLI | Role |
 | --- | --- | --- |
-| `wattlab.energyplus.geo_idf` | `wattlab geo-idf` | DOE Large Office (or similar) → site-scale massing (stories, WWR, XY scale, lat/lon) |
-| `wattlab.energyplus.dial_loads` | `wattlab dial-loads` | MCP: lights / equip W/m² + infil mult (needs full MCP image) |
+| ensure | `wattlab energyplus-ensure` | Clone pin + build `energyplus-mcp-dev` → capability `ready` |
+| `wattlab.energyplus.geo_idf` | `wattlab geo-idf` | DOE Large Office → site-scale massing |
+| `wattlab.energyplus.dial_loads` | `wattlab dial-loads` | MCP lights / equip W/m² + infil (auto mcp-exec) |
 | `wattlab.energyplus.score_monthly` | `wattlab score-monthly` | Last-12 Monthly meters vs bills; `area_scale=1` |
+| mcp-exec | `wattlab mcp-exec -- …` | Raw `uv run` inside MCP image |
 
-Workflow: **geo-idf → custom_idf + area_scale=1 → DinD sim → score-monthly**. If elec high /
-gas low, dial loads via MCP before more schedule patches. Bills: area-weighted half
-elec once — never double-half. Twin shows IDF 3D massing from published `model.idf`.
+Workflow: **ensure → geo-idf → custom_idf + area_scale=1 → DinD sim → score-monthly**.
+If elec high / gas low, dial loads via MCP before more schedule patches. Bills:
+area-weighted half elec once — never double-half. Twin shows IDF 3D massing from
+published `model.idf`. Liberty B100/B50 = labeled practice only.
 
 ---
 

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENT_TESTER_PROMPT.md
@@ -112,15 +112,16 @@ Both vibe19 and vibe20 are **native Streamlit** (not FastAPI embedding Streamlit
 ## SETUP — EnergyPlus + EnergyPlus-MCP
 
 ```bash
-docker images energyplus-mcp-dev
-# Build if missing: vibe_code_apps_20/third_party/README.md + scripts/build_energyplus_mcp.sh
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
+  -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace vibe20 \
+  wattlab energyplus-ensure
 
-cd ~/py-bacnet-stacks-playground/vibe_code_apps_20   # if present
-python -c "from wattlab.energyplus.mcp import capability_status; import json; print(json.dumps(capability_status(), indent=2))"
+docker exec … vibe20 python -c \
+  "from wattlab.energyplus.mcp import capability_status; import json; print(json.dumps(capability_status(), indent=2))"
 ```
 
-Need `mode` = `simulate_only` or `full_mcp_available`.  
-MCP config: [`../third_party/README.md`](../third_party/README.md).
+**Required:** `capability` = `ready` (image + vendor under `/data/third_party/EnergyPlus-MCP`).
+Fail the soak if ensure cannot reach `ready`. MCP config: [`../third_party/README.md`](../third_party/README.md).
 
 How to run sims (host agent CLI preferred if Studio cannot reach Docker sock):
 
@@ -184,7 +185,7 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 
 ## TURNKEY CHECKLIST
 
-1. Studio health ok; `energyplus-mcp-dev` present (`capability_status`).
+1. Studio health ok; `wattlab energyplus-ensure` → `capability_status()["capability"] == "ready"`.
 2. Dump + energy → Fuel: EUI + **peer p50/p20/p80** metrics green.
 3. Profile resolved with human — city keeps user label when given, but **lat/lon
    beat city string** for weather (e.g. Detroit coords for a Troy mailing label).
@@ -193,7 +194,7 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 6. **Studio-native** Docker E+ once → `eplusout.csv` (DinD sibling-mount gate).
 7. **Live campaign:** ≥3 Docker E+ sims (≥6–10 if sparse), each published, each confirmed in Twin UI.
 8. Partial-year AMY: RunPeriod ends on last **full** EPW day (W2b); not trailing hour-10 day.
-9. MCP inspect at least once if `full_mcp_available`; **optional** when `simulate_only`.
+9. **MCP inspect/modify at least once** (`wattlab dial-loads` or `mcp-exec`) — required, not optional.
 10. G14 / crosscheck logged per run when bills exist — or honest period/scale mismatch.
     Print NMBE/CV(RMSE) even when `months_compared` is already 12.
 11. Area honesty / `prototype_area_scale` called out (5Zone ≠ site ft²).
@@ -233,7 +234,7 @@ downloads report.md / results.xlsx / model zip. Entry: `/app/studio.py`.
 | Twin UI smoke | Visualizer works (replay ok); IDF massing when `model.idf` present |
 | **Studio DinD + `-r`** | ≥1 live sim **from Studio button** yields `eplusout.csv` |
 | **Twin calibrate** | **≥3 live** `energyplus-mcp-dev` sims in `runs/`, each with eplusout; human saw updates; G14 attempted **or** honest mismatch logged when bills exist |
-| E+ MCP | ≥1 inspect/validate if MCP available; else document `simulate_only` |
+| E+ MCP | `capability == ready` after ensure; ≥1 inspect/modify (`dial-loads` / `mcp-exec`) |
 | Honesty | No calibrated ROI without G14 + area + weather stamps |
 | W2b full-day AMY | RunPeriod end = last complete EPW day (not partial trailing hours) |
 | W3b hard-size | Area-scaled nameplate or refused + NEEDS_INPUT banner |

--- a/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
@@ -6,9 +6,9 @@ You are inside **`ghcr.io/bbartling/vibe20:latest`** (or vibe19). Work on the sh
 ## Behind the scenes (agent ↔ Studio)
 
 ```text
-agent: wattlab twin | calibrate-campaign | geo-idf | dial-loads | score-monthly
+agent: wattlab energyplus-ensure | geo-idf | dial-loads | mcp-exec | twin | calibrate-campaign
         │
-        ▼  Docker energyplus-mcp-dev (DinD)
+        ▼  Docker energyplus-mcp-dev (DinD + MCP surgery)
 runs/<id>/progress.json + console.log   ← live while sim runs
 runs/<id>/eplusout.csv                  ← after ReadVars (-r)
 runs/<id>/model.idf                     ← Twin 3D massing (unique per building)
@@ -21,6 +21,23 @@ Human Studio Twin: fragment polls progress; IDF massing + OA after publish
 No HTTP wrapper. No embedded `pyenergyplus` in Streamlit — live panes are **file polls**.
 Twin massing parses published IDF surfaces (not a hard-coded prototype footprint).
 
+## EnergyPlus MCP (required — same stack as a human)
+
+Production agents **must** reach capability ``ready`` before load/envelope dials:
+
+```bash
+wattlab energyplus-ensure   # once per host: clone pin → /data/third_party/EnergyPlus-MCP + build image
+python -c "from wattlab.energyplus.mcp import capability_status; print(capability_status())"
+# expect capability == "ready"
+```
+
+- **IDF surgery** (inspect/modify lights, equipment, infil, loops): `wattlab dial-loads` /
+  `wattlab mcp-exec -- …` (auto uses `energyplus-mcp-dev`)
+- **Annual simulate**: WattLab DinD (`run_energyplus` / Studio Easy Buttons)
+- Skip vendor `validate_idf` if eppy MSequence errors
+
+Never treat “image present but no MCP” as an acceptable soak outcome.
+
 ## Geometry gate (before G14 / fuel matching)
 
 Answers `floors` / `wwr` / `floor_area_ft2` do **not** rebuild the IDF. Default remains
@@ -29,7 +46,7 @@ office for fuel matching.
 
 For site-scale glass / multistory offices (any building):
 
-1. `wattlab geo-idf --src <DOE Large Office>.idf --dst … --target-area-ft2 … --stories … --wwr … --lat … --lon …`
+1. `wattlab geo-idf --src <DOE Large Office>.idf --dst … --target-area-ft2 … --stories … --wwr … [--lat … --lon …]`
 2. Profile / answers: `custom_idf` → that IDF, **`prototype_area_scale = 1`**
 3. Publish `model.idf` + `eplusout.csv` for Twin 3D massing
 4. Fuel-mix heuristic: high elec + low gas ⇒ excess internal gains — dial Lights/Equip down and
@@ -37,19 +54,17 @@ For site-scale glass / multistory offices (any building):
    patches on a tiny prototype.
 5. Score: `wattlab score-monthly eplusout.csv --bills … --area-ft2 …` (last-12 Monthly meters)
 
-**EnergyPlus MCP:** tip image = `simulate_only`. Full inspect/modify needs
-`third_party/EnergyPlus-MCP` + `energyplus-mcp-dev` docker one-shot (or Cursor MCP).
-Use MCP for load/envelope edits; use WattLab DinD for annual sims. Skip vendor
-`validate_idf` if eppy MSequence errors.
-
 **Bills honesty:** campus area-weighted half elec + per-building gas — never double-half.
+
+Practice evidence (Liberty B100 / B50) may appear in docs as labeled rehearsal only —
+never bake building ids into discovery defaults or silent CLI defaults.
 
 ## Read first
 
 | Path | Why |
 | --- | --- |
 | `/app/CONTAINER_AGENT.md` | This file |
-| `/app/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + DinD + bootstrap |
+| `/app/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md` | Shared volume + DinD + ensure |
 | `/app/vibe20_agent_spec/AGENTS.md` | Mission / agent OS |
 | `/app/vibe20_agent_spec/DATA_CONTRACT.md` | Dump / answers / campus schemas |
 | `/app/vibe20_agent_spec/AGENT_TESTER_PROMPT.md` | Soak checklist |
@@ -66,6 +81,8 @@ docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
 
 Useful commands:
 
+- `wattlab energyplus-ensure` — vendor + `energyplus-mcp-dev` (required once)
+- `wattlab mcp-exec -- python -c '…'` — raw MCP one-shot
 - `wattlab studio-status --write` → `reports/session_status.json`
 - `wattlab studio-bootstrap --campus … --dump … --run-id … --answers … --ecm-scenario …`
   (merges existing keys — does not drop `ecm_scenario_path`)
@@ -82,3 +99,4 @@ Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**. Twin DinD 
 - Claim calibrated ROI without G14 stamps
 - Expect answers `floors`/`wwr` alone to rebuild geometry
 - Double-half shared electric that is already area-weighted
+- Soft-fall past missing MCP (“sim only”) — ensure until `capability == ready`

--- a/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
@@ -56,7 +56,7 @@ For site-scale glass / multistory offices (any building):
 
 **Bills honesty:** campus area-weighted half elec + per-building gas — never double-half.
 
-Practice evidence (Liberty B100 / B50) may appear in docs as labeled rehearsal only —
+Practice evidence may appear in docs as labeled rehearsal only —
 never bake building ids into discovery defaults or silent CLI defaults.
 
 ## Read first

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -55,25 +55,31 @@ Do **not** point Schedule:File at absolute `/data/...` host paths (FATAL file no
 
 Helpers: `wattlab.existing_building.schedules` + `wattlab.energyplus.patches.weather_schedules`.
 
-## Site-scale geometry + EnergyPlus MCP (batch)
+## Site-scale geometry + EnergyPlus MCP (required)
 
-Tip image EnergyPlus MCP capability is often **`simulate_only`**. Annual sims use
-WattLab DinD (`run_energyplus`). For inspect/modify (lights, equipment, infil):
+Agents use the **same stack as a human in production**:
 
 ```bash
-# Host: vendor tree + workspace mounted; run dial script inside MCP image
-docker run --rm \
-  -v "$WATTLAB_HOST_WORKSPACE":/data \
-  -v "$REPO/vibe_code_apps_20/third_party/EnergyPlus-MCP":/workspace \
-  -w /workspace/energyplus-mcp-server \
-  --entrypoint bash energyplus-mcp-dev \
-  -lc 'uv run wattlab dial-loads …'   # or python -m wattlab.energyplus.dial_loads
+wattlab energyplus-ensure   # clone pin → /data/third_party/EnergyPlus-MCP + build energyplus-mcp-dev
+# capability_status()["capability"] must be "ready"
 ```
 
-Geometry ladder (any building; CLI args — not Liberty-hardcoded):
-`wattlab geo-idf` → `custom_idf` + `area_scale=1` → DinD → `wattlab score-monthly`.
-Skip vendor `validate_idf` if eppy MSequence errors. See `CONTAINER_AGENT.md`
-geometry gate + `TWIN_LOOP.md`.
+- **Annual sims:** WattLab DinD (`run_energyplus`)
+- **IDF surgery:** `wattlab dial-loads` / `wattlab mcp-exec -- …` (docker `energyplus-mcp-dev`)
+
+```bash
+# Host paths via WATTLAB_HOST_WORKSPACE; tip agents prefer workspace vendor
+wattlab mcp-exec -- python -c "import energyplus_mcp_server; print('ok')"
+wattlab dial-loads --src /data/uploads/prototypes/geo.idf --dst /data/uploads/prototypes/dialed.idf \
+  --lights 4.5 --equip 4.2 --infil-mult 1.4
+```
+
+Geometry ladder (any building; CLI args — not site-hardcoded):
+`wattlab geo-idf --stories … --wwr … --target-area-ft2 …` → `custom_idf` + `area_scale=1`
+→ DinD → `wattlab score-monthly`. Skip vendor `validate_idf` if eppy MSequence errors.
+
+Practice example (Liberty B100 rehearsal only): see campaign notes / `examples/liberty` —
+do not reuse B100/B50 numbers as silent defaults.
 
 ## G14 calibrate campaign (bill months → Twin)
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/SPARSE_BUILDING_PLAYBOOK.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/SPARSE_BUILDING_PLAYBOOK.md
@@ -87,10 +87,10 @@ Default sources when sparse (log which you used):
 
 ### MCP in the campaign
 
-Use EnergyPlus-MCP (when `full_mcp_available`) at least once per **major IDF
-change**: validate zones, meters, run period, schedules/loads. WattLab Docker
-CLI remains the default simulate path; MCP is the wrench for inspect/modify —
-not a calibration coach.
+Use EnergyPlus-MCP at least once per **major IDF change**: validate zones, meters,
+run period, schedules/loads (`wattlab energyplus-ensure` → `ready`, then
+`dial-loads` / `mcp-exec`). WattLab Docker CLI remains the default annual
+simulate path; MCP is the wrench for inspect/modify — not a calibration coach.
 
 ### Studio live loop (required env)
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -21,13 +21,13 @@ pyenergyplus / not Flask APIHelper / not hard-coded Liberty footprints.
 Answers `floors` / `wwr` / `sqft` do **not** rebuild the IDF. Default = 5Zone ×
 `prototype_area_scale`. For glass multistory offices:
 
-1. `wattlab geo-idf` (DOE Large Office → site-scale; any building via CLI args)
-2. `custom_idf` + **`area_scale = 1`**
-3. Fuel mix: high elec / low gas → `wattlab dial-loads` (EnergyPlus MCP one-shot)
-4. `wattlab score-monthly` — last-12 Monthly meters vs area-weighted bills (never double-half)
+1. `wattlab energyplus-ensure` → capability `ready`
+2. `wattlab geo-idf` (DOE Large Office → site-scale; any building via CLI args)
+3. `custom_idf` + **`area_scale = 1`**
+4. Fuel mix: high elec / low gas → `wattlab dial-loads` (EnergyPlus MCP via mcp-exec)
+5. `wattlab score-monthly` — last-12 Monthly meters vs area-weighted bills (never double-half)
 
-Annual simulate = WattLab DinD. MCP = inspect/modify loads only (`simulate_only` tip
-does not ship full MCP tools).
+Annual simulate = WattLab DinD. MCP = inspect/modify loads (required for production dials).
 
 Full paste prompt for QA + calibrate sessions:
 [`../AGENT_TESTER_PROMPT.md`](../AGENT_TESTER_PROMPT.md).

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -13,8 +13,9 @@ E+ iteration so Twin 08 panes appear in the browser
 **Live 08:** DinD writes `progress.json` + `console.log` during the sim; Twin polls
 (progress/log live). OA charts update when `eplusout.csv` exists (after ReadVars).
 **Building massing** comes from published `model.idf` (BuildingSurface:Detailed) —
-unique per run / site. Zone colors apply when CSV zone names match. Not embedded
-pyenergyplus / not Flask APIHelper / not hard-coded Liberty footprints.
+unique per run / site. Zone colors apply when CSV zone names match. Twin shows a
+**G14 epoch chart** (NMBE/CVRMSE across published iterations) and a read-only
+**model summary** (area, WWR, loads, HVAC hints) for the selected run.
 
 ## Geometry gate (site-scale twins)
 

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-energyplus-mcp/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-energyplus-mcp/SKILL.md
@@ -2,9 +2,9 @@
 name: wattlab-energyplus-mcp
 description: >-
   Use when driving LBNL EnergyPlus-MCP or energyplus-mcp-dev Docker for WattLab
-  twins: inspect/validate/modify/simulate IDF, capability_status, ReadVars CSV,
-  DinD mounts. Triggers on: EnergyPlus-MCP, MCP tools, validate_idf, load_idf,
-  energyplus-mcp-dev, simulate_only, full_mcp_available, eplusout.csv, -r.
+  twins: ensure, inspect/validate/modify/simulate IDF, capability_status,
+  eplusout.csv, -r. Triggers on: EnergyPlus-MCP, MCP tools, energyplus-ensure,
+  mcp-exec, dial-loads, energyplus-mcp-dev, ready, eplusout.csv.
 ---
 
 # EnergyPlus-MCP — wrench, not calibration coach
@@ -22,53 +22,35 @@ layer; WattLab is the assumption + honesty framework.
 
 ```python
 from wattlab.energyplus.mcp import capability_status
-print(capability_status())  # simulate_only | full_mcp_available | …
+print(capability_status())  # ready | image_missing | vendor_missing | unavailable
 ```
 
 | Mode | Meaning |
 | --- | --- |
-| `full_mcp_available` | Vendor tree + image; inspect tools usable |
-| `simulate_only` | Docker `energyplus-mcp-dev` sims OK; no interactive MCP |
-| missing image | Build per `third_party/README.md` / `scripts/build_energyplus_mcp.sh` |
+| `ready` | Image + vendor — DinD sims **and** mcp-exec/dial-loads surgery |
+| `image_missing` | Vendor OK; run `wattlab energyplus-ensure` to build |
+| `vendor_missing` | Image OK; run ensure to clone under `/data/third_party/EnergyPlus-MCP` |
+| `unavailable` | No Docker / nothing present — ensure after sock + host workspace |
 
-Studio GHCR image may be `simulate_only` until vendor MCP is mounted; host
-checkout often has `full_mcp_available`.
+**Required:** agents call `wattlab energyplus-ensure` until `capability == ready`.
+There is no supported “simulate only” soak path.
 
 ## Campaign usage (required pattern)
 
-1. **Simulate** via WattLab Docker (`wattlab easy-button` / `run_energyplus`).
+1. **Ensure** once: `wattlab energyplus-ensure`
+2. **Simulate** via WattLab Docker (`wattlab easy-button` / `run_energyplus`).
    Default includes **`-r` (ReadVars)** → `eplusout.csv` for Twin 08 panes.
-2. **Inspect** with MCP at least once per major IDF change: validate, zones,
-   meters, run period, schedules/people/lights/equipment.
-3. Prefer MCP modify tools for common knobs (people, lights, equipment,
-   infiltration scale, …) when available; else WattLab IDF patches.
+3. **Inspect/modify** with MCP for every major IDF change: zones, meters,
+   people/lights/equipment, infiltration — `wattlab dial-loads` or
+   `wattlab mcp-exec -- …`.
 4. Publish every successful sim: `publish_run_for_studio` → `runs/<id>/`.
 
 ## DinD / Studio
 
 When Studio runs in Docker with host docker.sock:
 
-- Image tip includes a **Docker CLI** binary — sock alone is insufficient.
-- Stage artifacts under `WATTLAB_STUDIO_WORKSPACE/.artifacts` (not `/app` only).
-- Set `WATTLAB_HOST_WORKSPACE` to the host side of the `/data` bind so volume
-  sources resolve on the daemon host.
-- Set `WATTLAB_ROOT=/app` so prototypes resolve under `/app/examples/…`.
-- Prefer `ENERGYPLUS_DOCKER_USER=1000:1000` for writable out dirs / ReadVars.
-- Prefer `docker exec vibe20 wattlab …` over host editable installs
-  ([`docs/AGENT_DOCKER_WORKSPACE.md`](../../docs/AGENT_DOCKER_WORKSPACE.md)).
+- Annual sim: WattLab mounts stage dirs into `energyplus-mcp-dev`
+- MCP surgery: `mcp-exec` mounts `$WATTLAB_HOST_WORKSPACE→/data` + vendor→`/workspace`
+- Vendor lives on the **shared workspace**, not inside the vibe20 GHCR tip image
 
-AMY RunPeriod: `simulate(align_run_period=True)` clips to last **full** EPW day
-(W2b). Calibrate path: [`docs/CALIBRATE_AND_DELIVERABLES.md`](../../docs/CALIBRATE_AND_DELIVERABLES.md).
-
-## What MCP does not cover (yet)
-
-No first-class tools for: geometry synthesis from area/stories; code-baseline
-generation; building-type default packs; tariff/emissions authoring; full HVAC
-creation from narrative. Those belong in WattLab assumption engine + templates
-— see [`wattlab-assumptions`](../wattlab-assumptions/SKILL.md).
-
-## Hard rules
-
-- No host `pyenergyplus` Runtime API.
-- Demo replay ≠ Twin calibrate PASS.
-- Log tool names used in `reports/CALIBRATE_SESSION.md`.
+Cursor interactive MCP: see `third_party/README.md` / `cursor_mcp_config_snippet()`.

--- a/vibe_code_apps_20/wattlab/cli.py
+++ b/vibe_code_apps_20/wattlab/cli.py
@@ -30,8 +30,10 @@ def _usage() -> str:
         "  studio-bootstrap  Write studio_bootstrap.json for Streamlit auto-load\n"
         "  studio-status     Merge dump/answers/bootstrap/run → session_status.json\n"
         "  geo-idf          Adapt DOE Large Office IDF → site-scale massing (any building)\n"
-        "  dial-loads       Dial lights/equip/infil via EnergyPlus MCP (full MCP image)\n"
+        "  dial-loads       Dial lights/equip/infil via EnergyPlus MCP (auto mcp-exec)\n"
         "  score-monthly    Score eplusout Monthly vs bills (last-12, area_scale=1)\n"
+        "  energyplus-ensure  Clone pinned EnergyPlus-MCP + build energyplus-mcp-dev\n"
+        "  mcp-exec         Run uv args inside energyplus-mcp-dev (IDF inspect/modify)\n"
         "  explore-existing  Existing Building Hypothesis Lab orchestration\n"
         "  hypothesis-lab    Alias for explore-existing\n"
         "  ecm          Canonical ECM catalog (list/describe/package/audit)\n"
@@ -181,6 +183,14 @@ def main(argv: list[str] | None = None) -> int:
         return int(m(rest) or 0)
     if cmd in {"score-monthly", "score_monthly"}:
         from wattlab.energyplus.score_monthly import main as m
+
+        return int(m(rest) or 0)
+    if cmd in {"energyplus-ensure", "energyplus_ensure"}:
+        from wattlab.energyplus.mcp_runtime import main_ensure as m
+
+        return int(m(rest) or 0)
+    if cmd in {"mcp-exec", "mcp_exec"}:
+        from wattlab.energyplus.mcp_runtime import main_mcp_exec as m
 
         return int(m(rest) or 0)
     if cmd in {"explore-existing", "hypothesis-lab"}:

--- a/vibe_code_apps_20/wattlab/config.py
+++ b/vibe_code_apps_20/wattlab/config.py
@@ -83,6 +83,29 @@ THIRD_PARTY = ROOT / "third_party"
 ENERGYPLUS_MCP = THIRD_PARTY / "EnergyPlus-MCP"
 
 DOCKER_IMAGE = (os.environ.get("ENERGYPLUS_MCP_IMAGE") or "energyplus-mcp-dev").strip()
+
+
+def resolve_energyplus_mcp_path() -> Path:
+    """Locate LBNL EnergyPlus-MCP vendor tree (workspace-first for tip agents).
+
+    Order: ``WATTLAB_ENERGYPLUS_MCP`` → ``$WATTLAB_STUDIO_WORKSPACE/third_party/EnergyPlus-MCP``
+    (if present) → legacy ``ROOT/third_party/EnergyPlus-MCP`` → workspace target if set.
+    """
+    env = (os.environ.get("WATTLAB_ENERGYPLUS_MCP") or "").strip()
+    if env:
+        return Path(env).expanduser().resolve()
+    ws = (os.environ.get("WATTLAB_STUDIO_WORKSPACE") or "").strip()
+    ws_cand = (
+        Path(ws).expanduser().resolve() / "third_party" / "EnergyPlus-MCP" if ws else None
+    )
+    if ws_cand is not None and (ws_cand / "energyplus-mcp-server").is_dir():
+        return ws_cand
+    legacy = ENERGYPLUS_MCP.resolve()
+    if (legacy / "energyplus-mcp-server").is_dir():
+        return legacy
+    if ws_cand is not None:
+        return ws_cand
+    return legacy
 EP_VERSION_PIN = "26.1.0"
 DEFAULT_PROTOTYPE_IDF = PROTOTYPES / "5ZoneAirCooled.idf"
 # Closest bundled TMY3 for Madison WI conceptual screening (no WI EPW in vendor samples).

--- a/vibe_code_apps_20/wattlab/deliverables.py
+++ b/vibe_code_apps_20/wattlab/deliverables.py
@@ -549,8 +549,10 @@ def package_deliverables(
             p = reports / name
             if p.is_file():
                 candidates.append(p)
-        for p in sorted(reports.glob("answers_*.json")):
-            candidates.append(p)
+        # Prefer bootstrap answers path already in candidates; else sole answers_*.json
+        extras = sorted(reports.glob("answers_*.json"))
+        if len(extras) == 1:
+            candidates.append(extras[0])
     except Exception:  # noqa: BLE001
         pass
     seen: set[str] = set()

--- a/vibe_code_apps_20/wattlab/deliverables.py
+++ b/vibe_code_apps_20/wattlab/deliverables.py
@@ -545,17 +545,12 @@ def package_deliverables(
         from wattlab.studio.workspace import reports_dir
 
         reports = reports_dir()
-        for name in (
-            "answers.json",
-            "answers_building_100.json",
-            "answers_building_50.json",
-            "utility_bills.csv",
-            "session_status.json",
-            "ecm_scenario.json",
-        ):
+        for name in ("answers.json", "utility_bills.csv", "session_status.json", "ecm_scenario.json"):
             p = reports / name
             if p.is_file():
                 candidates.append(p)
+        for p in sorted(reports.glob("answers_*.json")):
+            candidates.append(p)
     except Exception:  # noqa: BLE001
         pass
     seen: set[str] = set()

--- a/vibe_code_apps_20/wattlab/energyplus/dial_loads.py
+++ b/vibe_code_apps_20/wattlab/energyplus/dial_loads.py
@@ -1,8 +1,8 @@
 """Dial zone lights / electric equipment / infiltration on an existing IDF.
 
-Uses LBNL EnergyPlus-MCP ``EnergyPlusManager`` when available (full MCP tree /
-``energyplus-mcp-dev`` one-shot). Tip GHCR alone is ``simulate_only`` — run this
-inside the MCP docker workspace, then simulate with WattLab DinD.
+Uses LBNL EnergyPlus-MCP ``EnergyPlusManager`` when importable; otherwise
+auto-routes through ``wattlab mcp-exec`` (``energyplus-mcp-dev``). Run
+``wattlab energyplus-ensure`` once per host so capability is ``ready``.
 
     wattlab dial-loads --src model.idf --dst dialed.idf --lights 4.5 --equip 4.2 --infil-mult 1.4
 """
@@ -16,26 +16,15 @@ from pathlib import Path
 from typing import Any
 
 
-def dial_loads_mcp(
+def _dial_local(
     src_idf: Path,
     dst_idf: Path,
     *,
     lights_w_per_m2: float,
     equip_w_per_m2: float,
-    infil_mult: float | None = None,
+    infil_mult: float | None,
+    EnergyPlusManager: Any,
 ) -> dict[str, Any]:
-    """Apply Watts/Area lights+equip and optional infiltration multiplier via MCP."""
-    try:
-        from energyplus_mcp_server.energyplus_tools import EnergyPlusManager
-    except ImportError as exc:  # pragma: no cover
-        raise RuntimeError(
-            "EnergyPlus MCP not importable. Tip image is simulate_only — run dial-loads "
-            "inside energyplus-mcp-dev with third_party/EnergyPlus-MCP mounted, e.g.\n"
-            "  docker run --rm -v $WORKSPACE:/data -v $REPO/third_party/EnergyPlus-MCP:/workspace "
-            "-w /workspace/energyplus-mcp-server --entrypoint bash energyplus-mcp-dev "
-            "-lc 'uv run wattlab dial-loads …'"
-        ) from exc
-
     src_idf = Path(src_idf)
     dst_idf = Path(dst_idf)
     dst_idf.parent.mkdir(parents=True, exist_ok=True)
@@ -91,8 +80,41 @@ def dial_loads_mcp(
         "infil_mult": None if infil_mult is None else float(infil_mult),
         "src": str(src_idf),
         "dst": str(dst_idf),
+        "via": "local",
         "hint": "High elec + low gas ⇒ cut internal gains / raise infil — not more 5Zone schedule patches.",
     }
+
+
+def dial_loads_mcp(
+    src_idf: Path,
+    dst_idf: Path,
+    *,
+    lights_w_per_m2: float,
+    equip_w_per_m2: float,
+    infil_mult: float | None = None,
+) -> dict[str, Any]:
+    """Apply Watts/Area lights+equip and optional infiltration multiplier via MCP."""
+    try:
+        from energyplus_mcp_server.energyplus_tools import EnergyPlusManager
+    except ImportError:
+        from wattlab.energyplus.mcp_runtime import dial_loads_via_docker
+
+        return dial_loads_via_docker(
+            Path(src_idf),
+            Path(dst_idf),
+            lights_w_per_m2=lights_w_per_m2,
+            equip_w_per_m2=equip_w_per_m2,
+            infil_mult=infil_mult,
+        )
+
+    return _dial_local(
+        Path(src_idf),
+        Path(dst_idf),
+        lights_w_per_m2=lights_w_per_m2,
+        equip_w_per_m2=equip_w_per_m2,
+        infil_mult=infil_mult,
+        EnergyPlusManager=EnergyPlusManager,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/vibe_code_apps_20/wattlab/energyplus/docker.py
+++ b/vibe_code_apps_20/wattlab/energyplus/docker.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from wattlab.config import DOCKER_IMAGE, ENERGYPLUS_MCP, ROOT
+from wattlab.config import DOCKER_IMAGE, ROOT, resolve_energyplus_mcp_path
 
 # energyplus-mcp-dev image runs as vscode (uid 1000). Studio DinD often creates
 # bind-mounted dirs as root 755 → E+ cannot write eplusout.* under /work/out.
@@ -60,28 +60,17 @@ def ensure_image(*, build: bool = False) -> str:
     """Return image name; optionally build from vendored EnergyPlus-MCP."""
     if image_present():
         return DOCKER_IMAGE
+    vendor = resolve_energyplus_mcp_path()
     if not build:
         raise ImageMissing(
-            f"Docker image '{DOCKER_IMAGE}' not found. Build once from "
-            f"{ENERGYPLUS_MCP}: docker build -t {DOCKER_IMAGE} "
-            f"-f .devcontainer/Dockerfile .devcontainer"
+            f"Docker image '{DOCKER_IMAGE}' not found. Run: wattlab energyplus-ensure "
+            f"(or build from {vendor})"
         )
-    if not ENERGYPLUS_MCP.is_dir():
-        raise ImageMissing(
-            f"Missing {ENERGYPLUS_MCP}. Clone per third_party/VERSION.txt then rebuild."
-        )
-    dockerfile_dir = ENERGYPLUS_MCP / ".devcontainer"
-    cmd = [
-        docker_bin(),
-        "build",
-        "-t",
-        DOCKER_IMAGE,
-        "-f",
-        str(dockerfile_dir / "Dockerfile"),
-        str(dockerfile_dir),
-    ]
-    subprocess.run(cmd, check=True, cwd=str(ENERGYPLUS_MCP))
-    return DOCKER_IMAGE
+    if not vendor.is_dir():
+        raise ImageMissing(f"Missing {vendor}. Run: wattlab energyplus-ensure")
+    from wattlab.energyplus.mcp_runtime import build_energyplus_image
+
+    return build_energyplus_image(vendor)
 
 
 def _win_mount(path: Path) -> str:
@@ -256,8 +245,9 @@ def run_in_container(
     if user:
         args.extend(["--user", user])
     default_mounts: list[tuple[Path, str]] = [(ROOT, "/workspace/app")]
-    if ENERGYPLUS_MCP.is_dir():
-        default_mounts.append((ENERGYPLUS_MCP, "/workspace/EnergyPlus-MCP"))
+    _vendor = resolve_energyplus_mcp_path()
+    if _vendor.is_dir():
+        default_mounts.append((_vendor, "/workspace/EnergyPlus-MCP"))
     for host, container in mounts or default_mounts:
         args.extend(["-v", f"{_win_mount(host)}:{container}"])
     args.extend(["-w", workdir, tag, *cmd])

--- a/vibe_code_apps_20/wattlab/energyplus/geo_idf.py
+++ b/vibe_code_apps_20/wattlab/energyplus/geo_idf.py
@@ -1,16 +1,17 @@
 """Adapt a DOE Large Office (or similar) IDF to site-scale massing.
 
-Generalized from the Liberty B100 geometry campaign: mid-floor multipliers,
-XY scale to target conditioned area, fenestration height strip for WWR target,
-optional Site:Location + SHGC patches. No Liberty hardcodes — all via CLI args.
-
-Typical:
+Generalized geometry ladder: mid-floor multipliers, XY scale to target conditioned
+area, fenestration height strip for WWR target, optional Site:Location + SHGC.
+No site hardcodes — stories/WWR/area/lat/lon via CLI args.
 
     wattlab geo-idf \\
       --src uploads/prototypes/RefBldgLargeOfficeNew2004_Chicago.idf \\
       --dst uploads/prototypes/geo_site.idf \\
-      --target-area-ft2 140000 --stories 6 --wwr 0.60 \\
-      --lat 42.33 --lon -83.05 --site-name Detroit_MI
+      --target-area-ft2 <ft2> --stories <N> --wwr <0-1> \\
+      --lat <deg> --lon <deg> --site-name <Name>
+
+Practice example (Liberty B100 rehearsal only — do not reuse as defaults):
+  --target-area-ft2 140000 --stories 6 --wwr 0.60 --lat 42.33 --lon -83.05
 """
 
 from __future__ import annotations
@@ -205,17 +206,17 @@ def build_site_scale_idf(
     dst: Path,
     *,
     target_area_ft2: float,
-    stories: int = 6,
+    stories: int,
     floorplate_ft2: float = DEFAULT_FLOORPLATE_FT2,
-    wwr: float = 0.60,
+    wwr: float,
     mid_zones: list[str] | None = None,
     lat: float | None = None,
     lon: float | None = None,
-    elevation_m: float = 190.0,
-    tz_hr: float = -5.0,
+    elevation_m: float | None = None,
+    tz_hr: float | None = None,
     site_name: str | None = None,
     building_name: str | None = None,
-    shgc: float | None = 0.45,
+    shgc: float | None = None,
     enable_weather_run: bool = True,
     header_note: str | None = None,
 ) -> dict[str, Any]:
@@ -273,14 +274,16 @@ def build_site_scale_idf(
 
     if lat is not None and lon is not None:
         name = site_name or f"Site_{lat}_{lon}"
+        tz = 0.0 if tz_hr is None else float(tz_hr)
+        elev = 0.0 if elevation_m is None else float(elevation_m)
         text = re.sub(
             r"  Site:Location,\n    [^;]+;",
             f"""  Site:Location,
     {name},  !- Name
     {float(lat):.4f},                   !- Latitude {{deg}}
     {float(lon):.4f},                  !- Longitude {{deg}}
-    {float(tz_hr):.2f},                   !- Time Zone {{hr}}
-    {float(elevation_m):.2f};                  !- Elevation {{m}}""",
+    {tz:.2f},                   !- Time Zone {{hr}}
+    {elev:.2f};                  !- Elevation {{m}}""",
             text,
             count=1,
             flags=re.M,
@@ -340,25 +343,28 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--src", required=True, help="Source prototype IDF (e.g. DOE Large Office)")
     p.add_argument("--dst", required=True, help="Output site-scale IDF path")
     p.add_argument("--target-area-ft2", type=float, required=True)
-    p.add_argument("--stories", type=int, default=6)
+    p.add_argument("--stories", type=int, required=True)
     p.add_argument(
         "--floorplate-ft2",
         type=float,
         default=DEFAULT_FLOORPLATE_FT2,
         help="Source conditioned floorplate ft² (DOE Large Office ≈ 38476)",
     )
-    p.add_argument("--wwr", type=float, default=0.60)
+    p.add_argument("--wwr", type=float, required=True)
     p.add_argument("--lat", type=float, default=None)
     p.add_argument("--lon", type=float, default=None)
-    p.add_argument("--tz", type=float, default=-5.0)
-    p.add_argument("--elevation-m", type=float, default=190.0)
+    p.add_argument("--tz", type=float, default=None, help="Timezone hours (with --lat/--lon)")
+    p.add_argument(
+        "--elevation-m", type=float, default=None, help="Elevation m (with --lat/--lon)"
+    )
     p.add_argument("--site-name", default=None)
     p.add_argument("--building-name", default=None)
-    p.add_argument("--shgc", type=float, default=0.45)
-    p.add_argument("--no-shgc", action="store_true")
+    p.add_argument("--shgc", type=float, default=None, help="Optional glazing SHGC patch")
+    p.add_argument("--no-shgc", action="store_true", help="Explicitly skip SHGC patch")
     p.add_argument("--meta-out", default=None, help="Write provenance JSON")
     args = p.parse_args(argv)
 
+    shgc = None if args.no_shgc else args.shgc
     meta = build_site_scale_idf(
         Path(args.src),
         Path(args.dst),
@@ -372,7 +378,7 @@ def main(argv: list[str] | None = None) -> int:
         tz_hr=args.tz,
         site_name=args.site_name,
         building_name=args.building_name,
-        shgc=None if args.no_shgc else args.shgc,
+        shgc=shgc,
     )
     print(json.dumps(meta, indent=2))
     if args.meta_out:

--- a/vibe_code_apps_20/wattlab/energyplus/geo_idf.py
+++ b/vibe_code_apps_20/wattlab/energyplus/geo_idf.py
@@ -5,13 +5,10 @@ area, fenestration height strip for WWR target, optional Site:Location + SHGC.
 No site hardcodes — stories/WWR/area/lat/lon via CLI args.
 
     wattlab geo-idf \\
-      --src uploads/prototypes/RefBldgLargeOfficeNew2004_Chicago.idf \\
+      --src uploads/prototypes/<DOE_LargeOffice>.idf \\
       --dst uploads/prototypes/geo_site.idf \\
       --target-area-ft2 <ft2> --stories <N> --wwr <0-1> \\
-      --lat <deg> --lon <deg> --site-name <Name>
-
-Practice example (Liberty B100 rehearsal only — do not reuse as defaults):
-  --target-area-ft2 140000 --stories 6 --wwr 0.60 --lat 42.33 --lon -83.05
+      --lat <deg> --lon <deg> --tz <hr> --elevation-m <m> --site-name <Name>
 """
 
 from __future__ import annotations
@@ -273,9 +270,14 @@ def build_site_scale_idf(
         )
 
     if lat is not None and lon is not None:
+        if tz_hr is None or elevation_m is None:
+            raise ValueError(
+                "Site:Location patch needs --tz and --elevation-m with --lat/--lon "
+                "(do not invent 0.0 timezone/elevation)"
+            )
         name = site_name or f"Site_{lat}_{lon}"
-        tz = 0.0 if tz_hr is None else float(tz_hr)
-        elev = 0.0 if elevation_m is None else float(elevation_m)
+        tz = float(tz_hr)
+        elev = float(elevation_m)
         text = re.sub(
             r"  Site:Location,\n    [^;]+;",
             f"""  Site:Location,

--- a/vibe_code_apps_20/wattlab/energyplus/mcp.py
+++ b/vibe_code_apps_20/wattlab/energyplus/mcp.py
@@ -1,11 +1,8 @@
 ﻿"""Thin helpers mirroring EnergyPlus-MCP capabilities via Docker CLI / uv.
 
-Prefer driving the same toolkit the MCP server uses when the vendor tree is present.
-Full interactive MCP tool use is available via Cursor MCP config (see third_party/README.md).
-
-WattLab's in-package surface is **simulate-via-Docker**. Inspect/modify/plot tools
-from the LBNL EnergyPlus-MCP server require a cloned vendor tree + Cursor MCP —
-they are not reimplemented here.
+Production path: ``wattlab energyplus-ensure`` then MCP inspect/modify via
+``wattlab mcp-exec`` / ``wattlab dial-loads`` (docker ``energyplus-mcp-dev``),
+annual sims via WattLab DinD. Capability ``ready`` means image + vendor present.
 """
 
 from __future__ import annotations
@@ -16,7 +13,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from wattlab.config import DOCKER_IMAGE, ENERGYPLUS_MCP, THIRD_PARTY
+from wattlab.config import DOCKER_IMAGE, THIRD_PARTY, resolve_energyplus_mcp_path
 from wattlab.energyplus.docker import (
     DockerUnavailable,
     docker_bin,
@@ -25,22 +22,32 @@ from wattlab.energyplus.docker import (
     image_present,
     run_energyplus,
 )
+from wattlab.energyplus.mcp_runtime import mcp_vendor_ready as _mcp_vendor_ready_runtime
+
+
+def mcp_vendor_path() -> Path:
+    return resolve_energyplus_mcp_path()
 
 
 def mcp_vendor_ready() -> bool:
-    return (ENERGYPLUS_MCP / "energyplus-mcp-server").is_dir()
+    return _mcp_vendor_ready_runtime(mcp_vendor_path())
 
 
 def mcp_vendor_readme() -> Path | None:
     readme = THIRD_PARTY / "README.md"
-    return readme if readme.is_file() else None
+    if readme.is_file():
+        return readme
+    vend = mcp_vendor_path().parent / "README.md"
+    return vend if vend.is_file() else None
 
 
 def capability_status(*, probe_docker: bool = True) -> dict[str, Any]:
-    """Honest capability report: image?, vendor clone?, simulate-only vs full MCP.
+    """Honest capability report: ``ready`` | ``image_missing`` | ``vendor_missing`` | ``unavailable``.
 
     Does not pull/build images. Optional Docker probe is best-effort and never raises.
+    Run ``wattlab energyplus-ensure`` to reach ``ready``.
     """
+    vendor_path = mcp_vendor_path()
     vendor = mcp_vendor_ready()
     docker_ok = False
     img = False
@@ -55,31 +62,35 @@ def capability_status(*, probe_docker: bool = True) -> dict[str, Any]:
             docker_ok = False
             img = False
 
-    if img and vendor:
-        mode = "full_mcp_available"
+    if not docker_ok and probe_docker:
+        mode = "unavailable"
         note = (
-            "Docker image present and vendor clone ready — WattLab can simulate; "
-            "Cursor MCP can expose full inspect/modify/plot tools "
-            "(see third_party/README.md)."
+            "Docker daemon not available. Install Docker, mount docker.sock into vibe20, "
+            "set WATTLAB_HOST_WORKSPACE, then run: wattlab energyplus-ensure"
         )
-    elif img:
-        mode = "simulate_only"
+    elif img and vendor:
+        mode = "ready"
         note = (
-            "Docker image present — WattLab batch simulate works. "
-            "Full LBNL MCP inspect/modify/plot tools need a vendor clone "
-            f"at {ENERGYPLUS_MCP}."
+            "EnergyPlus MCP ready — DinD annual sims + mcp-exec/dial-loads inspect/modify. "
+            "Use wattlab energyplus-ensure if tools fail after a host reboot."
         )
-    elif vendor:
-        mode = "vendor_only_no_image"
+    elif vendor and not img:
+        mode = "image_missing"
         note = (
-            "Vendor clone present but Docker image missing — build "
-            f"{DOCKER_IMAGE} per third_party/README.md before live sims."
+            f"Vendor clone present at {vendor_path} but Docker image '{DOCKER_IMAGE}' "
+            "missing — run: wattlab energyplus-ensure"
+        )
+    elif img and not vendor:
+        mode = "vendor_missing"
+        note = (
+            f"Docker image present but EnergyPlus-MCP vendor missing "
+            f"(expected under {vendor_path}). Run: wattlab energyplus-ensure"
         )
     else:
         mode = "unavailable"
         note = (
-            "No Docker image and no vendor clone — install Docker, build "
-            f"{DOCKER_IMAGE}, and optionally clone EnergyPlus-MCP for full MCP tools."
+            "No Docker image and no vendor clone — run: wattlab energyplus-ensure "
+            f"(clones pin into workspace third_party and builds {DOCKER_IMAGE})."
         )
 
     return {
@@ -87,7 +98,7 @@ def capability_status(*, probe_docker: bool = True) -> dict[str, Any]:
         "docker_available": docker_ok,
         "image_present": img,
         "vendor_present": vendor,
-        "vendor_path": str(ENERGYPLUS_MCP),
+        "vendor_path": str(vendor_path),
         "vendor_readme": str(mcp_vendor_readme()) if mcp_vendor_readme() else None,
         "capability": mode,
         "simulate_via_docker": bool(img),
@@ -102,7 +113,7 @@ def capability_status(*, probe_docker: bool = True) -> dict[str, Any]:
 
 
 def cursor_mcp_config_snippet(host_mcp_path: Path | None = None) -> dict[str, Any]:
-    root = host_mcp_path or ENERGYPLUS_MCP
+    root = host_mcp_path or mcp_vendor_path()
     win = str(root.resolve()).replace("\\", "\\\\")
     return {
         "mcpServers": {
@@ -153,7 +164,9 @@ def get_server_status_via_docker(*, check_mcp_import: bool = False) -> dict[str,
         status["error"] = str(exc)
 
     if check_mcp_import and mcp_vendor_ready() and status.get("image_present"):
-        mount = str(ENERGYPLUS_MCP.resolve()).replace("\\", "/")
+        from wattlab.config import host_path_for_docker
+
+        mount = str(host_path_for_docker(mcp_vendor_path())).replace("\\", "/")
         ir = subprocess.run(
             [
                 docker_bin(),
@@ -219,7 +232,6 @@ def align_idf_to_epw(
             "out": str(idf),
         }
     dest = Path(out_idf) if out_idf is not None else idf.with_name(f"{idf.stem}_epw_aligned.idf")
-    # Prefer exact data-row dates (not header month/day without year).
     begin = span["begin"]
     end = span["end"]
     meta = apply_run_period(idf, dest, begin=begin, end=end)
@@ -259,7 +271,6 @@ def simulate(
     if align_run_period:
         try:
             aligned_path = output_dir.parent / f"{output_dir.name}__epw_aligned.idf"
-            # ensure parent exists for aligned idf (writable)
             from wattlab.energyplus.docker import ensure_ep_writable
 
             ensure_ep_writable(output_dir.parent)

--- a/vibe_code_apps_20/wattlab/energyplus/mcp_runtime.py
+++ b/vibe_code_apps_20/wattlab/energyplus/mcp_runtime.py
@@ -1,0 +1,430 @@
+"""Ensure EnergyPlus-MCP vendor + image; run MCP tools via docker (production path).
+
+Agents use this the same way a human would: ``wattlab energyplus-ensure`` once per
+host, then ``wattlab mcp-exec`` / ``wattlab dial-loads`` for IDF surgery. Annual
+sims stay on WattLab DinD (``run_energyplus``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from wattlab.config import (
+    DOCKER_IMAGE,
+    ROOT,
+    THIRD_PARTY,
+    artifacts_root,
+    host_path_for_docker,
+    resolve_energyplus_mcp_path,
+)
+from wattlab.energyplus.docker import (
+    DockerUnavailable,
+    docker_bin,
+    docker_info_ok,
+    image_present,
+)
+
+
+def parse_version_pin(pin_file: Path | None = None) -> dict[str, str]:
+    """Parse ``third_party/VERSION.txt`` (repo URL, commit, image)."""
+    path = pin_file or (THIRD_PARTY / "VERSION.txt")
+    if not path.is_file():
+        # Tip image may lack VERSION.txt beside workspace clone — fall back to ROOT
+        alt = ROOT / "third_party" / "VERSION.txt"
+        path = alt if alt.is_file() else path
+    text = path.read_text(encoding="utf-8") if path.is_file() else ""
+    repo = "https://github.com/LBNL-ETA/EnergyPlus-MCP"
+    commit = ""
+    image = DOCKER_IMAGE
+    for line in text.splitlines():
+        if line.lower().startswith("repo:"):
+            repo = line.split(":", 1)[1].strip()
+        elif line.lower().startswith("commit:"):
+            commit = line.split(":", 1)[1].strip()
+        elif line.lower().startswith("image:"):
+            image = line.split(":", 1)[1].strip() or image
+    return {"repo": repo, "commit": commit, "image": image, "pin_file": str(path)}
+
+
+def default_vendor_target() -> Path:
+    """Preferred clone destination for tip agents (shared workspace)."""
+    env = (os.environ.get("WATTLAB_ENERGYPLUS_MCP") or "").strip()
+    if env:
+        return Path(env).expanduser().resolve()
+    ws = (os.environ.get("WATTLAB_STUDIO_WORKSPACE") or "").strip()
+    if ws:
+        return Path(ws).expanduser().resolve() / "third_party" / "EnergyPlus-MCP"
+    return (ROOT / "third_party" / "EnergyPlus-MCP").resolve()
+
+
+def mcp_vendor_path() -> Path:
+    return resolve_energyplus_mcp_path()
+
+
+def mcp_vendor_ready(path: Path | None = None) -> bool:
+    p = path or mcp_vendor_path()
+    return (Path(p) / "energyplus-mcp-server").is_dir()
+
+
+def _git_bin() -> str:
+    exe = __import__("shutil").which("git")
+    if not exe:
+        raise RuntimeError("git not found on PATH — required to clone EnergyPlus-MCP")
+    return exe
+
+
+def clone_or_checkout_vendor(
+    dest: Path | None = None,
+    *,
+    pin: dict[str, str] | None = None,
+) -> Path:
+    """Clone LBNL EnergyPlus-MCP at the pinned commit into ``dest``."""
+    pin = pin or parse_version_pin()
+    dest = Path(dest) if dest is not None else default_vendor_target()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    git = _git_bin()
+    commit = (pin.get("commit") or "").strip()
+    repo = pin["repo"]
+    if not (dest / ".git").is_dir():
+        if dest.exists() and any(dest.iterdir()):
+            raise RuntimeError(
+                f"Vendor path {dest} exists but is not a git clone. "
+                "Remove it or set WATTLAB_ENERGYPLUS_MCP to a clean path."
+            )
+        subprocess.run(
+            [git, "clone", repo, str(dest)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    subprocess.run(
+        [git, "-C", str(dest), "fetch", "--all", "--tags"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if commit:
+        subprocess.run(
+            [git, "-C", str(dest), "checkout", commit],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    if not (dest / "energyplus-mcp-server").is_dir():
+        raise RuntimeError(f"Clone incomplete — missing energyplus-mcp-server under {dest}")
+    return dest
+
+
+def build_energyplus_image(vendor: Path | None = None) -> str:
+    """Build ``energyplus-mcp-dev`` with explicit TARGETPLATFORM (required by upstream)."""
+    vendor = Path(vendor) if vendor is not None else mcp_vendor_path()
+    if not (vendor / ".devcontainer" / "Dockerfile").is_file():
+        raise RuntimeError(
+            f"Missing {vendor / '.devcontainer' / 'Dockerfile'}. "
+            "Run wattlab energyplus-ensure first."
+        )
+    machine = platform.machine().lower()
+    if machine in {"aarch64", "arm64"}:
+        plat = "linux/arm64"
+    else:
+        plat = os.environ.get("TARGETPLATFORM") or "linux/amd64"
+    cmd = [
+        docker_bin(),
+        "build",
+        "--build-arg",
+        f"TARGETPLATFORM={plat}",
+        "-t",
+        DOCKER_IMAGE,
+        "-f",
+        str(vendor / ".devcontainer" / "Dockerfile"),
+        str(vendor / ".devcontainer"),
+    ]
+    subprocess.run(cmd, check=True)
+    return DOCKER_IMAGE
+
+
+def energyplus_ensure(
+    *,
+    clone: bool = True,
+    build: bool = True,
+    dest: Path | None = None,
+) -> dict[str, Any]:
+    """Ensure vendor clone + Docker image. Fail loud — never soft-fall to sim-only."""
+    pin = parse_version_pin()
+    out: dict[str, Any] = {
+        "pin": pin,
+        "image": DOCKER_IMAGE,
+        "vendor_path": None,
+        "vendor_ready": False,
+        "image_present": False,
+        "docker_available": False,
+        "actions": [],
+        "ok": False,
+    }
+    if not docker_info_ok():
+        out["error"] = (
+            "Docker daemon not available. Install Docker and expose the sock to vibe20 "
+            "(WATTLAB_HOST_WORKSPACE + /var/run/docker.sock)."
+        )
+        return out
+    out["docker_available"] = True
+
+    target = Path(dest) if dest is not None else default_vendor_target()
+    if mcp_vendor_ready(target):
+        vendor = target
+        out["actions"].append("vendor_already_present")
+    elif mcp_vendor_ready():
+        vendor = mcp_vendor_path()
+        out["actions"].append("vendor_found_via_resolve")
+    elif clone:
+        vendor = clone_or_checkout_vendor(target, pin=pin)
+        out["actions"].append(f"cloned:{vendor}")
+    else:
+        out["error"] = (
+            f"EnergyPlus-MCP vendor missing at {target}. "
+            "Re-run: wattlab energyplus-ensure"
+        )
+        out["vendor_path"] = str(target)
+        return out
+
+    out["vendor_path"] = str(vendor)
+    out["vendor_ready"] = mcp_vendor_ready(vendor)
+
+    if image_present():
+        out["image_present"] = True
+        out["actions"].append("image_already_present")
+    elif build:
+        build_energyplus_image(vendor)
+        out["image_present"] = image_present()
+        out["actions"].append("built_image")
+    else:
+        out["error"] = (
+            f"Docker image '{DOCKER_IMAGE}' missing. "
+            "Re-run: wattlab energyplus-ensure  (builds once from vendor pin)"
+        )
+        return out
+
+    out["ok"] = bool(out["vendor_ready"] and out["image_present"])
+    if not out["ok"] and "error" not in out:
+        out["error"] = "ensure incomplete — vendor or image still missing"
+    return out
+
+
+def _container_data_path(path: Path) -> str:
+    """Map a host/container workspace path to ``/data/...`` inside mcp-exec."""
+    p = Path(path).resolve()
+    ws = (os.environ.get("WATTLAB_STUDIO_WORKSPACE") or "").strip()
+    if ws:
+        cont = Path(ws).expanduser().resolve()
+        try:
+            rel = p.relative_to(cont)
+            return "/data/" + rel.as_posix()
+        except ValueError:
+            pass
+    host_ws = (os.environ.get("WATTLAB_HOST_WORKSPACE") or "").strip()
+    if host_ws:
+        try:
+            rel = p.relative_to(Path(host_ws).expanduser().resolve())
+            return "/data/" + rel.as_posix()
+        except ValueError:
+            pass
+    # Fall back: absolute path as-is (host docker without remapping)
+    return str(p).replace("\\", "/")
+
+
+def mcp_exec(
+    argv: list[str],
+    *,
+    timeout: int | None = 600,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``uv run <argv>`` inside energyplus-mcp-dev with vendor + /data mounts."""
+    if not argv:
+        raise ValueError("mcp_exec requires a command argv")
+    if not docker_info_ok():
+        raise DockerUnavailable("Docker daemon not available for mcp-exec")
+    if not image_present():
+        raise RuntimeError(
+            f"Image '{DOCKER_IMAGE}' missing — run: wattlab energyplus-ensure"
+        )
+    vendor = mcp_vendor_path()
+    if not mcp_vendor_ready(vendor):
+        raise RuntimeError(
+            f"Vendor missing at {vendor} — run: wattlab energyplus-ensure"
+        )
+
+    vendor_host = host_path_for_docker(vendor)
+    ws = (os.environ.get("WATTLAB_STUDIO_WORKSPACE") or "").strip()
+    host_ws = (os.environ.get("WATTLAB_HOST_WORKSPACE") or "").strip()
+    if host_ws:
+        data_host = Path(host_ws).expanduser().resolve()
+    elif ws:
+        data_host = host_path_for_docker(Path(ws))
+    else:
+        data_host = host_path_for_docker(artifacts_root().parent)
+
+    cmd = [
+        docker_bin(),
+        "run",
+        "--rm",
+        "-v",
+        f"{str(data_host).replace(chr(92), '/')}:/data",
+        "-v",
+        f"{str(vendor_host).replace(chr(92), '/')}:/workspace",
+        "-w",
+        "/workspace/energyplus-mcp-server",
+        DOCKER_IMAGE,
+        "uv",
+        "run",
+        *argv,
+    ]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def dial_loads_via_docker(
+    src_idf: Path,
+    dst_idf: Path,
+    *,
+    lights_w_per_m2: float,
+    equip_w_per_m2: float,
+    infil_mult: float | None = None,
+) -> dict[str, Any]:
+    """Apply load dials inside energyplus-mcp-dev (no local EnergyPlusManager)."""
+    src_idf = Path(src_idf).resolve()
+    dst_idf = Path(dst_idf).resolve()
+    dst_idf.parent.mkdir(parents=True, exist_ok=True)
+
+    # Ensure paths live under workspace so /data mount sees them
+    src_c = _container_data_path(src_idf)
+    dst_c = _container_data_path(dst_idf)
+    if not src_c.startswith("/data"):
+        # Copy into artifacts so DinD mount can read
+        art = artifacts_root() / "mcp_dial"
+        art.mkdir(parents=True, exist_ok=True)
+        staged_src = art / src_idf.name
+        staged_src.write_bytes(src_idf.read_bytes())
+        staged_dst = art / (dst_idf.stem + "_out.idf")
+        src_c = _container_data_path(staged_src)
+        dst_c = _container_data_path(staged_dst)
+        copy_back = staged_dst
+    else:
+        copy_back = None
+
+    infil_expr = "None" if infil_mult is None else repr(float(infil_mult))
+    py = f"""
+import json, shutil
+from pathlib import Path
+from energyplus_mcp_server.energyplus_tools import EnergyPlusManager
+
+src = Path({src_c!r})
+dst = Path({dst_c!r})
+dst.parent.mkdir(parents=True, exist_ok=True)
+tmp = dst.with_name(dst.stem + "_mcp_tmp.idf")
+if tmp.exists():
+    tmp.unlink()
+shutil.copy2(src, tmp)
+ep = EnergyPlusManager()
+r1 = ep.modify_lights(str(tmp), [{{"target": "all", "field_updates": {{
+    "Design_Level_Calculation_Method": "Watts/Area",
+    "Watts_per_Floor_Area": {float(lights_w_per_m2)},
+}}}}], output_path=str(tmp))
+r2 = ep.modify_electric_equipment(str(tmp), [{{"target": "all", "field_updates": {{
+    "Design_Level_Calculation_Method": "Watts/Area",
+    "Watts_per_Floor_Area": {float(equip_w_per_m2)},
+}}}}], output_path=str(tmp))
+r3 = None
+infil = {infil_expr}
+if infil is not None and float(infil) != 1.0:
+    r3 = ep.change_infiltration_by_mult(str(tmp), float(infil), output_path=str(tmp))
+shutil.copy2(tmp, dst)
+try:
+    tmp.unlink()
+except OSError:
+    pass
+print(json.dumps({{
+    "lights": str(r1)[:500],
+    "equip": str(r2)[:500],
+    "infil": None if r3 is None else str(r3)[:500],
+    "lights_w_per_m2": {float(lights_w_per_m2)},
+    "equip_w_per_m2": {float(equip_w_per_m2)},
+    "infil_mult": infil,
+    "src": str(src),
+    "dst": str(dst),
+    "via": "mcp-exec",
+}}))
+"""
+    proc = mcp_exec(["python", "-c", py], check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "dial-loads via mcp-exec failed:\n"
+            + (proc.stderr or "")[-2000:]
+            + "\n"
+            + (proc.stdout or "")[-1000:]
+        )
+    # Last JSON line
+    lines = [ln for ln in (proc.stdout or "").splitlines() if ln.strip().startswith("{")]
+    if not lines:
+        raise RuntimeError(f"dial-loads mcp-exec returned no JSON: {(proc.stdout or '')[-500:]}")
+    meta = json.loads(lines[-1])
+    if copy_back is not None and copy_back.is_file():
+        dst_idf.write_bytes(copy_back.read_bytes())
+        meta["dst"] = str(dst_idf)
+    meta["hint"] = (
+        "High elec + low gas ⇒ cut internal gains / raise infil — not more 5Zone schedule patches."
+    )
+    return meta
+
+
+def main_ensure(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="wattlab energyplus-ensure",
+        description="Clone pinned EnergyPlus-MCP + build energyplus-mcp-dev (once per host).",
+    )
+    p.add_argument("--dest", default=None, help="Vendor clone path (default: workspace/third_party)")
+    p.add_argument("--no-clone", action="store_true")
+    p.add_argument("--no-build", action="store_true")
+    args = p.parse_args(argv)
+    meta = energyplus_ensure(
+        clone=not args.no_clone,
+        build=not args.no_build,
+        dest=Path(args.dest) if args.dest else None,
+    )
+    print(json.dumps(meta, indent=2))
+    return 0 if meta.get("ok") else 1
+
+
+def main_mcp_exec(argv: list[str] | None = None) -> int:
+    """wattlab mcp-exec -- python -c '…'   (args after -- go to uv run)."""
+    raw = list(argv) if argv is not None else sys.argv[1:]
+    if raw and raw[0] == "--":
+        raw = raw[1:]
+    if not raw:
+        print(
+            "usage: wattlab mcp-exec -- <uv-run-args…>\n"
+            "example: wattlab mcp-exec -- python -c \"import energyplus_mcp_server; print('ok')\"",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        proc = mcp_exec(raw, check=False)
+    except Exception as exc:  # noqa: BLE001
+        print(str(exc), file=sys.stderr)
+        return 1
+    if proc.stdout:
+        print(proc.stdout, end="" if proc.stdout.endswith("\n") else "\n")
+    if proc.stderr:
+        print(proc.stderr, end="" if proc.stderr.endswith("\n") else "\n", file=sys.stderr)
+    return int(proc.returncode)

--- a/vibe_code_apps_20/wattlab/energyplus/mcp_runtime.py
+++ b/vibe_code_apps_20/wattlab/energyplus/mcp_runtime.py
@@ -103,12 +103,14 @@ def clone_or_checkout_vendor(
             check=True,
             capture_output=True,
             text=True,
+            timeout=600,
         )
     subprocess.run(
         [git, "-C", str(dest), "fetch", "--all", "--tags"],
         check=True,
         capture_output=True,
         text=True,
+        timeout=600,
     )
     if commit:
         subprocess.run(
@@ -116,6 +118,7 @@ def clone_or_checkout_vendor(
             check=True,
             capture_output=True,
             text=True,
+            timeout=120,
         )
     if not (dest / "energyplus-mcp-server").is_dir():
         raise RuntimeError(f"Clone incomplete — missing energyplus-mcp-server under {dest}")
@@ -146,7 +149,7 @@ def build_energyplus_image(vendor: Path | None = None) -> str:
         str(vendor / ".devcontainer" / "Dockerfile"),
         str(vendor / ".devcontainer"),
     ]
-    subprocess.run(cmd, check=True)
+    subprocess.run(cmd, check=True, timeout=3600)
     return DOCKER_IMAGE
 
 
@@ -220,22 +223,24 @@ def energyplus_ensure(
 def _container_data_path(path: Path) -> str:
     """Map a host/container workspace path to ``/data/...`` inside mcp-exec."""
     p = Path(path).resolve()
+    roots: list[Path] = []
     ws = (os.environ.get("WATTLAB_STUDIO_WORKSPACE") or "").strip()
     if ws:
-        cont = Path(ws).expanduser().resolve()
-        try:
-            rel = p.relative_to(cont)
-            return "/data/" + rel.as_posix()
-        except ValueError:
-            pass
+        roots.append(Path(ws).expanduser().resolve())
     host_ws = (os.environ.get("WATTLAB_HOST_WORKSPACE") or "").strip()
     if host_ws:
+        roots.append(Path(host_ws).expanduser().resolve())
+    # Same fallback mcp_exec mounts when env vars are unset
+    try:
+        roots.append(artifacts_root().parent.resolve())
+    except Exception:  # noqa: BLE001
+        pass
+    for root in roots:
         try:
-            rel = p.relative_to(Path(host_ws).expanduser().resolve())
+            rel = p.relative_to(root)
             return "/data/" + rel.as_posix()
         except ValueError:
-            pass
-    # Fall back: absolute path as-is (host docker without remapping)
+            continue
     return str(p).replace("\\", "/")
 
 

--- a/vibe_code_apps_20/wattlab/studio/eui_charts.py
+++ b/vibe_code_apps_20/wattlab/studio/eui_charts.py
@@ -54,6 +54,36 @@ def month_abbrev_columns(frame_or_cols: Any) -> Any:
     return [month_abbrev(c) for c in frame_or_cols]
 
 
+def plotly_layout_clean(
+    fig: Any,
+    *,
+    title: str | None = None,
+    height: int = 420,
+    yaxis_title: str | None = None,
+    xaxis_title: str | None = None,
+) -> Any:
+    """Apply consistent margins + horizontal legend above the plot (no title clash)."""
+    fig.update_layout(
+        height=int(height),
+        margin=dict(l=64, r=24, t=72 if title else 56, b=48),
+        title=dict(text=title, y=0.98, x=0.01, xanchor="left", yanchor="top") if title else None,
+        yaxis_title=yaxis_title,
+        xaxis_title=xaxis_title,
+        showlegend=True,
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.08,
+            x=0,
+            xanchor="left",
+            bgcolor="rgba(255,255,255,0.75)",
+        ),
+        plot_bgcolor="rgba(0,0,0,0)",
+        font=dict(size=12),
+    )
+    return fig
+
+
 def eui_peer_bullet_figure(
     *,
     peer_p20: float,
@@ -63,7 +93,7 @@ def eui_peer_bullet_figure(
     title: str | None = None,
     height: int | None = None,
 ):
-    """Horizontal bullet/box: peer p20–p80 band + p50 tick; one Y row per series.
+    """Upright peer-band chart: p20–p80 box per category + markers for Bills/Model/….
 
     Each item in ``series`` needs ``label`` and ``eui`` (kBtu/ft²·yr). Optional
     ``color`` (hex) and ``symbol`` (plotly marker symbol).
@@ -78,16 +108,16 @@ def eui_peer_bullet_figure(
     n = len(labels)
     fig = go.Figure()
 
-    # One peer band + p50 per category row (boxplot-like horizontal band)
-    for i, label in enumerate(labels):
+    # Vertical peer band + p50 tick under each category (boxplot-like upright)
+    for i, _label in enumerate(labels):
         fig.add_shape(
             type="rect",
             xref="x",
             yref="y",
-            x0=float(peer_p20),
-            x1=float(peer_p80),
-            y0=i - 0.35,
-            y1=i + 0.35,
+            x0=i - 0.35,
+            x1=i + 0.35,
+            y0=float(peer_p20),
+            y1=float(peer_p80),
             fillcolor="rgba(44,160,44,0.22)",
             line_width=0,
             layer="below",
@@ -96,29 +126,28 @@ def eui_peer_bullet_figure(
             type="line",
             xref="x",
             yref="y",
-            x0=float(peer_p50),
-            x1=float(peer_p50),
-            y0=i - 0.35,
-            y1=i + 0.35,
+            x0=i - 0.35,
+            x1=i + 0.35,
+            y0=float(peer_p50),
+            y1=float(peer_p50),
             line=dict(color="#2ca02c", width=2, dash="dash"),
             layer="below",
         )
 
-    xs = [float(r["eui"]) for r in rows]
+    ys = [float(r["eui"]) for r in rows]
     colors = [str(r.get("color") or "#1f77b4") for r in rows]
     symbols = [str(r.get("symbol") or "diamond") for r in rows]
     fig.add_scatter(
-        x=xs,
-        y=labels,
+        x=labels,
+        y=ys,
         mode="markers+text",
-        marker=dict(size=14, color=colors, symbol=symbols, line=dict(width=1, color="#333")),
-        text=[f"{x:.1f}" for x in xs],
-        textposition="middle right",
+        marker=dict(size=16, color=colors, symbol=symbols, line=dict(width=1, color="#333")),
+        text=[f"{y:.1f}" for y in ys],
+        textposition="top center",
         name="Site EUI",
-        hovertemplate="%{y}: %{x:.1f} kBtu/ft²<extra></extra>",
+        hovertemplate="%{x}: %{y:.1f} kBtu/ft²·yr<extra></extra>",
     )
 
-    # Invisible peer reference for legend clarity
     fig.add_scatter(
         x=[None],
         y=[None],
@@ -134,23 +163,21 @@ def eui_peer_bullet_figure(
         name=f"Peer p50 ({peer_p50:.1f})",
     )
 
-    h = height or max(160, 56 + 44 * n)
-    fig.update_layout(
-        height=h,
-        margin=dict(l=10, r=80, t=40 if title else 16, b=40),
+    h = height or max(420, 360 + 20 * max(0, n - 2))
+    plotly_layout_clean(
+        fig,
         title=title,
-        xaxis_title="Site EUI (kBtu/ft²·yr)",
-        yaxis=dict(
-            categoryorder="array",
-            categoryarray=list(reversed(labels)),
-            automargin=True,
-        ),
-        showlegend=True,
-        legend=dict(orientation="h", yanchor="bottom", y=1.02, x=0),
-        plot_bgcolor="rgba(0,0,0,0)",
+        height=h,
+        yaxis_title="Site EUI (kBtu/ft²·yr)",
+        xaxis_title=None,
     )
-    xmax = max(float(peer_p80), max(xs) if xs else float(peer_p80)) * 1.15
-    xmin = min(0.0, float(peer_p20) * 0.85, min(xs) if xs else 0.0)
-    fig.update_xaxes(range=[xmin, xmax], showgrid=True, gridcolor="rgba(0,0,0,0.08)")
-    fig.update_yaxes(showgrid=False)
+    ymax = max(float(peer_p80), max(ys) if ys else float(peer_p80)) * 1.18
+    ymin = min(0.0, float(peer_p20) * 0.85, min(ys) if ys else 0.0)
+    fig.update_yaxes(range=[ymin, ymax], showgrid=True, gridcolor="rgba(0,0,0,0.08)")
+    fig.update_xaxes(
+        categoryorder="array",
+        categoryarray=labels,
+        showgrid=False,
+        automargin=True,
+    )
     return fig

--- a/vibe_code_apps_20/wattlab/studio/g14_history.py
+++ b/vibe_code_apps_20/wattlab/studio/g14_history.py
@@ -1,0 +1,201 @@
+"""G14 calibration history across published Twin runs (epoch / loss-style chart)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from wattlab.studio.eui_charts import plotly_layout_clean
+from wattlab.studio.ep_viz import list_iteration_runs, read_run_progress
+
+G14_NMBE_GATE = 5.0
+G14_CVRMSE_GATE = 15.0
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+
+
+def _g14_from_scorecard(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract NMBE/CVRMSE from calibration_scorecard or wattlab_report utility_bills."""
+    bills = data.get("utility_bills") or {}
+    if not isinstance(bills, dict):
+        bills = {}
+    stats_e = bills.get("stats_electricity") or bills.get("stats") or {}
+    stats_g = bills.get("stats_natural_gas") or bills.get("stats_gas") or {}
+    if not isinstance(stats_e, dict):
+        stats_e = {}
+    if not isinstance(stats_g, dict):
+        stats_g = {}
+    # Some stamps put nmbe at top level
+    out = {
+        "nmbe_elec_pct": stats_e.get("nmbe_pct", data.get("nmbe_elec_pct")),
+        "cvrmse_elec_pct": stats_e.get("cvrmse_pct", data.get("cvrmse_elec_pct")),
+        "nmbe_gas_pct": stats_g.get("nmbe_pct", data.get("nmbe_gas_pct")),
+        "cvrmse_gas_pct": stats_g.get("cvrmse_pct", data.get("cvrmse_gas_pct")),
+        "pass_fail": bills.get("pass_fail")
+        or data.get("pass_fail")
+        or data.get("status")
+        or data.get("overall"),
+    }
+    return out
+
+
+def extract_run_g14(run_dir: Path | str | None) -> dict[str, Any]:
+    """Load G14 metrics from a published run directory."""
+    if not run_dir:
+        return {}
+    root = Path(run_dir)
+    for name in ("calibration_scorecard.json", "campaign_stamp.json", "wattlab_report.json"):
+        p = root / name
+        if p.is_file():
+            g = _g14_from_scorecard(_load_json(p))
+            if any(g.get(k) is not None for k in ("nmbe_elec_pct", "cvrmse_elec_pct", "nmbe_gas_pct")):
+                return g
+    return {}
+
+
+def iter_g14_history(runs_root: Path | str, *, limit: int = 30) -> list[dict[str, Any]]:
+    """Return chronological G14 rows for published runs (oldest → newest)."""
+    rows: list[dict[str, Any]] = []
+    for h in list_iteration_runs(Path(runs_root), limit=limit):
+        d = Path(str(h["dir"])) if h.get("dir") else None
+        g14 = extract_run_g14(d)
+        prog = read_run_progress(d) if d else {}
+        rows.append(
+            {
+                "run_id": h.get("run_id"),
+                "dir": str(d) if d else None,
+                "started_at": h.get("started_at") or prog.get("started_at"),
+                "finished_at": h.get("finished_at") or prog.get("finished_at"),
+                "status": h.get("status"),
+                "hypothesis": h.get("hypothesis"),
+                "has_eplusout": h.get("has_eplusout"),
+                "elapsed_s": h.get("elapsed_s"),
+                "mtime": h.get("mtime"),
+                **g14,
+            }
+        )
+
+    def _sort_key(r: dict[str, Any]) -> tuple:
+        ts = r.get("started_at") or ""
+        if ts:
+            return (0, str(ts), str(r.get("run_id") or ""))
+        mt = r.get("mtime")
+        return (1, float(mt) if mt is not None else 0.0, str(r.get("run_id") or ""))
+
+    rows.sort(key=_sort_key)
+    return rows
+
+
+def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
+    """Plot |NMBE| and CV(RMSE) vs iteration index (training-loss style)."""
+    import plotly.graph_objects as go
+
+    usable = [
+        r
+        for r in rows
+        if r.get("nmbe_elec_pct") is not None or r.get("cvrmse_elec_pct") is not None
+    ]
+    fig = go.Figure()
+    if not usable:
+        fig.add_annotation(
+            text="No per-run G14 scorecards yet — publish calibration_scorecard.json with each Twin run.",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+        return plotly_layout_clean(
+            fig,
+            title="G14 calibration across iterations",
+            height=height,
+            yaxis_title="% error",
+        )
+
+    xs = list(range(1, len(usable) + 1))
+    hover = [
+        f"{r.get('run_id')}<br>{r.get('started_at') or ''}<br>{(r.get('hypothesis') or '')[:80]}"
+        for r in usable
+    ]
+
+    def _abs_series(key: str) -> list[float | None]:
+        out: list[float | None] = []
+        for r in usable:
+            v = r.get(key)
+            try:
+                out.append(abs(float(v)) if v is not None else None)
+            except (TypeError, ValueError):
+                out.append(None)
+        return out
+
+    fig.add_scatter(
+        x=xs,
+        y=_abs_series("nmbe_elec_pct"),
+        mode="lines+markers",
+        name="|NMBE| elec %",
+        text=hover,
+        hovertemplate="iter %{x}<br>%{text}<br>|NMBE| %{y:.2f}%<extra></extra>",
+        line=dict(color="#1f77b4", width=2),
+    )
+    fig.add_scatter(
+        x=xs,
+        y=_abs_series("cvrmse_elec_pct"),
+        mode="lines+markers",
+        name="CV(RMSE) elec %",
+        text=hover,
+        hovertemplate="iter %{x}<br>%{text}<br>CVRMSE %{y:.2f}%<extra></extra>",
+        line=dict(color="#ff7f0e", width=2),
+    )
+    if any(r.get("nmbe_gas_pct") is not None for r in usable):
+        fig.add_scatter(
+            x=xs,
+            y=_abs_series("nmbe_gas_pct"),
+            mode="lines+markers",
+            name="|NMBE| gas %",
+            text=hover,
+            hovertemplate="iter %{x}<br>%{text}<br>|NMBE| gas %{y:.2f}%<extra></extra>",
+            line=dict(color="#2ca02c", width=2, dash="dot"),
+        )
+    if any(r.get("cvrmse_gas_pct") is not None for r in usable):
+        fig.add_scatter(
+            x=xs,
+            y=_abs_series("cvrmse_gas_pct"),
+            mode="lines+markers",
+            name="CV(RMSE) gas %",
+            text=hover,
+            hovertemplate="iter %{x}<br>%{text}<br>CVRMSE gas %{y:.2f}%<extra></extra>",
+            line=dict(color="#9467bd", width=2, dash="dot"),
+        )
+
+    fig.add_hline(
+        y=G14_NMBE_GATE,
+        line_dash="dash",
+        line_color="#d62728",
+        annotation_text=f"G14 |NMBE| ≤ {G14_NMBE_GATE:g}%",
+        annotation_position="top left",
+    )
+    fig.add_hline(
+        y=G14_CVRMSE_GATE,
+        line_dash="dash",
+        line_color="#8c564b",
+        annotation_text=f"G14 CV(RMSE) ≤ {G14_CVRMSE_GATE:g}%",
+        annotation_position="bottom left",
+    )
+
+    plotly_layout_clean(
+        fig,
+        title="G14 calibration across iterations (lower is better)",
+        height=height,
+        yaxis_title="% error",
+        xaxis_title="Iteration (oldest → newest)",
+    )
+    fig.update_xaxes(dtick=1, showgrid=True, gridcolor="rgba(0,0,0,0.06)")
+    fig.update_yaxes(rangemode="tozero", showgrid=True, gridcolor="rgba(0,0,0,0.08)")
+    return fig

--- a/vibe_code_apps_20/wattlab/studio/idf_geometry.py
+++ b/vibe_code_apps_20/wattlab/studio/idf_geometry.py
@@ -76,7 +76,48 @@ class IdfGeometry:
                 "dy": round((ymax - ymin) * _M_TO_FT, 1),
                 "dz": round((zmax - zmin) * _M_TO_FT, 1),
             }
+        out.update(self.envelope_ratios())
         return out
+
+    def envelope_ratios(self) -> dict[str, Any]:
+        """Gross wall / window areas (m²) and WWR from parsed surfaces."""
+        wall_m2 = 0.0
+        fen_m2 = 0.0
+        roof_m2 = 0.0
+        for s in self.surfaces:
+            area = _polygon_area_m2(s.vertices)
+            stype = (s.surface_type or "").strip().upper()
+            if s.is_fenestration:
+                fen_m2 += area
+            elif stype in {"WALL"} or stype.startswith("WALL"):
+                wall_m2 += area
+            elif stype in {"ROOF", "CEILING"}:
+                roof_m2 += area
+            elif "WALL" in stype:
+                wall_m2 += area
+        wwr = (fen_m2 / wall_m2) if wall_m2 > 1e-6 else None
+        return {
+            "wall_area_m2": round(wall_m2, 2),
+            "window_area_m2": round(fen_m2, 2),
+            "roof_area_m2": round(roof_m2, 2),
+            "wwr": round(wwr, 3) if wwr is not None else None,
+            "wwr_pct": round(100.0 * wwr, 1) if wwr is not None else None,
+        }
+
+
+def _polygon_area_m2(verts: list[tuple[float, float, float]]) -> float:
+    """3D polygon area via Newell's method (m²)."""
+    if len(verts) < 3:
+        return 0.0
+    nx = ny = nz = 0.0
+    n = len(verts)
+    for i in range(n):
+        x1, y1, z1 = verts[i]
+        x2, y2, z2 = verts[(i + 1) % n]
+        nx += (y1 - y2) * (z1 + z2)
+        ny += (z1 - z2) * (x1 + x2)
+        nz += (x1 - x2) * (y1 + y2)
+    return 0.5 * (nx * nx + ny * ny + nz * nz) ** 0.5
 
 
 def _parse_block(object_type: str, body: str) -> IdfSurface | None:

--- a/vibe_code_apps_20/wattlab/studio/model_summary.py
+++ b/vibe_code_apps_20/wattlab/studio/model_summary.py
@@ -1,0 +1,204 @@
+"""Read-only model summary for Twin (answers + published run artifacts)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from wattlab.studio.ep_viz import find_run_idf
+from wattlab.studio.eui_compare import load_model_eui_from_run
+from wattlab.studio.g14_history import extract_run_g14
+from wattlab.studio.idf_geometry import parse_idf_geometry
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+
+
+def _dash(v: Any) -> Any:
+    return "—" if v is None or v == "" else v
+
+
+def _scan_meta(run_dir: Path) -> dict[str, Any]:
+    """Merge first geo/dial/meta JSON found under the run."""
+    merged: dict[str, Any] = {}
+    patterns = ("*meta*.json", "*dial*.json", "geo_build_meta.json", "answers_stamp.json")
+    for pat in patterns:
+        for p in sorted(run_dir.glob(pat)):
+            if not p.is_file():
+                continue
+            data = _load_json(p)
+            for k, v in data.items():
+                if k not in merged and v is not None:
+                    merged[k] = v
+    return merged
+
+
+def _hvac_hints_from_idf_text(text: str) -> dict[str, Any]:
+    return {
+        "chiller_electric": text.count("Chiller:Electric"),
+        "cooling_tower": text.count("CoolingTower"),
+        "boiler_hotwater": text.count("Boiler:HotWater"),
+        "airloophvac": text.count("AirLoopHVAC,"),
+        "heatpump": text.count("HeatPump:"),
+    }
+
+
+def build_model_summary(
+    answers: dict[str, Any] | None,
+    run_dir: Path | str | None,
+    *,
+    profile: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Aggregate project / geometry / loads / HVAC / run blocks for UI display."""
+    answers = answers if isinstance(answers, dict) else {}
+    profile = profile if isinstance(profile, dict) else {}
+    utility = answers.get("utility") if isinstance(answers.get("utility"), dict) else {}
+    run_path = Path(run_dir) if run_dir else None
+    meta = _scan_meta(run_path) if run_path and run_path.is_dir() else {}
+    model_eui = load_model_eui_from_run(run_path) if run_path else {}
+    g14 = extract_run_g14(run_path) if run_path else {}
+
+    geom_block: dict[str, Any] = {
+        "floor_area_ft2": answers.get("floor_area_ft2")
+        or profile.get("floor_area_ft2")
+        or meta.get("target_area_ft2"),
+        "floors": answers.get("floors") or answers.get("stories") or meta.get("stories_above_grade"),
+        "wwr": answers.get("wwr") or meta.get("wwr_target") or meta.get("wwr"),
+        "n_zones": None,
+        "n_fenestration": None,
+        "wwr_from_idf_pct": None,
+        "wall_area_m2": None,
+        "window_area_m2": None,
+        "bbox_ft": None,
+    }
+    hvac_block: dict[str, Any] = {
+        "hints": {},
+        "heating_fuel": answers.get("heating_fuel") or profile.get("heating_fuel"),
+        "hvac_system": answers.get("hvac_system") or profile.get("hvac_system"),
+    }
+    idf_path = find_run_idf(run_path) if run_path else None
+    if idf_path and idf_path.is_file():
+        try:
+            text = idf_path.read_text(encoding="utf-8", errors="replace")
+            geom = parse_idf_geometry(text)
+            summ = geom.summary()
+            geom_block["n_zones"] = summ.get("n_zones")
+            geom_block["n_fenestration"] = summ.get("n_fenestration")
+            geom_block["wwr_from_idf_pct"] = summ.get("wwr_pct")
+            geom_block["wall_area_m2"] = summ.get("wall_area_m2")
+            geom_block["window_area_m2"] = summ.get("window_area_m2")
+            geom_block["bbox_ft"] = summ.get("bbox_ft")
+            if geom_block.get("wwr") is None and summ.get("wwr") is not None:
+                geom_block["wwr"] = summ.get("wwr")
+            hvac_block["hints"] = _hvac_hints_from_idf_text(text)
+        except OSError:
+            pass
+
+    loads = {
+        "lights_w_per_m2": meta.get("lights_w_per_m2")
+        or answers.get("lights_w_per_m2")
+        or meta.get("lights"),
+        "equip_w_per_m2": meta.get("equip_w_per_m2")
+        or answers.get("equip_w_per_m2")
+        or meta.get("equip"),
+        "infil_mult": meta.get("infil_mult") or answers.get("infil_mult"),
+        "shgc": meta.get("shgc") or answers.get("shgc"),
+    }
+
+    project = {
+        "building_id": answers.get("building_id") or profile.get("building_id"),
+        "building_type": answers.get("building_type") or profile.get("building_type"),
+        "city": answers.get("city") or profile.get("city"),
+        "lat": answers.get("lat") or profile.get("lat"),
+        "lon": answers.get("lon") or profile.get("lon"),
+        "climate_zone": answers.get("climate_zone") or meta.get("climate_zone"),
+        "elec_usd_per_kwh": utility.get("elec_usd_per_kwh"),
+        "gas_usd_per_therm": utility.get("gas_usd_per_therm"),
+    }
+
+    run_block = {
+        "run_id": model_eui.get("run_id") or (run_path.name if run_path else None),
+        "weather_mode": model_eui.get("weather_mode"),
+        "prototype_area_scale": model_eui.get("prototype_area_scale"),
+        "model_eui_kbtu_ft2": model_eui.get("model_eui_kbtu_ft2"),
+        "peak_demand_kw": model_eui.get("peak_demand_kw"),
+        "idf": str(idf_path) if idf_path else None,
+        "g14": g14,
+        "hypothesis": meta.get("hypothesis") or meta.get("note"),
+    }
+
+    return {
+        "project": project,
+        "geometry": geom_block,
+        "loads": loads,
+        "hvac": hvac_block,
+        "run": run_block,
+    }
+
+
+def render_model_summary_panel(summary: dict[str, Any]) -> None:
+    """Streamlit read-only panel (import streamlit only when rendering)."""
+    import streamlit as st
+
+    st.caption(
+        "Read-only snapshot from answers.json + published run (IDF / meta). "
+        "Missing fields show as — until the agent stamps them."
+    )
+    proj = summary.get("project") or {}
+    geom = summary.get("geometry") or {}
+    loads = summary.get("loads") or {}
+    hvac = summary.get("hvac") or {}
+    run = summary.get("run") or {}
+
+    c1, c2, c3 = st.columns(3)
+    with c1:
+        st.markdown("**Project**")
+        st.write(
+            {
+                "building_id": _dash(proj.get("building_id")),
+                "type": _dash(proj.get("building_type")),
+                "city": _dash(proj.get("city")),
+                "lat/lon": f"{_dash(proj.get('lat'))}, {_dash(proj.get('lon'))}",
+                "climate": _dash(proj.get("climate_zone")),
+                "elec $/kWh": _dash(proj.get("elec_usd_per_kwh")),
+                "gas $/therm": _dash(proj.get("gas_usd_per_therm")),
+            }
+        )
+    with c2:
+        st.markdown("**Geometry**")
+        st.write(
+            {
+                "area_ft2": _dash(geom.get("floor_area_ft2")),
+                "floors": _dash(geom.get("floors")),
+                "WWR": _dash(geom.get("wwr")),
+                "WWR from IDF %": _dash(geom.get("wwr_from_idf_pct")),
+                "zones": _dash(geom.get("n_zones")),
+                "fenestration objs": _dash(geom.get("n_fenestration")),
+                "bbox_ft": _dash(geom.get("bbox_ft")),
+            }
+        )
+    with c3:
+        st.markdown("**Loads / HVAC / run**")
+        hints = hvac.get("hints") or {}
+        g14 = run.get("g14") or {}
+        st.write(
+            {
+                "lights W/m²": _dash(loads.get("lights_w_per_m2")),
+                "equip W/m²": _dash(loads.get("equip_w_per_m2")),
+                "infil mult": _dash(loads.get("infil_mult")),
+                "SHGC": _dash(loads.get("shgc")),
+                "chillers": _dash(hints.get("chiller_electric")),
+                "towers": _dash(hints.get("cooling_tower")),
+                "boilers": _dash(hints.get("boiler_hotwater")),
+                "model EUI": _dash(run.get("model_eui_kbtu_ft2")),
+                "area_scale": _dash(run.get("prototype_area_scale")),
+                "NMBE elec %": _dash(g14.get("nmbe_elec_pct")),
+                "CVRMSE elec %": _dash(g14.get("cvrmse_elec_pct")),
+            }
+        )

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
@@ -168,6 +168,10 @@ def _render_portfolio(summary: dict[str, Any], campus: Campus, px, go) -> None:
         peer_p80=float(dfb["peer_p80"].iloc[0]),
         series=series,
         title="Site EUI vs peer p20–p80 band",
+        height=440,
+    )
+    st.caption(
+        "Upright peer band (green = p20–p80, dashed = p50). Diamonds = building site EUI from bills."
     )
     st.plotly_chart(fig_peer, width="stretch", key="fuel_peer_eui_chart")
 

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -505,17 +505,16 @@ def render() -> None:
         from wattlab.energyplus.mcp import capability_status
 
         cap = capability_status(probe_docker=True)
-        mode = cap.get("mode") or "?"
-        if mode == "simulate_only":
-            st.info(
-                f"EnergyPlus capability: **{mode}** — Docker sims OK; LBNL MCP inspect "
-                "tools need a host vendor clone (`full_mcp_available`). "
+        mode = cap.get("capability") or "?"
+        if mode == "ready":
+            st.success(
+                f"EnergyPlus MCP: **{mode}** — DinD sims + dial-loads/mcp-exec inspect/modify OK."
+            )
+        else:
+            st.warning(
+                f"EnergyPlus MCP: **{mode}** — run `wattlab energyplus-ensure`. "
                 f"{cap.get('note') or ''}"
             )
-        elif mode == "full_mcp_available":
-            st.success(f"EnergyPlus capability: **{mode}**")
-        else:
-            st.warning(f"EnergyPlus capability: **{mode}** — {cap.get('note') or ''}")
     except Exception as exc:
         st.caption(f"capability_status unavailable: {exc}")
 

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -51,124 +51,125 @@ def _render_eui_index(
     chart_key: str = "twin_eui_index",
 ) -> None:
     """Bills vs peer typical EUI vs EnergyPlus model — always visible when data exists."""
-    st.subheader("EUI index — bills vs peers vs model")
-    st.caption(
-        "**Bills** = your campus annualized site EUI. "
-        "**Peers** = EPA/CBECS-style registry p20/p50/p80 for this property type. "
-        "**Model** = EnergyPlus intensity on the prototype footprint "
-        "(comparable as EUI; absolute kWh is not site totals until geometry is scaled)."
-    )
-    bill_eui = None
-    ptype = "office"
-    bench = st.session_state.get("studio_benchmark_summary") or {}
-    if bench.get("campus"):
-        bill_eui = bench["campus"].get("site_eui_kbtu_ft2")
-    campus = st.session_state.get("studio_campus")
-    if campus is not None and campus.buildings:
-        ptype = campus.buildings[0].property_type or ptype
-        if bill_eui is None:
-            try:
-                from wattlab.benchmarks import annual_summary
-
-                summary = annual_summary(campus)
-                bill_eui = summary["campus"]["site_eui_kbtu_ft2"]
-                st.session_state["studio_benchmark_summary"] = summary
-            except Exception:
-                pass
-    if profile:
-        ptype = profile.get("building_type") or ptype
-
-    model = load_model_eui_from_run(run_dir)
-    report = st.session_state.get("studio_report") or {}
-    model_eui = model.get("model_eui_kbtu_ft2")
-    scale = model.get("prototype_area_scale") or report.get("prototype_area_scale")
-    target = model.get("target_floor_area_ft2") or report.get("target_floor_area_ft2")
-    if model_eui is None:
-        ann = (report.get("baseline_annual") or report.get("annual") or {})
-        if ann.get("site_eui_kbtu_ft2_year") is not None:
-            model_eui = float(ann["site_eui_kbtu_ft2_year"])
-        else:
-            for rr in report.get("result_records") or report.get("records") or []:
-                a = (rr or {}).get("annual") or {}
-                if a.get("site_eui_kbtu_ft2_year") is not None:
-                    model_eui = float(a["site_eui_kbtu_ft2_year"])
-                    break
-
-    if bill_eui is None and model_eui is None:
-        st.info(
-            "Load Fuel campus bills and/or publish a Twin run with report.json to see "
-            "bill EUI vs peer p20/p50/p80 vs model."
+    with st.container(border=True):
+        st.subheader("EUI index — bills vs peers vs model")
+        st.caption(
+            "Upright peer band (p20–p80, dashed p50). **Bills** = annualized site EUI from utilities. "
+            "**Peers** = public registry for this property type. **Model** = EnergyPlus site intensity "
+            "(comparable as EUI; absolute kWh needs site-scale geometry + area_scale=1)."
         )
-        return
+        bill_eui = None
+        ptype = "office"
+        bench = st.session_state.get("studio_benchmark_summary") or {}
+        if bench.get("campus"):
+            bill_eui = bench["campus"].get("site_eui_kbtu_ft2")
+        campus = st.session_state.get("studio_campus")
+        if campus is not None and campus.buildings:
+            ptype = campus.buildings[0].property_type or ptype
+            if bill_eui is None:
+                try:
+                    from wattlab.benchmarks import annual_summary
 
-    idx = build_eui_index(
-        bill_eui_kbtu_ft2=float(bill_eui) if bill_eui is not None else None,
-        property_type=str(ptype),
-        model_eui_kbtu_ft2=float(model_eui) if model_eui is not None else None,
-        prototype_area_scale=float(scale) if scale is not None else None,
-        target_floor_area_ft2=float(target) if target is not None else None,
-        model_label=str(model.get("run_id") or report.get("run_id") or "EnergyPlus"),
-    )
-    m1, m2, m3, m4 = st.columns(4)
-    m1.metric(
-        "Bills site EUI",
-        f"{idx['bill_eui_kbtu_ft2']} kBtu/ft²" if idx["bill_eui_kbtu_ft2"] is not None else "—",
-        help="Annualized utility bills ÷ floor area (kBtu/ft²·yr).",
-    )
-    m2.metric(
-        "Peer typical (p50)",
-        f"{idx['peer_p50']} kBtu/ft²",
-        help="Median peer site EUI for this property type (public registry).",
-    )
-    m3.metric(
-        "Model EUI (prototype)",
-        f"{idx['model_eui_kbtu_ft2']} kBtu/ft²" if idx["model_eui_kbtu_ft2"] is not None else "—",
-        help="EnergyPlus site EUI on prototype area (intensity comparable; scale absolute kWh).",
-    )
-    m4.metric(
-        "Peer band",
-        f"p20={idx['peer_p20']} · p80={idx['peer_p80']}",
-        help="p20–p80 peer band: below p20 is efficient vs peers; above p80 needs attention.",
-    )
+                    summary = annual_summary(campus)
+                    bill_eui = summary["campus"]["site_eui_kbtu_ft2"]
+                    st.session_state["studio_benchmark_summary"] = summary
+                except Exception:
+                    pass
+        if profile:
+            ptype = profile.get("building_type") or ptype
 
-    df = pd.DataFrame(idx["rows"])
-    st.dataframe(df, width="stretch", hide_index=True)
+        model = load_model_eui_from_run(run_dir)
+        report = st.session_state.get("studio_report") or {}
+        model_eui = model.get("model_eui_kbtu_ft2")
+        scale = model.get("prototype_area_scale") or report.get("prototype_area_scale")
+        target = model.get("target_floor_area_ft2") or report.get("target_floor_area_ft2")
+        if model_eui is None:
+            ann = (report.get("baseline_annual") or report.get("annual") or {})
+            if ann.get("site_eui_kbtu_ft2_year") is not None:
+                model_eui = float(ann["site_eui_kbtu_ft2_year"])
+            else:
+                for rr in report.get("result_records") or report.get("records") or []:
+                    a = (rr or {}).get("annual") or {}
+                    if a.get("site_eui_kbtu_ft2_year") is not None:
+                        model_eui = float(a["site_eui_kbtu_ft2_year"])
+                        break
 
-    series = []
-    if idx.get("bill_eui_kbtu_ft2") is not None:
-        series.append(
-            {
-                "label": "Bills (site)",
-                "eui": float(idx["bill_eui_kbtu_ft2"]),
-                "color": "#1f77b4",
-                "symbol": "diamond",
-            }
+        if bill_eui is None and model_eui is None:
+            st.info(
+                "Load Fuel campus bills and/or publish a Twin run with report.json to see "
+                "bill EUI vs peer p20/p50/p80 vs model."
+            )
+            return
+
+        idx = build_eui_index(
+            bill_eui_kbtu_ft2=float(bill_eui) if bill_eui is not None else None,
+            property_type=str(ptype),
+            model_eui_kbtu_ft2=float(model_eui) if model_eui is not None else None,
+            prototype_area_scale=float(scale) if scale is not None else None,
+            target_floor_area_ft2=float(target) if target is not None else None,
+            model_label=str(model.get("run_id") or report.get("run_id") or "EnergyPlus"),
         )
-    if idx.get("model_eui_kbtu_ft2") is not None:
-        series.append(
-            {
-                "label": "Model (prototype)",
-                "eui": float(idx["model_eui_kbtu_ft2"]),
-                "color": "#d62728",
-                "symbol": "circle",
-            }
+        m1, m2, m3, m4 = st.columns(4)
+        m1.metric(
+            "Bills site EUI",
+            f"{idx['bill_eui_kbtu_ft2']} kBtu/ft²" if idx["bill_eui_kbtu_ft2"] is not None else "—",
+            help="Annualized utility bills ÷ floor area (kBtu/ft²·yr).",
         )
-    fig = eui_peer_bullet_figure(
-        peer_p20=float(idx["peer_p20"]),
-        peer_p50=float(idx["peer_p50"]),
-        peer_p80=float(idx["peer_p80"]),
-        series=series,
-        title=f"{idx.get('benchmark_name') or idx['property_type']} — bills vs peers vs model",
-    )
-    st.plotly_chart(fig, width="stretch", key=chart_key)
-    if scale and float(scale) > 1.05:
-        st.warning(
-            f"prototype_area_scale ≈ {float(scale):.2f}× — model intensity (EUI) is comparable; "
-            "absolute modeled kWh is NOT site totals until geometry is scaled."
+        m2.metric(
+            "Peer typical (p50)",
+            f"{idx['peer_p50']} kBtu/ft²",
+            help="Median peer site EUI for this property type (public registry).",
         )
-    honesty = model.get("area_honesty") or report.get("area_honesty")
-    if honesty:
-        st.caption(honesty)
+        m3.metric(
+            "Model EUI (prototype)",
+            f"{idx['model_eui_kbtu_ft2']} kBtu/ft²" if idx["model_eui_kbtu_ft2"] is not None else "—",
+            help="EnergyPlus site EUI on prototype area (intensity comparable; scale absolute kWh).",
+        )
+        m4.metric(
+            "Peer band",
+            f"p20={idx['peer_p20']} · p80={idx['peer_p80']}",
+            help="Peer p20–p80 screening band for this property type.",
+        )
+
+        df = pd.DataFrame(idx["rows"])
+        st.dataframe(df, width="stretch", hide_index=True)
+
+        series = []
+        if idx.get("bill_eui_kbtu_ft2") is not None:
+            series.append(
+                {
+                    "label": "Bills (site)",
+                    "eui": float(idx["bill_eui_kbtu_ft2"]),
+                    "color": "#1f77b4",
+                    "symbol": "diamond",
+                }
+            )
+        if idx.get("model_eui_kbtu_ft2") is not None:
+            series.append(
+                {
+                    "label": "Model (prototype)",
+                    "eui": float(idx["model_eui_kbtu_ft2"]),
+                    "color": "#d62728",
+                    "symbol": "circle",
+                }
+            )
+        fig = eui_peer_bullet_figure(
+            peer_p20=float(idx["peer_p20"]),
+            peer_p50=float(idx["peer_p50"]),
+            peer_p80=float(idx["peer_p80"]),
+            series=series,
+            title=f"{idx.get('benchmark_name') or idx['property_type']} — bills vs peers vs model",
+            height=440,
+        )
+        st.plotly_chart(fig, width="stretch", key=chart_key)
+        if scale and float(scale) > 1.05:
+            st.warning(
+                f"prototype_area_scale ≈ {float(scale):.2f}× — model intensity (EUI) is comparable; "
+                "absolute modeled kWh is NOT site totals until geometry is scaled."
+            )
+        honesty = model.get("area_honesty") or report.get("area_honesty")
+        if honesty:
+            st.caption(honesty)
 
 
 def _fixture_eplusout() -> Path | None:
@@ -487,6 +488,7 @@ def render() -> None:
         run_dir=active_preview,
         chart_key="twin_eui_index_active",
     )
+    st.divider()
 
     if not profile:
         st.info(
@@ -945,96 +947,138 @@ def render() -> None:
                 "`05_Source_Data` · `06_Documentation` — or download report/workbook alone."
             )
 
-    st.subheader("Iteration history (agent + Studio)")
-    st.caption(
-        "Each published `runs/<id>/` after agent/CLI EnergyPlus. "
-        "Elapsed comes from `run_manifest.json` started_at → finished_at."
-    )
-    hist = list_iteration_runs(runs_dir(), limit=15)
-    if not hist:
-        manifests = sorted(ARTIFACTS.glob("wattlab_*/run_manifest.json"), reverse=True)[:10]
-        for mp in manifests:
-            try:
-                m = json.loads(mp.read_text(encoding="utf-8"))
-                hist.append(
-                    {
-                        "run_id": m.get("run_id"),
-                        "status": m.get("status"),
-                        "dir": str(mp.parent),
-                        "progress": 100 if m.get("status") in {"ok", "success", "SUCCESS"} else 0,
-                        "started_at": m.get("started_at"),
-                        "finished_at": m.get("finished_at"),
-                        "elapsed_s": None,
-                        "hypothesis": m.get("hypothesis") or m.get("notes"),
-                    }
-                )
-            except Exception:
-                continue
-    if not hist:
-        st.caption("No prior runs in workspace runs/.")
-    else:
-        st.metric("Published iterations shown", len(hist))
-        enriched = []
-        for h in hist:
-            row = {
-                "run_id": h.get("run_id"),
-                "hypothesis": h.get("hypothesis"),
-                "weather": h.get("weather_mode"),
-                "status": h.get("status"),
-                "eplusout": "yes" if h.get("has_eplusout") else "no",
-                "elapsed_s": h.get("elapsed_s"),
-                "progress": h.get("progress"),
-                "dir": h.get("dir"),
-            }
-            model = load_model_eui_from_run(Path(str(h["dir"])) if h.get("dir") else None)
-            if model.get("model_eui_kbtu_ft2") is not None:
-                row["model_eui_kbtu_ft2"] = model["model_eui_kbtu_ft2"]
-            if model.get("prototype_area_scale") is not None:
-                row["prototype_area_scale"] = model["prototype_area_scale"]
-            if model.get("weather_mode") and not row.get("weather"):
-                row["weather"] = model["weather_mode"]
-            if model.get("peak_demand_kw") is not None:
-                row["peak_demand_kw"] = model["peak_demand_kw"]
-            if row.get("elapsed_s") is not None:
-                try:
-                    row["elapsed_min"] = round(float(row["elapsed_s"]) / 60.0, 2)
-                except (TypeError, ValueError):
-                    pass
-            enriched.append(row)
-        show_cols = [
-            c
-            for c in (
-                "run_id",
-                "hypothesis",
-                "weather",
-                "status",
-                "eplusout",
-                "elapsed_min",
-                "elapsed_s",
-                "model_eui_kbtu_ft2",
-                "peak_demand_kw",
-                "prototype_area_scale",
-            )
-            if any(c in r for r in enriched)
-        ]
-        st.dataframe(
-            pd.DataFrame(enriched)[show_cols] if show_cols else pd.DataFrame(enriched),
-            width="stretch",
-            hide_index=True,
+    st.divider()
+    with st.container(border=True):
+        st.subheader("Iteration history (agent + Studio)")
+        st.caption(
+            "Each published `runs/<id>/` after agent/CLI EnergyPlus. "
+            "Timestamps from `run_manifest.json`. G14 columns need `calibration_scorecard.json` per run."
         )
-        pick = st.selectbox(
-            "Inspect iteration",
-            options=[h.get("dir") for h in hist if h.get("dir")],
-            key="twin_iter_pick",
-        )
-        if pick and st.button("Show 08 panes for selection", key="twin_show_iter"):
-            st.session_state["studio_active_run"] = pick
-            st.rerun()
+        from wattlab.studio.g14_history import g14_epoch_figure, iter_g14_history
+        from wattlab.studio.model_summary import build_model_summary, render_model_summary_panel
 
-    # EnergyPlus visualizer last — APIHelper-08 floor plan / OA / progress
+        hist = list_iteration_runs(runs_dir(), limit=30)
+        if not hist:
+            manifests = sorted(ARTIFACTS.glob("wattlab_*/run_manifest.json"), reverse=True)[:10]
+            for mp in manifests:
+                try:
+                    m = json.loads(mp.read_text(encoding="utf-8"))
+                    hist.append(
+                        {
+                            "run_id": m.get("run_id"),
+                            "status": m.get("status"),
+                            "dir": str(mp.parent),
+                            "progress": 100 if m.get("status") in {"ok", "success", "SUCCESS"} else 0,
+                            "started_at": m.get("started_at"),
+                            "finished_at": m.get("finished_at"),
+                            "elapsed_s": None,
+                            "hypothesis": m.get("hypothesis") or m.get("notes"),
+                        }
+                    )
+                except Exception:
+                    continue
+        if not hist:
+            st.caption("No prior runs in workspace runs/.")
+        else:
+            st.metric("Published iterations shown", len(hist))
+            g14_rows = iter_g14_history(runs_dir(), limit=30)
+            g14_by_dir = {str(r.get("dir")): r for r in g14_rows if r.get("dir")}
+            enriched = []
+            for h in hist:
+                dkey = str(h.get("dir") or "")
+                g = g14_by_dir.get(dkey) or {}
+                row = {
+                    "started_at": h.get("started_at") or g.get("started_at"),
+                    "run_id": h.get("run_id"),
+                    "hypothesis": h.get("hypothesis"),
+                    "weather": h.get("weather_mode"),
+                    "status": h.get("status"),
+                    "eplusout": "yes" if h.get("has_eplusout") else "no",
+                    "elapsed_s": h.get("elapsed_s"),
+                    "nmbe_elec_pct": g.get("nmbe_elec_pct"),
+                    "cvrmse_elec_pct": g.get("cvrmse_elec_pct"),
+                    "nmbe_gas_pct": g.get("nmbe_gas_pct"),
+                    "cvrmse_gas_pct": g.get("cvrmse_gas_pct"),
+                    "g14": g.get("pass_fail"),
+                    "dir": h.get("dir"),
+                }
+                model = load_model_eui_from_run(Path(str(h["dir"])) if h.get("dir") else None)
+                if model.get("model_eui_kbtu_ft2") is not None:
+                    row["model_eui_kbtu_ft2"] = model["model_eui_kbtu_ft2"]
+                if model.get("prototype_area_scale") is not None:
+                    row["prototype_area_scale"] = model["prototype_area_scale"]
+                if model.get("weather_mode") and not row.get("weather"):
+                    row["weather"] = model["weather_mode"]
+                if model.get("peak_demand_kw") is not None:
+                    row["peak_demand_kw"] = model["peak_demand_kw"]
+                if row.get("elapsed_s") is not None:
+                    try:
+                        row["elapsed_min"] = round(float(row["elapsed_s"]) / 60.0, 2)
+                    except (TypeError, ValueError):
+                        pass
+                enriched.append(row)
+            show_cols = [
+                c
+                for c in (
+                    "started_at",
+                    "run_id",
+                    "hypothesis",
+                    "status",
+                    "eplusout",
+                    "nmbe_elec_pct",
+                    "cvrmse_elec_pct",
+                    "nmbe_gas_pct",
+                    "cvrmse_gas_pct",
+                    "g14",
+                    "model_eui_kbtu_ft2",
+                    "elapsed_min",
+                    "peak_demand_kw",
+                    "prototype_area_scale",
+                    "weather",
+                )
+                if any(c in r and r.get(c) is not None for r in enriched)
+            ]
+            st.dataframe(
+                pd.DataFrame(enriched)[show_cols] if show_cols else pd.DataFrame(enriched),
+                width="stretch",
+                hide_index=True,
+            )
+
+            st.markdown("**Calibration iterations (G14)**")
+            st.caption(
+                "Like a training-loss curve: each published Twin run is an epoch. "
+                "Lower |NMBE| / CV(RMSE) is better. Dashed lines = ASHRAE G14 monthly gates "
+                "(±5% NMBE, 15% CVRMSE). Missing scorecards skip that point."
+            )
+            st.plotly_chart(
+                g14_epoch_figure(g14_rows, height=440),
+                width="stretch",
+                key="twin_g14_epoch",
+            )
+
+            pick = st.selectbox(
+                "Inspect iteration",
+                options=[h.get("dir") for h in hist if h.get("dir")],
+                format_func=lambda d: Path(str(d)).name if d else "",
+                key="twin_iter_pick",
+            )
+            if pick:
+                answers = st.session_state.get("studio_answers")
+                if not isinstance(answers, dict):
+                    answers = {}
+                summary = build_model_summary(answers, Path(str(pick)), profile=_profile())
+                with st.expander("Model summary (selected iteration)", expanded=True):
+                    render_model_summary_panel(summary)
+                if st.button("Show 08 panes for selection", key="twin_show_iter"):
+                    st.session_state["studio_active_run"] = pick
+                    st.rerun()
+
+    st.divider()
+    # EnergyPlus visualizer last — IDF massing / OA / progress
     viz_run = _resolve_active_run()
     if viz_run is not None:
-        _render_08_panes(viz_run)
+        with st.container(border=True):
+            _render_08_panes(viz_run)
     else:
         st.info(
             "No published Twin runs yet. An AI agent should write `runs/<id>/eplusout.csv` "

--- a/vibe_code_apps_20/wattlab/studio/status.py
+++ b/vibe_code_apps_20/wattlab/studio/status.py
@@ -166,15 +166,14 @@ def build_session_status(
         ans_path = cand if cand.is_file() else None
     reports = root / "reports"
     if ans_path is None:
-        for name in (
-            "answers.json",
-            "answers_building_100.json",
-            "answers_building_50.json",
-        ):
-            hit = reports / name
-            if hit.is_file():
-                ans_path = hit
-                break
+        hit = reports / "answers.json"
+        if hit.is_file():
+            ans_path = hit
+        else:
+            # Any answers_*.json (sorted) — no preferred building-id filenames
+            matches = sorted(reports.glob("answers_*.json"))
+            if matches:
+                ans_path = matches[0]
     answers = _load_json(ans_path)
 
     dump_p = Path(dump_path) if dump_path else None

--- a/vibe_code_apps_20/wattlab/studio/status.py
+++ b/vibe_code_apps_20/wattlab/studio/status.py
@@ -170,9 +170,9 @@ def build_session_status(
         if hit.is_file():
             ans_path = hit
         else:
-            # Any answers_*.json (sorted) — no preferred building-id filenames
+            # Exactly one answers_*.json → use it; multiple → leave unset (NEEDS_INPUT)
             matches = sorted(reports.glob("answers_*.json"))
-            if matches:
+            if len(matches) == 1:
                 ans_path = matches[0]
     answers = _load_json(ans_path)
 


### PR DESCRIPTION
## Summary
- Retire simulate_only; `wattlab energyplus-ensure` / `mcp-exec` / dial-loads docker route; capability `ready`
- Twin Calibrate: upright peer EUI charts, G14 epoch (loss-style) chart, iteration timestamps + G14 cols
- Read-only model summary (area, WWR from IDF, loads, HVAC hints) for selected run
- Shared plotly layout margins/legend to reduce overlap; bordered Twin sections

## Test plan
- [x] pytest charts / g14 history / model summary / mcp status
- [x] scripts/smoke_studio.py 0 exceptions
- [ ] CodeRabbit review
- [ ] vibe20-ghcr green on develop merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added EnergyPlus MCP setup and execution commands, with readiness checks before load tuning.
  - Added Twin iteration history with G14 calibration charts and read-only model summaries.
  - Added envelope metrics, including wall, window, roof, and window-to-wall ratios.
  - Added generalized geometry generation requiring explicit stories and window-to-wall inputs.

- **Improvements**
  - Redesigned EUI peer-band charts for clearer upright presentation.
  - Improved answer-file discovery and source-data packaging.
  - Updated workflow documentation and setup guidance for MCP-based operations.

- **Tests**
  - Expanded coverage for MCP readiness, geometry validation, calibration history, model summaries, and chart rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->