### PR TITLE
feat(vibe20): Twin monthly elec/gas % off on Inspect

### DIFF
--- a/vibe_code_apps_20/tests/test_monthly_pct_off.py
+++ b/vibe_code_apps_20/tests/test_monthly_pct_off.py
@@ -1,0 +1,110 @@
+"""Monthly model-vs-bills percent-off narratives."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wattlab.studio.monthly_pct_off import (
+    build_monthly_pct_off,
+    format_fuel_narrative,
+    load_per_month_from_run,
+    month_short_label,
+    pct_off,
+)
+
+
+def test_pct_off_sign():
+    assert pct_off(148.0, 100.0) == 48.0  # model too high
+    assert abs(pct_off(82.0, 100.0) - (-18.0)) < 1e-9  # model too low
+    assert pct_off(100.0, 0.0) is None
+
+
+def test_month_short_label():
+    assert month_short_label("2024-12") == "Dec"
+    assert month_short_label("1") == "Jan"
+    assert month_short_label("06") == "Jun"
+
+
+def test_gas_and_elec_narratives():
+    rows = [
+        {"month": "2024-12", "observed_therms": 100, "simulated_therms": 148},
+        {"month": "2024-01", "observed_therms": 100, "simulated_therms": 141},
+        {"month": "2024-08", "observed_therms": 100, "simulated_therms": 172},
+        {"month": "2024-10", "observed_therms": 100, "simulated_therms": 227},
+        {"month": "2024-11", "observed_therms": 100, "simulated_therms": 144},
+        {"month": "2024-02", "observed_therms": 100, "simulated_therms": 82},
+        {"month": "2024-03", "observed_therms": 100, "simulated_therms": 77},
+        {"month": "2024-04", "observed_therms": 100, "simulated_therms": 75},
+        {"month": "2024-05", "observed_therms": 100, "simulated_therms": 77},
+        {"month": "2024-06", "observed_therms": 100, "simulated_therms": 51},
+        {"month": "2024-07", "observed_therms": 100, "simulated_therms": 69},
+        {"month": "2024-09", "observed_therms": 100, "simulated_therms": 94},
+        {"month": "2024-12", "observed_kwh": 100, "simulated_kwh": 135},
+        {"month": "2024-04", "observed_kwh": 100, "simulated_kwh": 116},
+        {"month": "2024-06", "observed_kwh": 100, "simulated_kwh": 117},
+        {"month": "2024-01", "observed_kwh": 100, "simulated_kwh": 105},
+        {"month": "2024-02", "observed_kwh": 100, "simulated_kwh": 98},
+        {"month": "2024-03", "observed_kwh": 100, "simulated_kwh": 102},
+        {"month": "2024-05", "observed_kwh": 100, "simulated_kwh": 101},
+        {"month": "2024-07", "observed_kwh": 100, "simulated_kwh": 99},
+        {"month": "2024-08", "observed_kwh": 100, "simulated_kwh": 103},
+        {"month": "2024-09", "observed_kwh": 100, "simulated_kwh": 100},
+        {"month": "2024-10", "observed_kwh": 100, "simulated_kwh": 104},
+        {"month": "2024-11", "observed_kwh": 100, "simulated_kwh": 97},
+    ]
+    # Merge same-month elec+gas into combined rows like a real scorecard
+    by_m: dict[str, dict] = {}
+    for r in rows:
+        m = r["month"]
+        by_m.setdefault(m, {"month": m}).update(r)
+    merged = list(by_m.values())
+
+    analysis = build_monthly_pct_off(merged, ok_band_pct=15.0)
+    assert analysis["has_data"]
+    gas_txt = analysis["gas_narrative"]
+    assert "Gas over" in gas_txt
+    assert "Dec" in gas_txt and "+48%" in gas_txt
+    assert "Gas under" in gas_txt
+    assert "Feb" in gas_txt
+    assert "OK-ish" in gas_txt or "Sep" in gas_txt
+
+    elec_txt = analysis["elec_narrative"]
+    assert "Elec" in elec_txt
+    assert "Dec" in elec_txt
+    # Mostly-within phrasing when only a few outliers
+    assert "mostly within" in elec_txt.lower() or "over" in elec_txt.lower()
+
+
+def test_load_per_month_from_run(tmp_path: Path):
+    run = tmp_path / "run_a"
+    run.mkdir()
+    (run / "calibration_scorecard.json").write_text(
+        json.dumps(
+            {
+                "utility_bills": {
+                    "per_month": [
+                        {
+                            "month": "2024-01",
+                            "observed_kwh": 100,
+                            "simulated_kwh": 110,
+                            "observed_therms": 50,
+                            "simulated_therms": 40,
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    rows = load_per_month_from_run(run)
+    assert len(rows) == 1
+    assert rows[0]["modeled_kwh"] == 110
+    analysis = build_monthly_pct_off(rows)
+    assert analysis["elec"]["n"] == 1
+    assert analysis["gas"]["n"] == 1
+
+
+def test_format_empty():
+    empty = {"n": 0, "over": [], "under": [], "ok": [], "ok_band_pct": 15}
+    assert "no monthly" in format_fuel_narrative(empty, label="Gas").lower()

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -152,6 +152,8 @@ reports/utility_bills.csv | last_dry_run_plan.json | BUG_REPORT.md | CALIBRATE_S
 
 **Twin Model assumptions:** Inspect iteration shows Model-at-a-Glance + a provenance
 table from the **published IDF + meta + answers** (not a parallel editable form).
+When the run has `utility_bills.per_month`, Inspect also shows monthly % off
+narratives (model too high/low by month for elec and gas).
 Always publish `model.idf` and dial/geo meta into `runs/<id>/`. Twin panes follow
 `CURRENT_RUN.txt` / newest run; humans pin via **Show 08 panes for selection**.
 **Refresh agent runs** clears the pin. Code/reference basis wording is

--- a/vibe_code_apps_20/wattlab/studio/monthly_pct_off.py
+++ b/vibe_code_apps_20/wattlab/studio/monthly_pct_off.py
@@ -1,0 +1,256 @@
+"""Monthly model-vs-bills percent-off analytics for Twin Inspect."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from wattlab.studio.eui_charts import month_abbrev
+
+# Default "OK-ish" band (±%) for month-by-month narratives
+DEFAULT_OK_BAND_PCT = 15.0
+
+
+def _safe_float(v: Any) -> float | None:
+    if v is None or v == "":
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def month_short_label(month_key: Any) -> str:
+    """``2024-12`` / ``12`` / ``Dec`` → short month label for narratives."""
+    s = str(month_key or "").strip()
+    if not s:
+        return "?"
+    if len(s) >= 7 and s[4] == "-" and s[5:7].isdigit():
+        return month_abbrev(s[5:7])
+    if s.isdigit() and 1 <= int(s) <= 12:
+        return month_abbrev(s)
+    if len(s) >= 3 and s[:3].isalpha():
+        return s[:3].title()
+    return s
+
+
+def pct_off(modeled: float | None, observed: float | None) -> float | None:
+    """(model − bill) / bill × 100. Positive = model too high."""
+    if modeled is None or observed is None:
+        return None
+    if abs(observed) < 1e-9:
+        return None
+    return (float(modeled) - float(observed)) / float(observed) * 100.0
+
+
+def _pair_from_row(row: dict[str, Any], fuel: str) -> tuple[float | None, float | None]:
+    if fuel == "elec":
+        obs = _safe_float(row.get("observed_kwh"))
+        sim = _safe_float(
+            row.get("modeled_kwh")
+            if row.get("modeled_kwh") is not None
+            else row.get("simulated_kwh")
+        )
+        return sim, obs
+    obs = _safe_float(row.get("observed_therms"))
+    sim = _safe_float(
+        row.get("modeled_therms")
+        if row.get("modeled_therms") is not None
+        else row.get("simulated_therms")
+    )
+    return sim, obs
+
+
+def _fmt_signed(pct: float) -> str:
+    # Unicode minus for under, plus for over
+    if pct >= 0:
+        return f"+{pct:.0f}%"
+    return f"−{abs(pct):.0f}%"
+
+
+def _fmt_list(items: list[tuple[str, float]]) -> str:
+    if not items:
+        return ""
+    return ", ".join(f"{lab} {_fmt_signed(p)}" for lab, p in items)
+
+
+def analyze_fuel_months(
+    per_month: list[dict[str, Any]],
+    *,
+    fuel: str,
+    ok_band_pct: float = DEFAULT_OK_BAND_PCT,
+) -> dict[str, Any]:
+    """Bucket months into over / under / ok for one fuel."""
+    over: list[tuple[str, float]] = []
+    under: list[tuple[str, float]] = []
+    ok: list[tuple[str, float]] = []
+    for row in per_month:
+        if not isinstance(row, dict):
+            continue
+        sim, obs = _pair_from_row(row, fuel)
+        pct = pct_off(sim, obs)
+        if pct is None:
+            continue
+        lab = month_short_label(row.get("month") or row.get("period"))
+        if pct > ok_band_pct:
+            over.append((lab, pct))
+        elif pct < -ok_band_pct:
+            under.append((lab, pct))
+        else:
+            ok.append((lab, pct))
+    return {
+        "fuel": fuel,
+        "ok_band_pct": ok_band_pct,
+        "over": over,
+        "under": under,
+        "ok": ok,
+        "n": len(over) + len(under) + len(ok),
+    }
+
+
+def format_fuel_narrative(bucket: dict[str, Any], *, label: str) -> str:
+    """Human analytics blurb for one fuel (elec or gas)."""
+    over = bucket.get("over") or []
+    under = bucket.get("under") or []
+    ok = bucket.get("ok") or []
+    band = float(bucket.get("ok_band_pct") or DEFAULT_OK_BAND_PCT)
+    n = int(bucket.get("n") or 0)
+    if n == 0:
+        return f"{label}: no monthly model↔bill pairs in this scorecard."
+
+    lines: list[str] = []
+    # Prefer "mostly within" when outliers are few
+    outliers = over + under
+    if outliers and len(outliers) <= max(3, n // 4) and len(ok) >= n // 2:
+        except_txt = _fmt_list(sorted(outliers, key=lambda x: -abs(x[1])))
+        lines.append(
+            f"{label} is mostly within ~±{band:g}% except {except_txt}."
+        )
+    else:
+        if over:
+            lines.append(
+                f"{label} over (model too high): {_fmt_list(over)}"
+            )
+        if under:
+            lines.append(
+                f"{label} under (model too low): {_fmt_list(under)}"
+            )
+        if ok:
+            ok_txt = ", ".join(f"{lab} ({_fmt_signed(p)})" for lab, p in ok)
+            lines.append(f"OK-ish (±{band:g}%): {ok_txt}")
+        if not over and not under and ok:
+            lines.append(
+                f"{label}: all {n} months within ±{band:g}% of bills."
+            )
+    return "\n".join(lines)
+
+
+def build_monthly_pct_off(
+    per_month: list[dict[str, Any]] | None,
+    *,
+    ok_band_pct: float = DEFAULT_OK_BAND_PCT,
+) -> dict[str, Any]:
+    """Full elec + gas monthly % off analysis from scorecard ``per_month`` rows."""
+    rows = list(per_month or [])
+    elec = analyze_fuel_months(rows, fuel="elec", ok_band_pct=ok_band_pct)
+    gas = analyze_fuel_months(rows, fuel="gas", ok_band_pct=ok_band_pct)
+    return {
+        "ok_band_pct": ok_band_pct,
+        "elec": elec,
+        "gas": gas,
+        "elec_narrative": format_fuel_narrative(elec, label="Elec"),
+        "gas_narrative": format_fuel_narrative(gas, label="Gas"),
+        "has_data": bool(elec["n"] or gas["n"]),
+    }
+
+
+def load_per_month_from_run(run_dir: Path | str | None) -> list[dict[str, Any]]:
+    """Load ``utility_bills.per_month`` from a published Twin run directory."""
+    if not run_dir:
+        return []
+    root = Path(run_dir)
+    if not root.is_dir():
+        return []
+    for name in ("calibration_scorecard.json", "campaign_stamp.json", "report.json", "wattlab_report.json"):
+        path = root / name
+        if not path.is_file():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        if name == "campaign_stamp.json" and data.get("scorecard_path"):
+            sp = Path(str(data["scorecard_path"]))
+            if sp.is_file():
+                try:
+                    data = json.loads(sp.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError, TypeError):
+                    continue
+        ub = data.get("utility_bills") or {}
+        if not isinstance(ub, dict):
+            # Some reports nest calibration under calibration / g14
+            ub = (data.get("calibration") or {}).get("utility_bills") or {}
+        rows = ub.get("per_month") if isinstance(ub, dict) else None
+        if rows:
+            out = []
+            for pm in rows:
+                if not isinstance(pm, dict):
+                    continue
+                row = dict(pm)
+                if row.get("modeled_kwh") is None and row.get("simulated_kwh") is not None:
+                    row["modeled_kwh"] = row["simulated_kwh"]
+                if row.get("modeled_therms") is None and row.get("simulated_therms") is not None:
+                    row["modeled_therms"] = row["simulated_therms"]
+                out.append(row)
+            if out:
+                return out
+    return []
+
+
+def render_monthly_pct_off_panel(analysis: dict[str, Any]) -> None:
+    """Streamlit panel for Inspect / Modeled-vs-actual."""
+    import streamlit as st
+
+    if not analysis.get("has_data"):
+        st.caption(
+            "Monthly % off needs a published scorecard with `utility_bills.per_month` "
+            "(observed vs simulated kWh/therms) on this run."
+        )
+        return
+    band = analysis.get("ok_band_pct", DEFAULT_OK_BAND_PCT)
+    st.markdown("#### Monthly % off (model vs bills)")
+    st.caption(
+        f"Percent = (model − bill) / bill × 100. Positive = model too high. "
+        f"OK-ish band ±{band:g}%."
+    )
+    gas_n = (analysis.get("gas") or {}).get("n") or 0
+    elec_n = (analysis.get("elec") or {}).get("n") or 0
+    if gas_n:
+        st.markdown(analysis.get("gas_narrative") or "")
+    if elec_n:
+        st.markdown(analysis.get("elec_narrative") or "")
+    # Compact table
+    rows_out: list[dict[str, Any]] = []
+    for fuel_key, label in (("elec", "Elec"), ("gas", "Gas")):
+        b = analysis.get(fuel_key) or {}
+        for bucket_name, items in (
+            ("over", b.get("over") or []),
+            ("under", b.get("under") or []),
+            ("ok", b.get("ok") or []),
+        ):
+            for lab, pct in items:
+                rows_out.append(
+                    {
+                        "fuel": label,
+                        "month": lab,
+                        "pct_off": round(pct, 1),
+                        "bucket": bucket_name,
+                    }
+                )
+    if rows_out:
+        import pandas as pd
+
+        st.dataframe(pd.DataFrame(rows_out), width="stretch", hide_index=True, height=220)

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -877,6 +877,12 @@ def render() -> None:
             g1.metric("G14 NMBE %", f"{stats.get('nmbe_pct', '—')}")
             g2.metric("G14 CV(RMSE) %", f"{stats.get('cvrmse_pct', '—')}")
             g3.metric("Pass/fail", str(ubills.get("pass_fail") or "—"))
+        from wattlab.studio.monthly_pct_off import (
+            build_monthly_pct_off,
+            render_monthly_pct_off_panel,
+        )
+
+        render_monthly_pct_off_panel(build_monthly_pct_off(bills_rows))
     elif monthly_model:
         st.dataframe(pd.DataFrame(monthly_model).head(24), width="stretch", hide_index=True)
 
@@ -1107,7 +1113,10 @@ def render() -> None:
                         if str(d) == str(active_now):
                             default_ix = i
                             break
-            # Keep Inspect selection aligned with Twin active run when not mid-widget edit
+            # Avoid Streamlit "value not in options" when runs/ was pruned
+            cur_pick = st.session_state.get("twin_iter_pick")
+            if cur_pick is not None and cur_pick not in pick_opts:
+                st.session_state.pop("twin_iter_pick", None)
             if "twin_iter_pick" not in st.session_state and pick_opts:
                 st.session_state["twin_iter_pick"] = pick_opts[default_ix]
 
@@ -1134,6 +1143,14 @@ def render() -> None:
                 with st.expander("Model assumptions (selected iteration)", expanded=True):
                     st.caption(pin_note)
                     render_model_summary_panel(summary, rows)
+                    from wattlab.studio.monthly_pct_off import (
+                        build_monthly_pct_off,
+                        load_per_month_from_run,
+                        render_monthly_pct_off_panel,
+                    )
+
+                    pct_analysis = build_monthly_pct_off(load_per_month_from_run(pick))
+                    render_monthly_pct_off_panel(pct_analysis)
                 if st.button("Show 08 panes for selection", key="twin_show_iter"):
                     _pin_active_run(pick)
                     st.rerun()


### PR DESCRIPTION
## Summary
- Follow-up to #34: when Inspect selects a published run (or Modeled vs actual has `per_month`), show gas/elec monthly % off narratives — e.g. model too high/low by month, OK-ish within ±15%.
- Clears stale Inspect selectbox values that are no longer in `runs/`.

## Test plan
- [x] `pytest tests/test_monthly_pct_off.py tests/test_twin_active_run.py tests/test_twin_g14_model_summary.py -q`
- [ ] Merge + vibe20-ghcr; prune branch

Made with [Cursor](https://cursor.com)