### PR TITLE
feat(vibe20): Twin model assumptions + G14 legend + latest run

### DIFF
--- a/vibe_code_apps_20/tests/test_twin_active_run.py
+++ b/vibe_code_apps_20/tests/test_twin_active_run.py
@@ -1,0 +1,46 @@
+"""Active-run resolution: latest publish wins unless human pinned."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wattlab.studio.pages.twin_calibrate import resolve_active_run_dir
+
+
+def _mk_run(root: Path, name: str) -> Path:
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "run_manifest.json").write_text('{"run_id":"%s","status":"ok"}' % name, encoding="utf-8")
+    return d
+
+
+def test_resolve_prefers_current_run_over_stale_session(tmp_path: Path):
+    runs = tmp_path / "runs"
+    old = _mk_run(runs, "old_run")
+    new = _mk_run(runs, "new_run")
+    (runs / "CURRENT_RUN.txt").write_text(str(new.resolve()), encoding="utf-8")
+    # Stale session without pin → CURRENT_RUN wins
+    got = resolve_active_run_dir(runs, session_active=str(old), pinned=False)
+    assert got is not None
+    assert got.resolve() == new.resolve()
+
+
+def test_resolve_pin_sticks(tmp_path: Path):
+    runs = tmp_path / "runs"
+    old = _mk_run(runs, "old_run")
+    new = _mk_run(runs, "new_run")
+    (runs / "CURRENT_RUN.txt").write_text(str(new.resolve()), encoding="utf-8")
+    got = resolve_active_run_dir(runs, session_active=str(old), pinned=True)
+    assert got is not None
+    assert got.resolve() == old.resolve()
+
+
+def test_resolve_falls_back_to_newest_mtime(tmp_path: Path):
+    runs = tmp_path / "runs"
+    _mk_run(runs, "a")
+    b = _mk_run(runs, "b")
+    # Touch b to be newest
+    b.touch()
+    got = resolve_active_run_dir(runs, session_active=None, pinned=False)
+    assert got is not None
+    assert got.name == "b"

--- a/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
+++ b/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
@@ -91,6 +91,9 @@ def test_iter_g14_history_and_epoch(tmp_path: Path):
     fig = g14_epoch_figure(rows)
     assert len(fig.data) >= 2
     assert fig.layout.height >= 400
+    legend_names = [getattr(t, "name", "") or "" for t in fig.data]
+    assert any("G14 |NMBE| gate" in n for n in legend_names)
+    assert any("G14 CV(RMSE) gate" in n for n in legend_names)
 
 
 def test_build_model_summary(tmp_path: Path):
@@ -102,7 +105,8 @@ def test_build_model_summary(tmp_path: Path):
         encoding="utf-8",
     )
     (run / "run_manifest.json").write_text(
-        json.dumps({"run_id": "geo_dial", "status": "ok"}), encoding="utf-8"
+        json.dumps({"run_id": "geo_dial", "status": "ok", "energyplus_version": "26.1"}),
+        encoding="utf-8",
     )
     answers = {
         "building_type": "office",
@@ -117,3 +121,43 @@ def test_build_model_summary(tmp_path: Path):
     assert summary["loads"]["lights_w_per_m2"] == 4.5
     assert summary["geometry"]["n_zones"] == 1
     assert summary["geometry"]["wwr_from_idf_pct"] is not None
+
+    from wattlab.studio.model_summary import (
+        build_assumption_rows,
+        build_model_at_a_glance,
+        filter_assumption_rows,
+        missing_critical_inputs,
+        rank_assumption_risk,
+    )
+
+    profile = {
+        "field_sources": {
+            "floor_area_ft2": {"value": 140000, "source": "user", "unit": "ft2"},
+            "building_type": {"value": "office", "source": "default"},
+        }
+    }
+    rows = build_assumption_rows(answers, run, profile=profile, summary=summary)
+    assert any(r["parameter"] == "wwr_from_idf_pct" for r in rows)
+    assert any(r["source"] == "INFERRED_FROM_GEOMETRY" for r in rows)
+    assert any(r["parameter"] == "lights_w_per_m2" and r["value"] == 4.5 for r in rows)
+    # WWR / area sanity: IDF WWR in (0, 100]
+    wwr_row = next(r for r in rows if r["parameter"] == "wwr_from_idf_pct")
+    assert wwr_row["value"] is not None and wwr_row["value"] != "—"
+    assert 0 < float(wwr_row["value"]) <= 100
+
+    glance = build_model_at_a_glance(summary, rows)
+    assert glance["gross_floor_area_ft2"] == 140000
+    assert glance["building_type"] == "office"
+    assert "low_confidence_inputs" in glance
+
+    risk = rank_assumption_risk(rows)
+    assert risk
+    assert any("risk_bucket" in r for r in risk)
+    missing = missing_critical_inputs(rows)
+    assert isinstance(missing, list)
+    low = filter_assumption_rows(rows, mode="LOW CONFIDENCE")
+    assert all(str(r["confidence"]).upper() in {"LOW", "UNKNOWN"} for r in low)
+
+    # Documented profile source maps to USER_ENTERED
+    area_rows = [r for r in rows if r["parameter"] == "floor_area_ft2" and r["category"] == "PROFILE"]
+    assert area_rows and area_rows[0]["source"] == "USER_ENTERED"

--- a/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
@@ -48,11 +48,14 @@ For site-scale glass / multistory offices (any building):
 
 1. `wattlab geo-idf --src <DOE Large Office>.idf --dst … --target-area-ft2 … --stories … --wwr … [--lat … --lon …]`
 2. Profile / answers: `custom_idf` → that IDF, **`prototype_area_scale = 1`**
-3. Publish `model.idf` + `eplusout.csv` for Twin 3D massing
+3. Publish `model.idf` + `eplusout.csv` (+ `dial_meta.json` / `geo_build_meta.json` when used) for Twin 3D massing **and** Model assumptions dashboard
 4. Fuel-mix heuristic: high elec + low gas ⇒ excess internal gains — dial Lights/Equip down and
    infiltration up via **EnergyPlus MCP** (`wattlab dial-loads`), not more fan/DAT schedule
    patches on a tiny prototype.
 5. Score: `wattlab score-monthly eplusout.csv --bills … --area-ft2 …` (last-12 Monthly meters)
+
+Twin defaults to the latest `CURRENT_RUN.txt` publish unless the human pins an Inspect
+iteration. Do not treat sticky browser session as the source of truth after a new agent publish.
 
 **Bills honesty:** campus area-weighted half elec + per-building gas — never double-half.
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -145,8 +145,17 @@ calibrated ROI without G14 + stamps.
 ```
 uploads/dump/  uploads/energy/  uploads/energy/derived/
 runs/<run_id>/eplusout.csv | model.idf | run_manifest.json | progress.json | report.json
+runs/<run_id>/dial_meta.json | geo_build_meta.json   # stamp when dialing / geo-idf
+runs/CURRENT_RUN.txt          # Twin defaults to this publish (unless human pins Inspect)
 reports/utility_bills.csv | last_dry_run_plan.json | BUG_REPORT.md | CALIBRATE_SESSION.md
 ```
+
+**Twin Model assumptions:** Inspect iteration shows Model-at-a-Glance + a provenance
+table from the **published IDF + meta + answers** (not a parallel editable form).
+Always publish `model.idf` and dial/geo meta into `runs/<id>/`. Twin panes follow
+`CURRENT_RUN.txt` / newest run; humans pin via **Show 08 panes for selection**.
+**Refresh agent runs** clears the pin. Code/reference basis wording is
+“model reference/default” — never claim ASHRAE 90.1 compliance from defaults alone.
 
 ## Docker turnkey (Studio + EnergyPlus MCP image)
 

--- a/vibe_code_apps_20/wattlab/studio/g14_history.py
+++ b/vibe_code_apps_20/wattlab/studio/g14_history.py
@@ -174,19 +174,26 @@ def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
             line=dict(color="#9467bd", width=2, dash="dot"),
         )
 
-    fig.add_hline(
-        y=G14_NMBE_GATE,
-        line_dash="dash",
-        line_color="#d62728",
-        annotation_text=f"G14 |NMBE| ≤ {G14_NMBE_GATE:g}%",
-        annotation_position="top left",
+    # ASHRAE G14 monthly gates — as legend traces (add_hline annotations alone
+    # do not appear in the Plotly legend and look like anonymous dashboard lines).
+    x0, x1 = xs[0], xs[-1]
+    fig.add_scatter(
+        x=[x0, x1],
+        y=[G14_NMBE_GATE, G14_NMBE_GATE],
+        mode="lines",
+        name=f"G14 |NMBE| gate ≤{G14_NMBE_GATE:g}%",
+        line=dict(color="#d62728", width=2, dash="dash"),
+        hovertemplate=f"ASHRAE G14 monthly |NMBE| gate ≤ {G14_NMBE_GATE:g}%<extra></extra>",
+        showlegend=True,
     )
-    fig.add_hline(
-        y=G14_CVRMSE_GATE,
-        line_dash="dash",
-        line_color="#8c564b",
-        annotation_text=f"G14 CV(RMSE) ≤ {G14_CVRMSE_GATE:g}%",
-        annotation_position="bottom left",
+    fig.add_scatter(
+        x=[x0, x1],
+        y=[G14_CVRMSE_GATE, G14_CVRMSE_GATE],
+        mode="lines",
+        name=f"G14 CV(RMSE) gate ≤{G14_CVRMSE_GATE:g}%",
+        line=dict(color="#8c564b", width=2, dash="dash"),
+        hovertemplate=f"ASHRAE G14 monthly CV(RMSE) gate ≤ {G14_CVRMSE_GATE:g}%<extra></extra>",
+        showlegend=True,
     )
 
     plotly_layout_clean(
@@ -195,6 +202,16 @@ def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
         height=height,
         yaxis_title="% error",
         xaxis_title="Iteration (oldest → newest)",
+    )
+    fig.update_layout(
+        legend=dict(
+            title_text="Series (dashed = ASHRAE G14 monthly gates)",
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="left",
+            x=0,
+        ),
     )
     fig.update_xaxes(dtick=1, showgrid=True, gridcolor="rgba(0,0,0,0.06)")
     fig.update_yaxes(rangemode="tozero", showgrid=True, gridcolor="rgba(0,0,0,0.08)")

--- a/vibe_code_apps_20/wattlab/studio/model_summary.py
+++ b/vibe_code_apps_20/wattlab/studio/model_summary.py
@@ -1,4 +1,4 @@
-"""Read-only model summary for Twin (answers + published run artifacts)."""
+"""Read-only model summary / assumptions for Twin (answers + published run)."""
 
 from __future__ import annotations
 
@@ -10,6 +10,79 @@ from wattlab.studio.ep_viz import find_run_idf
 from wattlab.studio.eui_compare import load_model_eui_from_run
 from wattlab.studio.g14_history import extract_run_g14
 from wattlab.studio.idf_geometry import parse_idf_geometry
+
+# Mission taxonomy (honest mapping only — never invent MEASURED).
+SOURCE_CLASSES = frozenset(
+    {
+        "MEASURED",
+        "DOCUMENTED",
+        "BAS_OBSERVED",
+        "UTILITY_DERIVED",
+        "ENERGY_CODE_DEFAULT",
+        "ENERGYPLUS_AUTOSIZED",
+        "RULE_OF_THUMB",
+        "INFERRED_FROM_GEOMETRY",
+        "INFERRED_FROM_OPERATION",
+        "TYPICAL_BUILDING_DEFAULT",
+        "USER_ENTERED",
+        "UNKNOWN",
+    }
+)
+
+_FIELD_SOURCE_MAP = {
+    "user": "USER_ENTERED",
+    "human": "USER_ENTERED",
+    "default": "TYPICAL_BUILDING_DEFAULT",
+    "vibe19": "BAS_OBSERVED",
+    "inferred": "INFERRED_FROM_OPERATION",
+    "measured": "MEASURED",
+    "documented": "DOCUMENTED",
+    "code": "ENERGY_CODE_DEFAULT",
+    "energy_code": "ENERGY_CODE_DEFAULT",
+    "autosized": "ENERGYPLUS_AUTOSIZED",
+    "rule_of_thumb": "RULE_OF_THUMB",
+    "missing": "UNKNOWN",
+}
+
+# Impact heuristic for risk ranking (no sensitivity sims).
+_IMPACT: dict[str, str] = {
+    "floor_area_ft2": "HIGH",
+    "wwr": "HIGH",
+    "wwr_from_idf_pct": "HIGH",
+    "infil_mult": "HIGH",
+    "lights_w_per_m2": "HIGH",
+    "equip_w_per_m2": "HIGH",
+    "hvac_system": "HIGH",
+    "heating_fuel": "MEDIUM",
+    "climate_zone": "MEDIUM",
+    "floors": "MEDIUM",
+    "shgc": "HIGH",
+    "building_type": "MEDIUM",
+    "weather_mode": "HIGH",
+    "prototype_area_scale": "HIGH",
+    "design_oa": "HIGH",
+    "occupancy": "HIGH",
+    "schedules": "HIGH",
+    "setpoints": "HIGH",
+    "cooling_capacity": "HIGH",
+    "heating_capacity": "HIGH",
+    "fan_power": "MEDIUM",
+}
+
+_CRITICAL_PARAMS = (
+    ("BUILDING", "building_type"),
+    ("BUILDING", "floor_area_ft2"),
+    ("GEOMETRY", "floors"),
+    ("GEOMETRY", "wwr"),
+    ("ENVELOPE", "infil_mult"),
+    ("ENVELOPE", "shgc"),
+    ("INTERNAL_LOADS", "lights_w_per_m2"),
+    ("INTERNAL_LOADS", "equip_w_per_m2"),
+    ("HVAC", "hvac_system"),
+    ("HVAC", "heating_fuel"),
+    ("WEATHER", "weather_mode"),
+    ("CODE", "climate_zone"),
+)
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -49,6 +122,73 @@ def _hvac_hints_from_idf_text(text: str) -> dict[str, Any]:
     }
 
 
+def map_field_source(raw: str | None) -> str:
+    """Map profile field_sources labels → mission source taxonomy."""
+    if not raw:
+        return "UNKNOWN"
+    key = str(raw).strip().lower()
+    if key.upper() in SOURCE_CLASSES:
+        return key.upper()
+    return _FIELD_SOURCE_MAP.get(key, "UNKNOWN")
+
+
+def _confidence_for_source(source: str) -> str:
+    if source in {"MEASURED", "DOCUMENTED", "BAS_OBSERVED", "UTILITY_DERIVED"}:
+        return "HIGH"
+    if source in {"USER_ENTERED", "ENERGYPLUS_AUTOSIZED", "INFERRED_FROM_GEOMETRY"}:
+        return "MEDIUM"
+    if source in {
+        "ENERGY_CODE_DEFAULT",
+        "RULE_OF_THUMB",
+        "TYPICAL_BUILDING_DEFAULT",
+        "INFERRED_FROM_OPERATION",
+    }:
+        return "LOW"
+    return "UNKNOWN"
+
+
+def _impact_for(parameter: str, category: str = "") -> str:
+    if parameter in _IMPACT:
+        return _IMPACT[parameter]
+    cat = category.upper()
+    if cat in {"ENVELOPE", "VENTILATION", "SCHEDULES", "CONTROLS"}:
+        return "HIGH"
+    if cat in {"HVAC", "INTERNAL_LOADS", "GEOMETRY"}:
+        return "MEDIUM"
+    return "LOW"
+
+
+def _row(
+    *,
+    category: str,
+    parameter: str,
+    value: Any,
+    unit: str = "",
+    source: str = "UNKNOWN",
+    confidence: str | None = None,
+    energyplus_object: str = "",
+    verification: str = "",
+    notes: str = "",
+) -> dict[str, Any]:
+    src = source if source in SOURCE_CLASSES else map_field_source(source)
+    conf = confidence or _confidence_for_source(src)
+    missing = value is None or value == "" or value == "—"
+    return {
+        "category": category,
+        "parameter": parameter,
+        "value": "—" if missing else value,
+        "unit": unit,
+        "source": src,
+        "confidence": "UNKNOWN" if missing else conf,
+        "impact": _impact_for(parameter, category),
+        "energyplus_object": energyplus_object,
+        "verification": verification or ("NEEDS REVIEW" if missing or conf == "LOW" else "OK"),
+        "notes": notes,
+        "autosized": src == "ENERGYPLUS_AUTOSIZED",
+        "missing": missing,
+    }
+
+
 def build_model_summary(
     answers: dict[str, Any] | None,
     run_dir: Path | str | None,
@@ -63,6 +203,11 @@ def build_model_summary(
     meta = _scan_meta(run_path) if run_path and run_path.is_dir() else {}
     model_eui = load_model_eui_from_run(run_path) if run_path else {}
     g14 = extract_run_g14(run_path) if run_path else {}
+    manifest = (
+        _load_json(run_path / "run_manifest.json")
+        if run_path and (run_path / "run_manifest.json").is_file()
+        else {}
+    )
 
     geom_block: dict[str, Any] = {
         "floor_area_ft2": answers.get("floor_area_ft2")
@@ -117,20 +262,31 @@ def build_model_summary(
         "city": answers.get("city") or profile.get("city"),
         "lat": answers.get("lat") or profile.get("lat"),
         "lon": answers.get("lon") or profile.get("lon"),
-        "climate_zone": answers.get("climate_zone") or meta.get("climate_zone"),
+        "climate_zone": answers.get("climate_zone")
+        or profile.get("climate_zone")
+        or meta.get("climate_zone"),
+        "code_basis": answers.get("code_basis")
+        or profile.get("code_basis")
+        or meta.get("code_basis")
+        or meta.get("energy_code"),
+        "year_built": answers.get("year_built") or profile.get("year_built"),
         "elec_usd_per_kwh": utility.get("elec_usd_per_kwh"),
         "gas_usd_per_therm": utility.get("gas_usd_per_therm"),
     }
 
     run_block = {
         "run_id": model_eui.get("run_id") or (run_path.name if run_path else None),
-        "weather_mode": model_eui.get("weather_mode"),
+        "weather_mode": model_eui.get("weather_mode") or manifest.get("weather_mode"),
         "prototype_area_scale": model_eui.get("prototype_area_scale"),
         "model_eui_kbtu_ft2": model_eui.get("model_eui_kbtu_ft2"),
         "peak_demand_kw": model_eui.get("peak_demand_kw"),
         "idf": str(idf_path) if idf_path else None,
         "g14": g14,
-        "hypothesis": meta.get("hypothesis") or meta.get("note"),
+        "hypothesis": meta.get("hypothesis") or meta.get("note") or manifest.get("hypothesis"),
+        "energyplus_version": manifest.get("energyplus_version"),
+        "model_sha256": manifest.get("model_sha256"),
+        "weather_sha256": manifest.get("weather_sha256"),
+        "manifest_status": manifest.get("status"),
     }
 
     return {
@@ -139,66 +295,601 @@ def build_model_summary(
         "loads": loads,
         "hvac": hvac_block,
         "run": run_block,
+        "meta": meta,
     }
 
 
-def render_model_summary_panel(summary: dict[str, Any]) -> None:
-    """Streamlit read-only panel (import streamlit only when rendering)."""
-    import streamlit as st
+def _rows_from_field_sources(profile: dict[str, Any]) -> list[dict[str, Any]]:
+    fs = profile.get("field_sources") or {}
+    rows: list[dict[str, Any]] = []
+    for field, meta in sorted(fs.items()):
+        if not isinstance(meta, dict):
+            rows.append(
+                _row(
+                    category="PROFILE",
+                    parameter=str(field),
+                    value=meta,
+                    source="UNKNOWN",
+                    notes="field_sources scalar",
+                )
+            )
+            continue
+        rows.append(
+            _row(
+                category="PROFILE",
+                parameter=str(field),
+                value=meta.get("value"),
+                unit=str(meta.get("unit") or ""),
+                source=map_field_source(meta.get("source")),
+                notes=str(meta.get("note") or ""),
+            )
+        )
+    return rows
 
-    st.caption(
-        "Read-only snapshot from answers.json + published run (IDF / meta). "
-        "Missing fields show as — until the agent stamps them."
-    )
+
+def _sizing_rows(run_path: Path | None) -> list[dict[str, Any]]:
+    if run_path is None or not run_path.is_dir():
+        return []
+    try:
+        from wattlab.energyplus.sizing import parse_sizing_inventory
+    except ImportError:
+        return []
+    try:
+        inv = parse_sizing_inventory(run_path)
+    except Exception:  # noqa: BLE001 — optional artifact
+        return []
+    if not isinstance(inv, dict):
+        return []
+    rows: list[dict[str, Any]] = []
+    components = inv.get("components") or inv.get("component_sizing") or []
+    for c in list(components)[:25]:
+        if not isinstance(c, dict):
+            continue
+        name = c.get("component") or c.get("name") or c.get("object") or "component"
+        field = c.get("field") or c.get("description") or "autosized"
+        val = c.get("value") or c.get("user_design") or c.get("calc_design")
+        rows.append(
+            _row(
+                category="SIZING",
+                parameter=f"{name}:{field}",
+                value=val,
+                unit=str(c.get("units") or ""),
+                source="ENERGYPLUS_AUTOSIZED",
+                energyplus_object=str(name),
+                notes="From eplusout.eio / eplustbl sizing inventory",
+            )
+        )
+    plant = inv.get("central_plant") or inv.get("equipment", {}).get("central_plant") or []
+    if isinstance(plant, list):
+        for p in plant[:10]:
+            if not isinstance(p, dict):
+                continue
+            rows.append(
+                _row(
+                    category="SIZING",
+                    parameter=str(p.get("name") or p.get("equipment") or "plant"),
+                    value=p.get("capacity") or p.get("nominal_capacity"),
+                    source="ENERGYPLUS_AUTOSIZED",
+                    notes="Central plant table",
+                )
+            )
+    return rows
+
+
+def build_assumption_rows(
+    answers: dict[str, Any] | None,
+    run_dir: Path | str | None,
+    *,
+    profile: dict[str, Any] | None = None,
+    summary: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Flatten mission-critical inputs with provenance for Twin tables."""
+    answers = answers if isinstance(answers, dict) else {}
+    profile = profile if isinstance(profile, dict) else {}
+    summary = summary or build_model_summary(answers, run_dir, profile=profile)
     proj = summary.get("project") or {}
     geom = summary.get("geometry") or {}
     loads = summary.get("loads") or {}
     hvac = summary.get("hvac") or {}
     run = summary.get("run") or {}
+    meta = summary.get("meta") or {}
+    run_path = Path(run_dir) if run_dir else None
 
-    c1, c2, c3 = st.columns(3)
-    with c1:
-        st.markdown("**Project**")
-        st.write(
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def _add(row: dict[str, Any]) -> None:
+        key = f"{row['category']}|{row['parameter']}"
+        if key in seen:
+            return
+        seen.add(key)
+        rows.append(row)
+
+    # Profile field_sources first (honest provenance)
+    for r in _rows_from_field_sources(profile):
+        _add(r)
+
+    # Building / project
+    for param, val, unit, src, notes in (
+        ("building_id", proj.get("building_id"), "", "USER_ENTERED", "answers/profile"),
+        ("building_type", proj.get("building_type"), "", "USER_ENTERED", "answers/profile"),
+        ("city", proj.get("city"), "", "USER_ENTERED", ""),
+        ("climate_zone", proj.get("climate_zone"), "", "ENERGY_CODE_DEFAULT", "reference/default basis only"),
+        ("code_basis", proj.get("code_basis"), "", "ENERGY_CODE_DEFAULT", "Not a compliance claim"),
+        ("year_built", proj.get("year_built"), "", "DOCUMENTED", ""),
+        ("lat", proj.get("lat"), "deg", "USER_ENTERED", ""),
+        ("lon", proj.get("lon"), "deg", "USER_ENTERED", ""),
+    ):
+        _add(_row(category="BUILDING", parameter=param, value=val, unit=unit, source=src, notes=notes))
+
+    # Geometry — answers vs IDF
+    _add(
+        _row(
+            category="GEOMETRY",
+            parameter="floor_area_ft2",
+            value=geom.get("floor_area_ft2"),
+            unit="ft²",
+            source="USER_ENTERED" if answers.get("floor_area_ft2") else "INFERRED_FROM_GEOMETRY",
+            notes="answers / geo meta / profile",
+        )
+    )
+    _add(
+        _row(
+            category="GEOMETRY",
+            parameter="floors",
+            value=geom.get("floors"),
+            source="USER_ENTERED" if answers.get("floors") or answers.get("stories") else "UNKNOWN",
+        )
+    )
+    _add(
+        _row(
+            category="GEOMETRY",
+            parameter="wwr",
+            value=geom.get("wwr"),
+            unit="fraction",
+            source="USER_ENTERED" if answers.get("wwr") else "INFERRED_FROM_GEOMETRY",
+            notes="answers or geo_build_meta target",
+        )
+    )
+    _add(
+        _row(
+            category="GEOMETRY",
+            parameter="wwr_from_idf_pct",
+            value=geom.get("wwr_from_idf_pct"),
+            unit="%",
+            source="INFERRED_FROM_GEOMETRY",
+            energyplus_object="FenestrationSurface:Detailed",
+            notes="Parsed from published model.idf",
+        )
+    )
+    _add(
+        _row(
+            category="GEOMETRY",
+            parameter="n_zones",
+            value=geom.get("n_zones"),
+            source="INFERRED_FROM_GEOMETRY",
+            energyplus_object="Zone",
+        )
+    )
+    _add(
+        _row(
+            category="GEOMETRY",
+            parameter="wall_area_m2",
+            value=geom.get("wall_area_m2"),
+            unit="m²",
+            source="INFERRED_FROM_GEOMETRY",
+            energyplus_object="BuildingSurface:Detailed",
+        )
+    )
+    _add(
+        _row(
+            category="GEOMETRY",
+            parameter="window_area_m2",
+            value=geom.get("window_area_m2"),
+            unit="m²",
+            source="INFERRED_FROM_GEOMETRY",
+            energyplus_object="FenestrationSurface:Detailed",
+        )
+    )
+
+    # Loads / dials
+    _add(
+        _row(
+            category="INTERNAL_LOADS",
+            parameter="lights_w_per_m2",
+            value=loads.get("lights_w_per_m2"),
+            unit="W/m²",
+            source="INFERRED_FROM_OPERATION" if meta.get("lights_w_per_m2") is not None else "UNKNOWN",
+            notes="dial_meta / answers",
+        )
+    )
+    _add(
+        _row(
+            category="INTERNAL_LOADS",
+            parameter="equip_w_per_m2",
+            value=loads.get("equip_w_per_m2"),
+            unit="W/m²",
+            source="INFERRED_FROM_OPERATION" if meta.get("equip_w_per_m2") is not None else "UNKNOWN",
+            notes="dial_meta / answers",
+        )
+    )
+    _add(
+        _row(
+            category="ENVELOPE",
+            parameter="infil_mult",
+            value=loads.get("infil_mult"),
+            source="INFERRED_FROM_OPERATION" if meta.get("infil_mult") is not None else "UNKNOWN",
+            notes="HIGH IMPACT when guessed — dial_meta",
+        )
+    )
+    _add(
+        _row(
+            category="ENVELOPE",
+            parameter="shgc",
+            value=loads.get("shgc"),
+            source="INFERRED_FROM_GEOMETRY" if loads.get("shgc") is not None else "UNKNOWN",
+            notes="geo/dial SHGC patch if present",
+        )
+    )
+
+    # HVAC
+    _add(
+        _row(
+            category="HVAC",
+            parameter="hvac_system",
+            value=hvac.get("hvac_system"),
+            source="USER_ENTERED" if answers.get("hvac_system") or profile.get("hvac_system") else "UNKNOWN",
+        )
+    )
+    _add(
+        _row(
+            category="HVAC",
+            parameter="heating_fuel",
+            value=hvac.get("heating_fuel"),
+            source="USER_ENTERED" if answers.get("heating_fuel") or profile.get("heating_fuel") else "UNKNOWN",
+        )
+    )
+    hints = hvac.get("hints") or {}
+    for key, label in (
+        ("chiller_electric", "Chiller:Electric count"),
+        ("cooling_tower", "CoolingTower count"),
+        ("boiler_hotwater", "Boiler:HotWater count"),
+        ("airloophvac", "AirLoopHVAC count"),
+        ("heatpump", "HeatPump count"),
+    ):
+        _add(
+            _row(
+                category="HVAC",
+                parameter=key,
+                value=hints.get(key),
+                source="INFERRED_FROM_GEOMETRY",
+                energyplus_object=label,
+                notes="IDF inventory hint — not nameplate capacity",
+            )
+        )
+
+    # Weather / calibration / repro
+    g14 = run.get("g14") or {}
+    _add(
+        _row(
+            category="WEATHER",
+            parameter="weather_mode",
+            value=run.get("weather_mode"),
+            source="UTILITY_DERIVED" if run.get("weather_mode") else "UNKNOWN",
+            notes="TMY vs AMY from report/manifest",
+        )
+    )
+    _add(
+        _row(
+            category="CALIBRATION",
+            parameter="model_eui_kbtu_ft2",
+            value=run.get("model_eui_kbtu_ft2"),
+            unit="kBtu/ft²-yr",
+            source="UTILITY_DERIVED",
+            notes="From published report.json",
+        )
+    )
+    _add(
+        _row(
+            category="CALIBRATION",
+            parameter="prototype_area_scale",
+            value=run.get("prototype_area_scale"),
+            source="INFERRED_FROM_GEOMETRY",
+        )
+    )
+    _add(
+        _row(
+            category="CALIBRATION",
+            parameter="nmbe_elec_pct",
+            value=g14.get("nmbe_elec_pct"),
+            unit="%",
+            source="UTILITY_DERIVED",
+            notes="G14 scorecard",
+        )
+    )
+    _add(
+        _row(
+            category="CALIBRATION",
+            parameter="cvrmse_elec_pct",
+            value=g14.get("cvrmse_elec_pct"),
+            unit="%",
+            source="UTILITY_DERIVED",
+            notes="G14 scorecard",
+        )
+    )
+    _add(
+        _row(
+            category="REPRO",
+            parameter="energyplus_version",
+            value=run.get("energyplus_version"),
+            source="DOCUMENTED",
+            notes="run_manifest.json",
+        )
+    )
+    _add(
+        _row(
+            category="REPRO",
+            parameter="model_sha256",
+            value=run.get("model_sha256"),
+            source="DOCUMENTED",
+            notes="run_manifest.json",
+        )
+    )
+
+    for r in _sizing_rows(run_path):
+        _add(r)
+
+    # Conditioned vs gross sanity note
+    area = geom.get("floor_area_ft2")
+    if isinstance(area, (int, float)) and area > 0:
+        _add(
+            _row(
+                category="GEOMETRY",
+                parameter="conditioned_area_ft2",
+                value=area,
+                unit="ft²",
+                source="UNKNOWN",
+                confidence="LOW",
+                notes="No separate conditioned area stamp — using gross/model area as proxy",
+                verification="NEEDS REVIEW",
+            )
+        )
+
+    return rows
+
+
+def build_model_at_a_glance(
+    summary: dict[str, Any],
+    rows: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Level-1 engineer snapshot (~30 seconds)."""
+    proj = summary.get("project") or {}
+    geom = summary.get("geometry") or {}
+    hvac = summary.get("hvac") or {}
+    run = summary.get("run") or {}
+    loads = summary.get("loads") or {}
+    g14 = run.get("g14") or {}
+    rows = rows or []
+    low_conf = sum(1 for r in rows if str(r.get("confidence")).upper() == "LOW")
+    missing = sum(1 for r in rows if r.get("missing"))
+    pass_fail = g14.get("pass_fail")
+    if pass_fail:
+        cal = f"G14 {pass_fail}"
+    elif run.get("model_eui_kbtu_ft2") is not None:
+        cal = "preliminary (EUI present)"
+    else:
+        cal = "none"
+
+    wwr = geom.get("wwr_from_idf_pct")
+    if wwr is None and geom.get("wwr") is not None:
+        try:
+            w = float(geom["wwr"])
+            wwr = round(100.0 * w, 1) if w <= 1.0 else round(w, 1)
+        except (TypeError, ValueError):
+            wwr = geom.get("wwr")
+
+    return {
+        "building_type": proj.get("building_type"),
+        "year_built": proj.get("year_built"),
+        "location": proj.get("city"),
+        "code_basis": proj.get("code_basis") or "— (reference/default only; not a compliance claim)",
+        "climate_zone": proj.get("climate_zone"),
+        "weather": run.get("weather_mode"),
+        "gross_floor_area_ft2": geom.get("floor_area_ft2"),
+        "floors": geom.get("floors"),
+        "wwr_pct": wwr,
+        "n_zones": geom.get("n_zones"),
+        "primary_hvac": hvac.get("hvac_system"),
+        "heating": hvac.get("heating_fuel"),
+        "lights_w_per_m2": loads.get("lights_w_per_m2"),
+        "equip_w_per_m2": loads.get("equip_w_per_m2"),
+        "infil_mult": loads.get("infil_mult"),
+        "calibration": cal,
+        "energyplus_version": run.get("energyplus_version"),
+        "run_id": run.get("run_id"),
+        "model_eui_kbtu_ft2": run.get("model_eui_kbtu_ft2"),
+        "low_confidence_inputs": low_conf,
+        "missing_critical_inputs": missing,
+        "hypothesis": run.get("hypothesis"),
+    }
+
+
+def rank_assumption_risk(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """HIGH impact × LOW/UNKNOWN confidence first."""
+    ranked = []
+    for r in rows:
+        impact = str(r.get("impact") or "LOW").upper()
+        conf = str(r.get("confidence") or "UNKNOWN").upper()
+        if impact == "HIGH" and conf in {"LOW", "UNKNOWN"}:
+            bucket = "HIGH IMPACT / LOW CONFIDENCE"
+            order = 0
+        elif impact == "HIGH":
+            bucket = "HIGH IMPACT / HIGH CONFIDENCE"
+            order = 1
+        elif conf in {"LOW", "UNKNOWN"}:
+            bucket = "LOW IMPACT / LOW CONFIDENCE"
+            order = 2
+        else:
+            bucket = "LOW IMPACT / HIGH CONFIDENCE"
+            order = 3
+        ranked.append({**r, "risk_bucket": bucket, "_order": order})
+    ranked.sort(key=lambda x: (x["_order"], x.get("parameter") or ""))
+    for r in ranked:
+        r.pop("_order", None)
+    return ranked
+
+
+def missing_critical_inputs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """What we still don't know — critical params missing or UNKNOWN."""
+    by_param = {r["parameter"]: r for r in rows}
+    out: list[dict[str, Any]] = []
+    for category, param in _CRITICAL_PARAMS:
+        r = by_param.get(param)
+        if r is None or r.get("missing") or str(r.get("confidence")).upper() in {"LOW", "UNKNOWN"}:
+            out.append(
+                {
+                    "parameter": param,
+                    "category": category,
+                    "importance": _impact_for(param, category),
+                    "current_fallback": (r or {}).get("value", "—"),
+                    "confidence": (r or {}).get("confidence", "UNKNOWN"),
+                    "how_to_improve": _how_to_improve(param),
+                }
+            )
+    # Also any other HIGH impact missing
+    for r in rows:
+        if not r.get("missing"):
+            continue
+        if r["parameter"] in {p for _, p in _CRITICAL_PARAMS}:
+            continue
+        if str(r.get("impact")).upper() != "HIGH":
+            continue
+        out.append(
             {
-                "building_id": _dash(proj.get("building_id")),
-                "type": _dash(proj.get("building_type")),
-                "city": _dash(proj.get("city")),
-                "lat/lon": f"{_dash(proj.get('lat'))}, {_dash(proj.get('lon'))}",
-                "climate": _dash(proj.get("climate_zone")),
-                "elec $/kWh": _dash(proj.get("elec_usd_per_kwh")),
-                "gas $/therm": _dash(proj.get("gas_usd_per_therm")),
+                "parameter": r["parameter"],
+                "category": r.get("category"),
+                "importance": "HIGH",
+                "current_fallback": r.get("value"),
+                "confidence": r.get("confidence"),
+                "how_to_improve": _how_to_improve(str(r["parameter"])),
             }
         )
-    with c2:
-        st.markdown("**Geometry**")
-        st.write(
-            {
-                "area_ft2": _dash(geom.get("floor_area_ft2")),
-                "floors": _dash(geom.get("floors")),
-                "WWR": _dash(geom.get("wwr")),
-                "WWR from IDF %": _dash(geom.get("wwr_from_idf_pct")),
-                "zones": _dash(geom.get("n_zones")),
-                "fenestration objs": _dash(geom.get("n_fenestration")),
-                "bbox_ft": _dash(geom.get("bbox_ft")),
-            }
+    return out
+
+
+def _how_to_improve(param: str) -> str:
+    hints = {
+        "wwr": "As-built drawings / takeoff; confirm geo-idf WWR target vs IDF fenestration",
+        "infil_mult": "Blower-door / calibration; avoid leaving prototype default unlabeled",
+        "lights_w_per_m2": "Lighting inventory or dial-loads from measured LPD",
+        "equip_w_per_m2": "Plug-load audit or submeter; stamp dial_meta",
+        "hvac_system": "Mechanical schedules / nameplates; answers.json hvac_system",
+        "design_oa": "TAB report / BAS OA flow; do not treat code min as measured",
+        "floor_area_ft2": "Rentable/gross drawings; answers floor_area_ft2",
+        "climate_zone": "ASHRAE climate map for site lat/lon",
+        "weather_mode": "Publish AMY vs TMY on run report",
+        "shgc": "Window schedule / NFRC; geo SHGC patch meta",
+        "building_type": "Confirm property type in answers (drives defaults)",
+        "floors": "Site survey / drawings",
+        "heating_fuel": "Utility accounts / plant nameplates",
+    }
+    return hints.get(param, "Obtain documented value; re-publish run with meta stamps")
+
+
+def filter_assumption_rows(
+    rows: list[dict[str, Any]],
+    *,
+    mode: str = "ALL",
+) -> list[dict[str, Any]]:
+    mode = (mode or "ALL").upper().replace(" ", "_")
+    if mode in {"ALL", ""}:
+        return list(rows)
+    if mode == "LOW_CONFIDENCE":
+        return [r for r in rows if str(r.get("confidence")).upper() in {"LOW", "UNKNOWN"}]
+    if mode == "AUTOSIZED":
+        return [r for r in rows if r.get("autosized") or r.get("source") == "ENERGYPLUS_AUTOSIZED"]
+    if mode == "CODE_DEFAULT":
+        return [
+            r
+            for r in rows
+            if r.get("source") in {"ENERGY_CODE_DEFAULT", "TYPICAL_BUILDING_DEFAULT"}
+        ]
+    if mode == "NEEDS_REVIEW":
+        return [r for r in rows if str(r.get("verification")).upper() == "NEEDS REVIEW" or r.get("missing")]
+    return list(rows)
+
+
+def render_model_summary_panel(summary: dict[str, Any], rows: list[dict[str, Any]] | None = None) -> None:
+    """Streamlit Model-at-a-Glance + filterable assumptions table."""
+    import pandas as pd
+    import streamlit as st
+
+    rows = rows if rows is not None else []
+    glance = build_model_at_a_glance(summary, rows)
+    risk = rank_assumption_risk(rows)
+    missing = missing_critical_inputs(rows)
+
+    st.caption(
+        "Read-only snapshot from the **actual published run** (model.idf + dial/geo meta + "
+        "answers/profile). Missing fields show as —. "
+        "Code/reference basis is **not** a compliance claim. "
+        "Full dump-gap provenance also on the Assumption Ledger page."
+    )
+
+    st.markdown("#### Model at a glance")
+    g1, g2, g3, g4 = st.columns(4)
+    g1.metric("Gross area (ft²)", _dash(glance.get("gross_floor_area_ft2")))
+    g2.metric("Floors", _dash(glance.get("floors")))
+    g3.metric("WWR %", _dash(glance.get("wwr_pct")))
+    g4.metric("Low-confidence inputs", glance.get("low_confidence_inputs") or 0)
+    glance_table = [
+        {"Item": k.replace("_", " ").title(), "Value": _dash(v)}
+        for k, v in glance.items()
+        if k not in {"low_confidence_inputs", "missing_critical_inputs"}
+    ]
+    st.dataframe(pd.DataFrame(glance_table), width="stretch", hide_index=True, height=280)
+
+    hi_low = [r for r in risk if r.get("risk_bucket") == "HIGH IMPACT / LOW CONFIDENCE"]
+    st.markdown("#### Assumption risk (high impact × low confidence)")
+    if hi_low:
+        st.dataframe(
+            pd.DataFrame(hi_low)[
+                [c for c in ("parameter", "value", "unit", "source", "confidence", "impact", "notes") if c in hi_low[0]]
+            ],
+            width="stretch",
+            hide_index=True,
         )
-    with c3:
-        st.markdown("**Loads / HVAC / run**")
-        hints = hvac.get("hints") or {}
-        g14 = run.get("g14") or {}
-        st.write(
-            {
-                "lights W/m²": _dash(loads.get("lights_w_per_m2")),
-                "equip W/m²": _dash(loads.get("equip_w_per_m2")),
-                "infil mult": _dash(loads.get("infil_mult")),
-                "SHGC": _dash(loads.get("shgc")),
-                "chillers": _dash(hints.get("chiller_electric")),
-                "towers": _dash(hints.get("cooling_tower")),
-                "boilers": _dash(hints.get("boiler_hotwater")),
-                "model EUI": _dash(run.get("model_eui_kbtu_ft2")),
-                "area_scale": _dash(run.get("prototype_area_scale")),
-                "NMBE elec %": _dash(g14.get("nmbe_elec_pct")),
-                "CVRMSE elec %": _dash(g14.get("cvrmse_elec_pct")),
-            }
-        )
+    else:
+        st.caption("No HIGH IMPACT / LOW CONFIDENCE rows in this snapshot.")
+
+    st.markdown("#### What we still don’t know")
+    if missing:
+        st.dataframe(pd.DataFrame(missing), width="stretch", hide_index=True)
+    else:
+        st.caption("Critical Level-1 parameters appear populated.")
+
+    st.markdown("#### Mission-critical inputs")
+    mode = st.selectbox(
+        "Filter",
+        options=["ALL", "LOW CONFIDENCE", "AUTOSIZED", "CODE DEFAULT", "NEEDS REVIEW"],
+        key="twin_assumption_filter",
+    )
+    filtered = filter_assumption_rows(rows, mode=mode)
+    show_cols = [
+        "category",
+        "parameter",
+        "value",
+        "unit",
+        "source",
+        "confidence",
+        "impact",
+        "energyplus_object",
+        "verification",
+        "notes",
+    ]
+    if filtered:
+        df = pd.DataFrame(filtered)
+        cols = [c for c in show_cols if c in df.columns]
+        st.dataframe(df[cols], width="stretch", hide_index=True, height=360)
+    else:
+        st.caption("No rows for this filter.")

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -177,12 +177,23 @@ def _fixture_eplusout() -> Path | None:
     return cand if cand.is_file() else None
 
 
-def _resolve_active_run() -> Path | None:
-    """Prefer session selection, then CURRENT_RUN.txt, then latest runs/ entry."""
-    active = st.session_state.get("studio_active_run")
-    if active and Path(active).is_dir():
-        return Path(active)
-    pointer = runs_dir() / "CURRENT_RUN.txt"
+def resolve_active_run_dir(
+    runs_root: Path,
+    *,
+    session_active: str | Path | None = None,
+    pinned: bool = False,
+) -> Path | None:
+    """Resolve Twin's active run.
+
+    Default: ``CURRENT_RUN.txt`` (agent publish pointer), else newest ``runs/``
+    by mtime. Sticky ``session_active`` wins only when ``pinned`` (human chose
+    Inspect → Show 08 panes).
+    """
+    if pinned and session_active:
+        p = Path(session_active)
+        if p.is_dir():
+            return p
+    pointer = Path(runs_root) / "CURRENT_RUN.txt"
     if pointer.is_file():
         try:
             p = Path(pointer.read_text(encoding="utf-8").strip())
@@ -190,10 +201,29 @@ def _resolve_active_run() -> Path | None:
                 return p
         except OSError:
             pass
-    hist = list_iteration_runs(runs_dir(), limit=1)
+    hist = list_iteration_runs(Path(runs_root), limit=1)
     if hist and hist[0].get("dir"):
         return Path(str(hist[0]["dir"]))
     return None
+
+
+def _resolve_active_run() -> Path | None:
+    """Streamlit wrapper: latest publish unless human pinned an Inspect selection."""
+    return resolve_active_run_dir(
+        runs_dir(),
+        session_active=st.session_state.get("studio_active_run"),
+        pinned=bool(st.session_state.get("studio_run_pinned")),
+    )
+
+
+def _clear_run_pin() -> None:
+    st.session_state.pop("studio_run_pinned", None)
+    st.session_state.pop("twin_iter_pick", None)
+
+
+def _pin_active_run(path: Path | str) -> None:
+    st.session_state["studio_active_run"] = str(path)
+    st.session_state["studio_run_pinned"] = True
 
 
 def _resolve_viz_run(preferred: Path | None = None) -> tuple[Path | None, str | None]:
@@ -397,6 +427,7 @@ def render() -> None:
     )
 
     if st.button("Refresh agent runs", key="twin_refresh_runs"):
+        _clear_run_pin()
         active = _resolve_active_run()
         if active is not None:
             st.session_state["studio_active_run"] = str(active)
@@ -955,7 +986,11 @@ def render() -> None:
             "Timestamps from `run_manifest.json`. G14 columns need `calibration_scorecard.json` per run."
         )
         from wattlab.studio.g14_history import g14_epoch_figure, iter_g14_history
-        from wattlab.studio.model_summary import build_model_summary, render_model_summary_panel
+        from wattlab.studio.model_summary import (
+            build_assumption_rows,
+            build_model_summary,
+            render_model_summary_panel,
+        )
 
         hist = list_iteration_runs(runs_dir(), limit=30)
         if not hist:
@@ -1047,8 +1082,10 @@ def render() -> None:
             st.markdown("**Calibration iterations (G14)**")
             st.caption(
                 "Like a training-loss curve: each published Twin run is an epoch. "
-                "Lower |NMBE| / CV(RMSE) is better. Dashed lines = ASHRAE G14 monthly gates "
-                "(±5% NMBE, 15% CVRMSE). Missing scorecards skip that point."
+                "Lower |NMBE| / CV(RMSE) is better. "
+                "**Dashed legend entries** are ASHRAE G14 monthly gates "
+                "(±5% |NMBE|, ≤15% CVRMSE) — not extra model series. "
+                "Missing scorecards skip that point."
             )
             st.plotly_chart(
                 g14_epoch_figure(g14_rows, height=440),
@@ -1056,9 +1093,27 @@ def render() -> None:
                 key="twin_g14_epoch",
             )
 
+            pick_opts = [h.get("dir") for h in hist if h.get("dir")]
+            active_now = _resolve_active_run()
+            default_ix = 0
+            if active_now is not None:
+                active_s = str(active_now.resolve()) if active_now.exists() else str(active_now)
+                for i, d in enumerate(pick_opts):
+                    try:
+                        if d and str(Path(str(d)).resolve()) == active_s:
+                            default_ix = i
+                            break
+                    except OSError:
+                        if str(d) == str(active_now):
+                            default_ix = i
+                            break
+            # Keep Inspect selection aligned with Twin active run when not mid-widget edit
+            if "twin_iter_pick" not in st.session_state and pick_opts:
+                st.session_state["twin_iter_pick"] = pick_opts[default_ix]
+
             pick = st.selectbox(
                 "Inspect iteration",
-                options=[h.get("dir") for h in hist if h.get("dir")],
+                options=pick_opts,
                 format_func=lambda d: Path(str(d)).name if d else "",
                 key="twin_iter_pick",
             )
@@ -1066,11 +1121,21 @@ def render() -> None:
                 answers = st.session_state.get("studio_answers")
                 if not isinstance(answers, dict):
                     answers = {}
-                summary = build_model_summary(answers, Path(str(pick)), profile=_profile())
-                with st.expander("Model summary (selected iteration)", expanded=True):
-                    render_model_summary_panel(summary)
+                profile = _profile()
+                summary = build_model_summary(answers, Path(str(pick)), profile=profile)
+                rows = build_assumption_rows(
+                    answers, Path(str(pick)), profile=profile, summary=summary
+                )
+                pin_note = (
+                    "Pinned to this Inspect selection."
+                    if st.session_state.get("studio_run_pinned")
+                    else "Twin panes follow latest CURRENT_RUN unless you pin below."
+                )
+                with st.expander("Model assumptions (selected iteration)", expanded=True):
+                    st.caption(pin_note)
+                    render_model_summary_panel(summary, rows)
                 if st.button("Show 08 panes for selection", key="twin_show_iter"):
-                    st.session_state["studio_active_run"] = pick
+                    _pin_active_run(pick)
                     st.rerun()
 
     st.divider()


### PR DESCRIPTION
## Summary
- Twin defaults to latest `CURRENT_RUN` / newest publish; pin only via Show 08 panes; Refresh clears pin.
- Inspect iteration: Model at a glance, risk, missing inputs, filterable provenance assumptions table from actual IDF/meta/answers.
- Calibration iterations (G14): ASHRAE gate lines appear as labeled dashed legend series (not anonymous hlines).

## Test plan
- [x] `pytest tests/test_twin_active_run.py tests/test_twin_g14_model_summary.py tests/test_idf_geometry_viz.py -q`
- [ ] Merge + vibe20-ghcr green; prune branch

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Model-at-a-Glance view with model metadata, assumptions, confidence levels, impact, provenance, and missing-input indicators.
  * Added filterable assumption and risk views for easier review of critical model inputs.
  * Improved iteration selection, pinning, refresh behavior, and automatic active-run detection.
  * Published additional metadata to support Twin 3D massing and model-assumption displays.
  * Updated G14 charts with visible legend entries and hover details for monthly gate thresholds.

* **Documentation**
  * Clarified run publishing, inspection, pinning, and model-assumption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->