### PR TITLE
feat(vibe20): Fuel/Twin UX + dial playbook + Uploads path fix

### DIFF
--- a/vibe_code_apps_19/tests/test_turnkey_app.py
+++ b/vibe_code_apps_19/tests/test_turnkey_app.py
@@ -11,6 +11,7 @@ import json
 import os
 import socket
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -472,7 +473,7 @@ def test_turnkey_live_html_smoke():
     env.pop("VIBE19_BOOTSTRAP", None)
 
     cmd = [
-        env.get("VIBE19_WATTLAB_PYTHON") or "python",
+        env.get("VIBE19_WATTLAB_PYTHON") or sys.executable,
         "-m",
         "streamlit",
         "run",

--- a/vibe_code_apps_20/examples/workspace_tools/README.md
+++ b/vibe_code_apps_20/examples/workspace_tools/README.md
@@ -10,6 +10,9 @@ Prefer product CLIs when they exist (`wattlab geo-idf`, `dial-loads`,
 `score-monthly`, `controls-checklist`). Keep this folder for ladders and
 site experiments.
 
+**Twin dial order + script index:** `vibe20_agent_spec/docs/AGENT_TOOLS.md` and
+`vibe20_agent_spec/docs/TWIN_DIAL_PLAYBOOK.md` (skill `wattlab-twin-calibrate-dial`).
+
 ## Controls checklist
 
 Product path (tip image):
@@ -40,6 +43,6 @@ See `vibe20_agent_spec/docs/AGENT_TOOLS.md` and skill `wattlab-controls-fdd`.
 | Controls | dump HWS peek, checklist wrapper |
 | Geometry | stacked-floor IDF builders |
 | Loads / envelope | vintage climate patches, reheat/SAT patches |
-| Score / ladders | gas G14 ladder, vintage ladder, Open-Meteo vs bills |
+| Score / ladders | `score_g14_monthly`, `write_calibration_scorecard`, gas/vintage ladders |
 
 Pass paths for **any** building — do not hardcode campus names into new scripts.

--- a/vibe_code_apps_20/tests/test_degree_days_fuel_weather.py
+++ b/vibe_code_apps_20/tests/test_degree_days_fuel_weather.py
@@ -119,3 +119,56 @@ def test_fuel_weather_on_fixture_campus():
     assert report["degree_days"]["base_f"] == 65.0
     # Even if polyfit fails on noisy bills, report still builds
     assert "fits" in report
+
+
+def test_select_fits_for_view_filters():
+    from wattlab.benchmarks.fuel_weather import (
+        FIT_VIEW_BOTH,
+        FIT_VIEW_ELECTRIC,
+        FIT_VIEW_GAS,
+        FuelFit,
+        select_fits_for_view,
+    )
+
+    fits = [
+        FuelFit("gas", "hdd", "usage", "mcf", 12, 0.1, 10.0, 0.9, 65.0),
+        FuelFit("electricity", "cdd", "usage", "kwh", 12, 0.2, 20.0, 0.8, 65.0),
+    ]
+    assert len(select_fits_for_view(fits, FIT_VIEW_BOTH)) == 2
+    assert [f.fuel for f in select_fits_for_view(fits, FIT_VIEW_ELECTRIC)] == ["electricity"]
+    assert [f.fuel for f in select_fits_for_view(fits, FIT_VIEW_GAS)] == ["gas"]
+
+
+def test_cooling_season_avg_high_and_pearson():
+    from wattlab.benchmarks.fuel_weather import (
+        cooling_season_avg_high_by_year,
+        pearson_corr,
+        weekday_weekend_elec_cdd_frames,
+    )
+
+    # May–Sep 2024: daily max ~80°F; Jan cold days ignored
+    idx = pd.date_range("2024-01-01", periods=24 * 200, freq="h")
+    temps = []
+    for ts in idx:
+        if ts.month in (5, 6, 7, 8, 9):
+            # Daytime high ~80, night ~70
+            temps.append(80.0 if ts.hour >= 12 else 70.0)
+        else:
+            temps.append(30.0)
+    hourly = pd.Series(temps, index=idx, name="dry_bulb_f")
+    by_year = cooling_season_avg_high_by_year(hourly)
+    assert 2024 in by_year
+    assert by_year[2024] == pytest.approx(80.0, abs=0.5)
+
+    r = pearson_corr([1.0, 2.0, 3.0, 4.0], [2.0, 4.0, 6.0, 8.0])
+    assert r == pytest.approx(1.0, abs=1e-9)
+    assert np.isnan(pearson_corr([1.0], [2.0]))
+
+    # Weekday/weekend split
+    days = pd.date_range("2024-06-03", periods=14, freq="D")  # Mon start
+    kwh = pd.Series([100.0 if d.dayofweek < 5 else 40.0 for d in days], index=days)
+    cdd = pd.Series([10.0] * 14, index=days)
+    frames = weekday_weekend_elec_cdd_frames(kwh, cdd)
+    assert len(frames["weekday"]) == 10
+    assert len(frames["weekend"]) == 4
+    assert frames["weekday"]["kwh"].mean() > frames["weekend"]["kwh"].mean()

--- a/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
+++ b/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from wattlab.studio.g14_history import g14_epoch_figure, iter_g14_history
+from wattlab.studio.g14_history import (
+    assign_run_numbers,
+    g14_epoch_figure,
+    iter_g14_history,
+    pick_best_g14_run,
+)
 from wattlab.studio.idf_geometry import parse_idf_geometry
-from wattlab.studio.model_summary import build_model_summary
+from wattlab.studio.model_summary import build_dial_knobs_rows, build_model_summary
 
 
 def _wall_idf() -> str:
@@ -88,12 +93,50 @@ def test_iter_g14_history_and_epoch(tmp_path: Path):
     assert len(rows) == 3
     assert rows[0]["run_id"] == "run_1"
     assert rows[-1]["nmbe_elec_pct"] == 3.0
+    numbered = assign_run_numbers(rows)
+    assert [r["run"] for r in numbered] == [1, 2, 3]
+    best = pick_best_g14_run(numbered)
+    assert best is not None
+    assert best["run_id"] == "run_3"  # PASS + lowest error
+    # Prefer PASS over lower FAIL error
+    fail_better = [
+        {**numbered[0], "pass_fail": "FAIL", "nmbe_elec_pct": 1.0, "cvrmse_elec_pct": 2.0},
+        {**numbered[2], "pass_fail": "PASS", "nmbe_elec_pct": 4.0, "cvrmse_elec_pct": 10.0},
+    ]
+    assert pick_best_g14_run(fail_better)["run_id"] == "run_3"
     fig = g14_epoch_figure(rows)
     assert len(fig.data) >= 2
     assert fig.layout.height >= 400
     legend_names = [getattr(t, "name", "") or "" for t in fig.data]
     assert any("G14 |NMBE| gate" in n for n in legend_names)
     assert any("G14 CV(RMSE) gate" in n for n in legend_names)
+
+
+def test_build_dial_knobs_rows(tmp_path: Path):
+    run = tmp_path / "knobs"
+    run.mkdir()
+    (run / "dial_meta.json").write_text(
+        json.dumps(
+            {
+                "lights_w_per_m2": 5.0,
+                "equip_w_per_m2": 6.0,
+                "infil_mult": 1.2,
+                "shgc": 0.35,
+                "wwr": 0.4,
+                "hypothesis": "raise LPD",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run / "run_manifest.json").write_text(
+        json.dumps({"run_id": "knobs", "status": "ok"}),
+        encoding="utf-8",
+    )
+    rows = build_dial_knobs_rows({"building_type": "office"}, run)
+    by_knob = {r["knob"]: r["value"] for r in rows}
+    assert by_knob["lights_w_per_m2"] == 5.0
+    assert by_knob["hypothesis"] == "raise LPD"
+    assert by_knob["infil_mult"] == 1.2
 
 
 def test_build_model_summary(tmp_path: Path):

--- a/vibe_code_apps_20/tests/test_uploads_path_resolve.py
+++ b/vibe_code_apps_20/tests/test_uploads_path_resolve.py
@@ -1,0 +1,30 @@
+"""Uploads path resolution under Studio workspace (BUG-001)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wattlab.studio.pages.uploads import _resolve_upload_path
+
+
+def test_resolve_upload_path_relative_under_workspace(tmp_path: Path):
+    dump = tmp_path / "uploads" / "dump"
+    dump.mkdir(parents=True)
+    target = dump / "wattlab_dump_X.zip"
+    target.write_bytes(b"PK\x05\x06" + b"\x00" * 18)
+    got = _resolve_upload_path("uploads/dump/wattlab_dump_X.zip", root=tmp_path)
+    assert got == target.resolve()
+
+
+def test_resolve_upload_path_absolute(tmp_path: Path):
+    target = tmp_path / "abs.zip"
+    target.write_bytes(b"x")
+    got = _resolve_upload_path(str(target), root=tmp_path / "other")
+    assert got == target.resolve()
+
+
+def test_resolve_upload_path_missing_hints_workspace(tmp_path: Path):
+    with pytest.raises(FileNotFoundError, match="Studio workspace"):
+        _resolve_upload_path("uploads/dump/missing.zip", root=tmp_path)

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -111,7 +111,9 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 10. **[`docs/BENCHMARK_GOVERNANCE.md`](docs/BENCHMARK_GOVERNANCE.md)** — when touching benchmarks/guardrails/meters
 11. **[`docs/ESCO_RETROFIT_COST_ROI.md`](docs/ESCO_RETROFIT_COST_ROI.md)** — Lower-48 ESCO $/sf + ROI screening honesty
 12. **[`docs/AGENT_TOOLS.md`](docs/AGENT_TOOLS.md)** — `/data/tools` campaign scripts vs WattLab CLIs
+12b. **[`docs/TWIN_DIAL_PLAYBOOK.md`](docs/TWIN_DIAL_PLAYBOOK.md)** — envelope → shape dial (G14)
 13. **`skills/wattlab-assumptions/SKILL.md`** — defaults hierarchy / Ideal Loads vs explicit HVAC
+13b. **`skills/wattlab-twin-calibrate-dial/SKILL.md`** — short/long fuel + monthly shape knobs
 14. **`skills/wattlab-energyplus-mcp/SKILL.md`** — MCP inspect/sim; DinD + ReadVars
 15. **`skills/wattlab-esco-bins/SKILL.md`** — run/extend the bin-method calculators
 16. **`skills/wattlab-benchmarking/SKILL.md`** — bills → EUI → peer bands → gate
@@ -166,11 +168,13 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 
 | Skill | When |
 | --- | --- |
-| `skills/wattlab-assumptions/` | Sparse twin defaults, Ideal Loads vs explicit HVAC, assumption ledger |
+| `skills/wattlab-assumptions/` | Sparse twin defaults, Ideal Loads vs explicit HVAC, assumption ledger, short/long fuel |
+| `skills/wattlab-twin-calibrate-dial/` | G14 dial: WWR/U/ACH then banded SAT/VAV; scorecard publish |
 | `skills/wattlab-energyplus-mcp/` | MCP tools, capability_status, DinD mounts, ReadVars CSV |
 | `skills/wattlab-esco-bins/` | **Primary math** — bin-method savings calculators + weather bins |
 | `skills/wattlab-benchmarking/` | Bills, EUI, allocation, cost bands, guardrail gate |
 | `skills/wattlab-studio/` | Studio UI work + smoke testing |
+| `skills/wattlab-controls-fdd/` | BAS dump checklist + vibe19 FDD FP tuning |
 | `.agents/skills/*` | Measure-domain depth (schedules, SAT reset, plant efficiency, …) |
 
 ---
@@ -189,9 +193,11 @@ Default archetype remains 5Zone × `prototype_area_scale` — screening only.
 | mcp-exec | `wattlab mcp-exec -- …` | Raw `uv run` inside MCP image |
 
 Workflow: **ensure → geo-idf → custom_idf + area_scale=1 → DinD sim → score-monthly**.
-If elec high / gas low, dial loads via MCP before more schedule patches. Bills:
-area-weighted half elec once — never double-half. Twin shows IDF 3D massing from
-published `model.idf`. Practice campus dumps = labeled rehearsal only.
+If elec high / gas low, dial loads via MCP before more schedule patches. When gas
+is **short** annually, raise **WWR / leaky glass U / ACH** before plant tweaks —
+[`docs/TWIN_DIAL_PLAYBOOK.md`](docs/TWIN_DIAL_PLAYBOOK.md). Bills: area-weighted
+half elec once — never double-half. Twin shows IDF 3D massing from published
+`model.idf`. Practice campus dumps = labeled rehearsal only.
 
 ---
 

--- a/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
@@ -73,7 +73,9 @@ never bake building ids into discovery defaults or silent CLI defaults.
 | `/app/vibe20_agent_spec/AGENT_TESTER_PROMPT.md` | Soak checklist |
 | `/app/vibe20_agent_spec/docs/TWIN_LOOP.md` | Twin loop + geometry gate |
 | `/app/vibe20_agent_spec/skills/wattlab-*/SKILL.md` | Procedure skills |
-| `/app/vibe20_agent_spec/docs/AGENT_TOOLS.md` | `/data/tools` vs WattLab CLIs |
+| `/app/vibe20_agent_spec/docs/AGENT_TOOLS.md` | `/data/tools` vs WattLab CLIs + dial publish chain |
+| `/app/vibe20_agent_spec/docs/TWIN_DIAL_PLAYBOOK.md` | Envelope → shape dial order (G14) |
+| `/app/vibe20_agent_spec/skills/wattlab-twin-calibrate-dial/SKILL.md` | Short/long fuel + monthly shape knobs |
 | `/app/vibe20_agent_spec/docs/ESCO_RETROFIT_COST_ROI.md` | Lower-48 $/sf + ROI screening |
 | `/app/vibe20_agent_spec/skills/wattlab-controls-fdd/SKILL.md` | Dump checklist + vibe19 FP tuning |
 
@@ -91,6 +93,8 @@ Useful commands:
 - `wattlab controls-checklist --dump … --docx` — controls FDD handoff; iterate vibe19 if FP epidemic
 - `wattlab geo-idf` / `dial-loads` / `score-monthly` — geometry / loads / G14 monthly
 - `wattlab mcp-exec -- python -c '…'` — raw MCP one-shot
+- Campaign ladders / dual-fuel scorecard mapping: `python /data/tools/<script>.py`
+  (see `docs/AGENT_TOOLS.md` — prefer product CLIs when they cover the job)
 - `wattlab studio-status --write` → `reports/session_status.json`
 - `wattlab studio-bootstrap --campus … --dump … --run-id … --answers … --ecm-scenario …`
   (merges existing keys — does not drop `ecm_scenario_path`)

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -47,6 +47,33 @@ so agents match the Studio image (avoids host package drift). If the host git
 checkout is on a deleted branch or behind tip, ignore it — use `/app` docs inside
 the container and the tip image revision label.
 
+## Uploads path gotchas (Docker GHCR)
+
+Studio process workspace is usually **`/data`** (`WATTLAB_STUDIO_WORKSPACE`).
+Cwd is often `/app`. Relative path-box inputs must resolve under `/data`
+(fixed BUG-001). Prefer the **file picker**.
+
+| Input | Works? |
+| --- | --- |
+| File picker → `wattlab_dump_*.zip` | Yes (recommended) |
+| `uploads/dump/<file>.zip` | Yes (joins `/data`) |
+| `/data/uploads/dump/<file>.zip` | Yes |
+| `/home/ben/…` host path | No — not mounted |
+| `openfdd_package_v1` / raw OpenFDD zip | No — need vibe19 **WattLab dump** v2/v3 |
+
+Listed dumps appear as absolute `/data/uploads/dump/…` chips on Uploads
+(BUG-002). Schema mismatch for OpenFDD packages raises a clear error (BUG-003).
+
+Session log / bug index often lives on the volume as `reports/BUG_REPORT.md`
+and `reports/CALIBRATE_SESSION.md` (not always in git).
+
+## Twin dial playbook (short/long fuel)
+
+Envelope first (WWR / leaky glass U / ACH), then LPD/EPD for elec, then banded
+SAT + VAV min-flow for monthly gas shape. Autosize plant stays.
+See [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md),
+[`AGENT_TOOLS.md`](AGENT_TOOLS.md), skill `wattlab-twin-calibrate-dial`.
+
 ## Schedule:File + DinD (BUG-W-SCHEDULE-FILE-DIND)
 
 EnergyPlus only mounts `__stage_in` → `/work/in` and the out dir → `/work/out`.

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
@@ -14,18 +14,98 @@ Prefer packaged WattLab commands when they cover the job:
 | Bills → EUI peer bands | `wattlab benchmark` |
 
 Use `/data/tools/<script>.py` for vintage ladders, gas G14 campaigns, stacked
-floor IDFs, HWS peeks, or one-off site experiments. Seed copies live in
-[`examples/workspace_tools/`](../../examples/workspace_tools/).
+floor IDFs, HWS peeks, dual-fuel G14 scorecards, or one-off site experiments.
+Seed themes: [`examples/workspace_tools/`](../../examples/workspace_tools/).
+Human workspace copies often live at `~/wattlab_workspace/tools/` (not in git).
+
+**Twin calibrate dial** (short/long gas & elec, monthly shape): envelope first
+(WWR / U / ACH), then banded SAT + VAV min-flow; EnergyPlus stays **autosize**.
+Playbook: [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md) · skill
+`skills/wattlab-twin-calibrate-dial/SKILL.md`.
 
 ## Layout
 
 ```text
 $WATTLAB_HOST_WORKSPACE/
   tools/                 # campaign scripts (this bin)
+  tools/TWIN_DIAL_PLAYBOOK.md   # optional live workspace copy of dial playbook
   uploads/dump/          # vibe19 wattlab_dump_*.zip
+  uploads/prototypes/    # geo / dial IDFs (+ optional best/ freeze)
   reports/controls_checklist/
+  reports/utility_bills*.csv
+  runs/<id>/             # Twin publish + calibration_scorecard.json
   .artifacts/<campaign>/
 ```
+
+## Prefer product CLIs, then tools scripts
+
+```bash
+docker exec vibe20 wattlab geo-idf …
+docker exec vibe20 wattlab dial-loads …
+docker exec vibe20 wattlab score-monthly …
+docker exec vibe20 wattlab controls-checklist …
+```
+
+```bash
+docker exec -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace \
+  -e ENERGYPLUS_DOCKER_USER=1000:1000 -e PYTHONUNBUFFERED=1 vibe20 \
+  python /data/tools/<script>.py --help
+```
+
+Do **not** hardcode client site names into new scripts — pass paths/args.
+
+## Script index (typical workspace bin)
+
+Names below match common `/data/tools` campaigns. Your volume may have a subset;
+`--help` before inventing flags.
+
+### Controls (vibe19 dump — no EnergyPlus)
+
+| Script | Role |
+| --- | --- |
+| `controls_service_checklist.py` | Dump zip → VAV / sensor / hunting checklist (prefer `wattlab controls-checklist`) |
+| `analyze_hws_reset.py` | Peek dump HWS vs OAT (ad-hoc boiler reset) |
+
+### Geometry / IDF builders
+
+| Script | Role |
+| --- | --- |
+| `build_stacked_6floor_idf.py` | N× single-zone stacked floors + HVACTemplate VAV + WC plant |
+| `build_geo_idf.py` | DOE Large Office → site-scale (prefer `wattlab geo-idf`) |
+
+### Loads / envelope patches
+
+| Script | Role |
+| --- | --- |
+| `dial_loads_mcp.py` | MCP lights/equip/infil (prefer `wattlab dial-loads`) |
+| `patch_reheat_envelope.py` | Seasonal/flat SAT, window U/SHGC, infil, HW SP |
+| `apply_doe_vintage_5a.py` | Post-1980 / Pre-1980 climate fabric + infil + LPD + boiler |
+
+### Score / ladders / weather / Twin publish
+
+| Script | Role |
+| --- | --- |
+| `score_g14_monthly.py` | Monthly G14 NMBE/CVRMSE for **elec and gas** |
+| `write_calibration_scorecard.py` | Map `g14_score.json` → Twin `calibration_scorecard.json` (epoch charts need this shape) |
+| `save_best_model.py` | Freeze a Twin run → `uploads/prototypes/best/<label>/` (+ optional `--set-current`) |
+| `score_b100_monthly.py` | Site annual score vs bills (prefer `wattlab score-monthly`) |
+| `compare_open_meteo_bills.py` | Month-align Open-Meteo AMY vs utility bills |
+| `run_gas_g14_ladder.py` | patch → DinD sim → G14 → Twin publish + hypothesis |
+| `run_vintage_ladder.py` | Vintage IDFs → sim → G14 → Twin publish |
+
+### Publish chain (Studio G14 charts)
+
+```text
+sim → score_g14_monthly → write_calibration_scorecard → publish_run_for_studio
+→ optional save_best_model.py --set-current
+```
+
+Twin G14 epoch / Inspect metrics read `calibration_scorecard.json` (nested
+`utility_bills.stats_electricity` / `stats_natural_gas`). A bare `g14_score.json`
+or flat `wattlab_report.g14` blob is **not** enough for the charts.
+
+G14 pass = both fuels \|NMBE\|≤5% **and** CVRMSE≤15% when both exist.
+Annual % alone ≠ calibrated.
 
 ## Controls checklist + false-positive tuning
 
@@ -42,15 +122,19 @@ FDD (thresholds / gates / role map), re-export, and record before/after notes
 in the MD/DOCX **Agent FDD false-positive tuning** section. Skill:
 `skills/wattlab-controls-fdd/SKILL.md`.
 
-## Run a campaign script
+Checklist JSON is **detection input**. Client Engineering Findings Report is a
+separate vibe19 bridge (`app/reporting/` / Overview **Generate Engineering
+Findings Report**) — see vibe19 agent spec skill `vibe19-engineering-report`.
 
-```bash
-docker exec -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace \
-  -e ENERGYPLUS_DOCKER_USER=1000:1000 -e PYTHONUNBUFFERED=1 vibe20 \
-  python /data/tools/<script>.py --help
-```
+## Dial order (learned from live campaigns)
 
-Do **not** hardcode client site names into new scripts — pass paths/args.
+1. **Geometry lock** — stacked floors or honest `geo-idf`; refuse wrong zoning as “done.”
+2. **Annual gas short** → WWR ↑, leaky glass U ↑, infil ACH ↑ (not plant tons).
+3. **Annual elec short** → LPD / EPD ↑.
+4. **Monthly gas shape** (annual flat, CVRMSE fails) → banded SAT + VAV min-flow + OA hours; read vibe19 DAT first.
+5. **Scorecard + publish** — stamp dial knobs on `dial_meta.json` / `run_manifest.json`.
+
+Details: [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md).
 
 See also: [`AGENT_DOCKER_WORKSPACE.md`](AGENT_DOCKER_WORKSPACE.md),
-[`ESCO_RETROFIT_COST_ROI.md`](ESCO_RETROFIT_COST_ROI.md).
+[`TWIN_LOOP.md`](TWIN_LOOP.md), [`ESCO_RETROFIT_COST_ROI.md`](ESCO_RETROFIT_COST_ROI.md).

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_DIAL_PLAYBOOK.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_DIAL_PLAYBOOK.md
@@ -1,0 +1,95 @@
+# Twin dial playbook (EnergyPlus × utility bills)
+
+Living playbook for agents dialing WattLab Studio twins. Skills:
+[`wattlab-twin-calibrate-dial`](../skills/wattlab-twin-calibrate-dial/SKILL.md),
+[`wattlab-assumptions`](../skills/wattlab-assumptions/SKILL.md) (§ Short/long fuel).
+Tools bin context: [`AGENT_TOOLS.md`](AGENT_TOOLS.md).
+
+Practice campus trajectories (Liberty-style stacked towers) are **labeled
+rehearsal evidence** — pass paths/args for any building; never bake site ids
+into product defaults.
+
+## Autosize note
+
+Stacked HVACTemplate → ExpandObjects twins use **`autosize`** on coils, fans,
+boilers, chillers, and terminal flows. Dialing is **not** about picking tons —
+it is envelope / infiltration / internal gains / **as-operated SAT & VAV mins**.
+
+## Ordered phases
+
+### 0. Geometry + weather + bills
+
+- Confirm the twin geometry the human expects (e.g. stacked `Floor_1`…`Floor_N`,
+  one zone/floor — **not** DOE mid×4 perimeter-core when they want floor massing).
+- AMY EPW overlapping bill months (not TMY screening for G14).
+- Bills: correct CSV (shared elec allocation + **that building’s** gas — never
+  double-half).
+- Builders: `wattlab geo-idf` or `/data/tools/build_stacked_*_idf.py` →
+  ExpandObjects → `run_energyplus`.
+
+### 1. Annual gas short → envelope first
+
+| Step | Knob | Typical direction |
+| --- | --- | --- |
+| 1 | WWR ↑ | toward site curtain-wall reality (often 0.70–0.75) |
+| 2 | Window U (leaky) | toward **U-0.80–1.0 IP** (~4.5–5.7 SI), not pretty DOE glass |
+| 3 | Infiltration ACH ↑ | ladder until annual gas ~flat |
+| 4 | Stop | when \|gas ann\| ≤ ~5% or overshoots |
+
+Do **not** start with plant oversizing when gas is short.
+
+### 2. Annual elec short → plugs/lights
+
+- Raise EPD / LPD (W/m²). Prefer this over random chiller oversizing.
+- Hold LPD/EPD steady while chasing gas **shape** once annual elec is near gate.
+
+### 3. Monthly gas shape (CVRMSE) — after annual ~flat
+
+Classic failure: winter/shoulder gas high, summer gas low (annual cancels).
+
+1. Read vibe19 **AHU discharge-air-temp / SP** by month (fan-on) before inventing SAT.
+2. Seasonal / **banded** cooling SAT (summer dump often ~50°F where dump shows it;
+   winter warmer).
+3. **Scheduled VAV min-flow** (higher true summer, lower winter/shoulder).
+4. Shorter **winter OA** hours to cut Dec/Jan without killing summer reheat.
+5. Soft summer HW OA-reset only if late summer still overshoots with cold dump.
+
+**Trap:** Long cold-dump window (e.g. Apr–Oct @ 50°F) + high constant min-flow →
+shoulder months gas +100%+. Cold-dump **peak summer only**; keep shoulders warmer.
+
+**Trap:** Bills may not track HDD (Feb bill ≫ Jan HDD; Oct bill tiny vs HDD).
+Residual CVRMSE ~25–30% can remain after honest HVAC banding — **document it**;
+do not invent physics to force a 15% CV.
+
+### 4. Score + publish
+
+```bash
+# inside vibe20 (paths are examples)
+python /data/tools/score_g14_monthly.py --eplusout … --bills …
+python /data/tools/write_calibration_scorecard.py   # Twin G14 charts need this
+# publish_run_for_studio / save_best_model.py --set-current
+```
+
+Prefer `wattlab score-monthly` when it covers the job; use tools scripts for
+dual-fuel ladders and scorecard shape mapping.
+
+G14 pass = \|NMBE\|≤5% **and** CVRMSE≤15% on **both** fuels when both exist.
+Stamp WWR / U / ACH / SAT bands / min-flow / OA / hypothesis on
+`dial_meta.json` + `run_manifest.json`.
+
+## Studio UX (agent awareness)
+
+- Twin iteration history: chronological **run #** matching G14 epoch chart.
+- Inspect: dial/hypothesis knobs table + monthly % off + elec/gas overlays.
+- ECMs: default baseline = best G14 run (`pick_best_g14_run`); human override OK.
+- Fuel Weather: reuse Open-Meteo hourly cache for Demand cooling-season avg high.
+
+## Workspace pointers
+
+| Path | Role |
+| --- | --- |
+| `/data/tools/` | Campaign scripts ([`AGENT_TOOLS.md`](AGENT_TOOLS.md)) |
+| `/data/tools/TWIN_DIAL_PLAYBOOK.md` | Optional live copy of this playbook |
+| `/data/reports/CALIBRATE_SESSION.md` | Session narrative (human/agent append) |
+| `/data/runs/CURRENT_RUN.txt` | Preferred Twin publish |
+| `vibe20_agent_spec/skills/wattlab-twin-calibrate-dial/` | Cursor/agent skill |

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -108,6 +108,13 @@ wattlab calibrate-campaign --bundle dump.zip --bills utility_bills.csv --lat …
 See [`CALIBRATE_AND_DELIVERABLES.md`](CALIBRATE_AND_DELIVERABLES.md). Twin UI:
 scorecard metrics + **Build client package** (report / xlsx / zip).
 
+**Site-scale dial order** (when annual or monthly fuels miss — not sparse TMY
+screening): envelope first (WWR / leaky glass U / ACH), then LPD/EPD for elec,
+then banded SAT + VAV min-flow for monthly gas shape. Autosize plant stays.
+Full playbook: [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md) · skill
+`wattlab-twin-calibrate-dial` · tools bin [`AGENT_TOOLS.md`](AGENT_TOOLS.md)
+(`score_g14_monthly` → `write_calibration_scorecard` → publish).
+
 DinD: image includes Docker CLI; set `WATTLAB_HOST_WORKSPACE` + sock.
 Prefer `docker exec vibe20` — [`AGENT_DOCKER_WORKSPACE.md`](AGENT_DOCKER_WORKSPACE.md).
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -152,12 +152,19 @@ reports/utility_bills.csv | last_dry_run_plan.json | BUG_REPORT.md | CALIBRATE_S
 
 **Twin Model assumptions:** Inspect iteration shows Model-at-a-Glance + a provenance
 table from the **published IDF + meta + answers** (not a parallel editable form).
+Iteration history lists chronological **run #** (1…N, oldest → newest) matching the
+G14 epoch chart; Inspect labels look like `#3 · run_id`. A compact **dial / hypothesis
+knobs** table (lights/equip/infil/SHGC/WWR/U/ACH/SAT/OA + hypothesis) sits above the
+full assumptions panel, sourced from `dial_meta` / geo meta / answers.
 When the run has `utility_bills.per_month`, Inspect also shows monthly % off
-narratives (model too high/low by month for elec and gas).
+narratives (model too high/low by month for elec and gas) plus elec **and gas**
+monthly bills-vs-model overlays when therms are present.
 Always publish `model.idf` and dial/geo meta into `runs/<id>/`. Twin panes follow
 `CURRENT_RUN.txt` / newest run; humans pin via **Show 08 panes for selection**.
 **Refresh agent runs** clears the pin. Code/reference basis wording is
 “model reference/default” — never claim ASHRAE 90.1 compliance from defaults alone.
+ECMs default the baseline Twin run to best G14 (`pick_best_g14_run`); override via
+`studio_ecm_baseline_run`.
 
 ## Docker turnkey (Studio + EnergyPlus MCP image)
 

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-assumptions/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-assumptions/SKILL.md
@@ -3,8 +3,10 @@ name: wattlab-assumptions
 description: >-
   Use when building sparse / minimal-info EnergyPlus twins: defaults hierarchy,
   Ideal Loads vs explicit HVAC, PNNL infiltration/OA candidates, assumption
-  ledger, TMY→AMY ladder. Triggers on: sparse building, minimal info, defaults,
-  IdealLoads, assumption ledger, autosize, constrain plant, TMY, AMY, prototype.
+  ledger, TMY→AMY ladder, and short/long fuel G14 dial (WWR/glass/ACH then
+  banded SAT/reheat). Triggers on: sparse building, minimal info, defaults,
+  IdealLoads, assumption ledger, autosize, constrain plant, TMY, AMY, prototype,
+  short gas, CVRMSE, calibrate dial, WWR, infiltration.
 ---
 
 # WattLab assumptions — agent is the assumption-maker
@@ -13,6 +15,8 @@ EnergyPlus simulates; **you** choose, justify, and log defaults. EnergyPlus-MCP
 inspects/patches/sims — it does not pick TMY vs AMY or invent city/area.
 
 Full ladder: [`../../docs/SPARSE_BUILDING_PLAYBOOK.md`](../../docs/SPARSE_BUILDING_PLAYBOOK.md).
+Fuel dial depth: [`../wattlab-twin-calibrate-dial/SKILL.md`](../wattlab-twin-calibrate-dial/SKILL.md)
+· [`../../docs/TWIN_DIAL_PLAYBOOK.md`](../../docs/TWIN_DIAL_PLAYBOOK.md).
 
 ## Hierarchy (strict order)
 
@@ -64,8 +68,42 @@ thermostat / fan hours, WWR, HVAC family, weather mode
 (`TYPICAL_YEAR_SCREENING` / `ACTUAL_YEAR_CALIBRATION` /
 `SUBSTITUTE_CLIMATE_CONCEPTUAL_ONLY`), `prototype_area_scale`.
 
+## Short / long fuel playbook (Twin G14 dial)
+
+Autosized plant is fine for sparse twins — dial **envelope + loads + as-operated
+SAT/VAV**, not invented nameplate tons. Full playbook:
+[`../../docs/TWIN_DIAL_PLAYBOOK.md`](../../docs/TWIN_DIAL_PLAYBOOK.md) (Cursor skill:
+`wattlab-twin-calibrate-dial`). Tools publish chain: [`../../docs/AGENT_TOOLS.md`](../../docs/AGENT_TOOLS.md).
+
+### Gas short annually (model ≪ bills)
+
+1. Lock **good geometry** (e.g. stacked `Floor_1`…`Floor_N` — not DOE mid×4 when
+   the human wants floor massing).
+2. Raise **WWR** toward site (curtain wall often 0.70–0.75).
+3. Leaky glass: **U ≈ 0.80–1.0 IP**, not pretty DOE U.
+4. **Infiltration ACH** ladder; stop near annual gas ±5%.
+5. Only then HVAC shape (below).
+
+### Elec short annually
+
+- Raise **LPD / EPD** (W/m²) before plant oversizing.
+
+### Annual flat but monthly gas CVRMSE fails (winter high / summer low)
+
+1. Read vibe19 **AHU discharge-air-temp / SP** by month (fan-on).
+2. Summer dump (often ~**50°F** when dump shows it) + higher **VAV min-flow** in
+   true summer only.
+3. Warmer winter SAT + shorter winter OA; **band** months — do **not** hold cold
+   dump across long shoulder seasons (blows Oct/Aug gas).
+4. If bills ≠ HDD (Feb peak / Oct tiny), band aggressively and document residual CV.
+
+G14 pass = both fuels \|NMBE\|≤5% **and** CVRMSE≤15%. Annual % alone ≠ calibrated.
+Always write `calibration_scorecard.json` in the Twin-expected nested shape.
+
 ## Do not
 
 - Invent office / Madison / Chicago for a real dump.
 - Claim G14 on TMY vs non-overlapping bills or unscaled ~10k ft² prototype.
 - Quietly publish ROI when guardrails hit `INVESTIGATE`.
+- Call stacked-twin calibrate “done” on DOE mid×4 zoning when the user expects Floor_1–N.
+- Start gas-short campaigns with plant oversizing before envelope / infil.

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-energyplus-mcp/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-energyplus-mcp/SKILL.md
@@ -13,7 +13,10 @@ LBNL EnergyPlus-MCP (~35 tools) is strong for **IDF surgery loops**: load,
 validate, zones/surfaces/schedules/loads, HVAC topology, outputs, simulate,
 plots, diagnostics. It will **not** decide TMY vs AMY, G14, or which FDD finding
 to trust — WattLab + [`docs/SPARSE_BUILDING_PLAYBOOK.md`](../../docs/SPARSE_BUILDING_PLAYBOOK.md)
-own that judgment.
+own that judgment. For **short/long fuel** dial order (WWR / U / ACH → LPD/EPD →
+banded SAT), see [`wattlab-twin-calibrate-dial`](../wattlab-twin-calibrate-dial/SKILL.md)
+and [`docs/TWIN_DIAL_PLAYBOOK.md`](../../docs/TWIN_DIAL_PLAYBOOK.md) — MCP patches
+the IDF; the playbook chooses which knobs.
 
 DOE positions EnergyPlus as an **engine** third parties wrap. MCP is the access
 layer; WattLab is the assumption + honesty framework.

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-twin-calibrate-dial/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-twin-calibrate-dial/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: wattlab-twin-calibrate-dial
+description: >-
+  Dial EnergyPlus Twin models vs utility bills (G14). Use when gas/elec is short
+  or long vs monthly bills, Twin calibrate, WWR/glass/infil ladders, seasonal SAT
+  / VAV reheat / DAT dump, or stacked Floor_1–N twins. Triggers on: calibrate,
+  G14, CVRMSE, short gas, short elec, dial knobs, WWR, infiltration, discharge
+  air temp, reheat, AMY bills, calibration_scorecard.
+---
+
+# WattLab Twin calibrate dial playbook
+
+EnergyPlus **autosizes** plant/coils when fields are `autosize`. You dial
+**envelope + loads + as-operated HVAC setpoints** — not nameplate tons — unless
+the human supplies them.
+
+Canonical doc: [`../../docs/TWIN_DIAL_PLAYBOOK.md`](../../docs/TWIN_DIAL_PLAYBOOK.md).
+Tools bin: [`../../docs/AGENT_TOOLS.md`](../../docs/AGENT_TOOLS.md).
+Assumptions hierarchy: [`../wattlab-assumptions/SKILL.md`](../wattlab-assumptions/SKILL.md).
+
+## Phase 0 — Geometry lock (do this first)
+
+1. Confirm the twin the human expects (e.g. **stacked floors × 1 zone** =
+   `Floor_1`…`Floor_N`).
+2. **Refuse** DOE mid×4 (`Basement` / `Core_mid` / `Perimeter_*`) as the campus
+   twin when the user wants stacked floors.
+3. Weather for G14: **AMY** overlapping bill months (not TMY screening).
+4. Bills: correct CSV (shared elec once + **that building’s** gas).
+5. One hypothesis per `runs/<id>/`; publish + `calibration_scorecard.json`.
+
+## Phase 1 — Annual fuel short/long (envelope + internal gains)
+
+### Gas / heating **short** (model ≪ bills annually)
+
+Ordered knobs (stop when annual gas enters ~±5% or overshoots):
+
+1. Raise **WWR** toward site reality (curtain wall often **0.70–0.75**).
+2. Leaky glass: assembly **U ≈ 0.80–1.0 IP** (~4.5–5.7 SI), not pretty DOE glass.
+3. Raise **infiltration** (ACH ladder).
+4. Only then HVAC shape knobs (Phase 2).
+
+### Electric **short** (model ≪ bills)
+
+- Raise **LPD / EPD** (W/m²). Prefer this over random chiller oversizing.
+- Hold LPD/EPD while chasing gas shape once annual elec is near gate.
+
+### Gas **long** / elec **long**
+
+- Reverse the same knobs (tighter glass, less ACH, lower LPD/EPD).
+
+## Phase 2 — Monthly **shape** (annual flat but CVRMSE fails)
+
+Classic failure: **winter/shoulder gas high, summer gas low** (annual cancels).
+
+### Read vibe19 AHU DAT before inventing SAT
+
+- Map `discharge-air-temp` / `discharge-air-temp-sp` by month (fan-on).
+- Cold dump + aggressive VAV reheat is often as-operated — match it with
+  **banded** SAT, do not invent year-round constant dumps.
+
+### Shape knobs (keep envelope locked once annual is close)
+
+| Symptom | Knob |
+| --- | --- |
+| Summer gas low | Cooler summer **DAT/SAT**, raise **VAV min-flow** in true summer |
+| Winter gas high | Warmer winter SAT, **shorter winter OA** hours, lower winter min-flow |
+| Shoulder spikes from long cold-dump window | **Band** SAT (cold dump peak summer only; warmer shoulders) |
+| Bills ≠ HDD | Do not force physics-only; band months; note residual CV floor |
+
+Prefer **seasonal / banded** `Schedule:Compact` on cooling SAT + scheduled VAV
+min-flow fraction over year-round constant min-flow bumps.
+
+### Honesty
+
+- G14 pass = both fuels \|NMBE\|≤5% **and** CVRMSE≤15%.
+- Annual % alone is **not** calibrated.
+- Document residual: bill shape may not track HDD (log it).
+
+## Phase 3 — Publish / freeze
+
+```text
+sim → score_g14_monthly (or wattlab score-monthly)
+  → write_calibration_scorecard → publish_run_for_studio
+  → optional save_best_model.py --set-current
+```
+
+Stamp WWR / U / ACH / SAT bands / min-flow / OA on `dial_meta.json` /
+`run_manifest.json`. Twin charts need nested `calibration_scorecard.json`
+(`utility_bills.stats_*`) — not a bare `g14_score.json` alone.
+
+## Workspace pointers
+
+- Playbook: `vibe20_agent_spec/docs/TWIN_DIAL_PLAYBOOK.md` (and optional
+  `/data/tools/TWIN_DIAL_PLAYBOOK.md`)
+- Session log: `/data/reports/CALIBRATE_SESSION.md`
+- Score / scorecard / ladders: `/data/tools/` — see `AGENT_TOOLS.md`
+- Studio: chronological run #, dial knobs table, ECMs best-G14 baseline

--- a/vibe_code_apps_20/wattlab/benchmarks/fuel_weather.py
+++ b/vibe_code_apps_20/wattlab/benchmarks/fuel_weather.py
@@ -279,6 +279,124 @@ def residual_frame(aligned: pd.DataFrame, fit: FuelFit) -> pd.DataFrame:
     return sub[["month", "usage", "predicted", "residual", fit.x_name]].reset_index(drop=True)
 
 
+FIT_VIEW_ELECTRIC = "Electric × CDD"
+FIT_VIEW_GAS = "Gas × HDD"
+FIT_VIEW_BOTH = "Both"
+FIT_VIEW_OPTIONS = (FIT_VIEW_BOTH, FIT_VIEW_ELECTRIC, FIT_VIEW_GAS)
+
+
+def select_fits_for_view(fits: list[FuelFit], view: str) -> list[FuelFit]:
+    """Filter OLS fits for the Weather-tab view selectbox."""
+    v = (view or FIT_VIEW_BOTH).strip()
+    if v == FIT_VIEW_ELECTRIC:
+        return [f for f in fits if f.fuel == "electricity"]
+    if v == FIT_VIEW_GAS:
+        return [f for f in fits if f.fuel == "gas"]
+    return list(fits)
+
+
+def _hourly_dry_bulb(hourly: pd.Series | pd.DataFrame, *, col: str = "dry_bulb_f") -> pd.Series:
+    if isinstance(hourly, pd.DataFrame):
+        if col not in hourly.columns:
+            raise KeyError(f"hourly frame missing {col!r}")
+        s = hourly[col].astype(float)
+    else:
+        s = hourly.astype(float)
+    if not isinstance(s.index, pd.DatetimeIndex):
+        raise TypeError("hourly series/frame must have a DatetimeIndex")
+    return s
+
+
+def daily_max_oat_f(hourly: pd.Series | pd.DataFrame, *, col: str = "dry_bulb_f") -> pd.Series:
+    """Daily maximum dry-bulb (°F) from hourly weather."""
+    s = _hourly_dry_bulb(hourly, col=col)
+    return s.groupby(s.index.floor("D")).max()
+
+
+def cooling_season_avg_high_by_year(
+    hourly: pd.Series | pd.DataFrame,
+    *,
+    col: str = "dry_bulb_f",
+    months: tuple[int, ...] = (5, 6, 7, 8, 9),
+) -> dict[int, float]:
+    """Per calendar year: mean of daily-max dry-bulb °F over cooling-season months.
+
+    Default cooling season is May–Sep (months 5–9).
+    """
+    daily_max = daily_max_oat_f(hourly, col=col)
+    if daily_max.empty:
+        return {}
+    idx = pd.DatetimeIndex(daily_max.index)
+    mask = idx.month.isin(months)
+    sub = daily_max.loc[mask]
+    if sub.empty:
+        return {}
+    out: dict[int, float] = {}
+    for year, g in sub.groupby(pd.DatetimeIndex(sub.index).year):
+        vals = g.dropna()
+        if len(vals) == 0:
+            continue
+        out[int(year)] = float(vals.mean())
+    return out
+
+
+def pearson_corr(x: np.ndarray | list[float], y: np.ndarray | list[float]) -> float:
+    """Pearson r; NaN when fewer than 2 finite paired points or zero variance."""
+    xa = np.asarray(x, dtype=float)
+    ya = np.asarray(y, dtype=float)
+    mask = np.isfinite(xa) & np.isfinite(ya)
+    xa, ya = xa[mask], ya[mask]
+    if xa.size < 2:
+        return float("nan")
+    if float(np.std(xa)) < 1e-12 or float(np.std(ya)) < 1e-12:
+        return float("nan")
+    return float(np.corrcoef(xa, ya)[0, 1])
+
+
+def daily_cdd_from_hourly(
+    hourly: pd.Series | pd.DataFrame,
+    *,
+    col: str = "dry_bulb_f",
+    base_f: float = DD_BASE_F,
+) -> pd.Series:
+    """Daily CDD series (index = day) from hourly OAT."""
+    from wattlab.weather.degree_days import daily_mean_oat_f, degree_days_from_daily
+
+    daily = degree_days_from_daily(daily_mean_oat_f(hourly, col=col), base_f=base_f)
+    return daily["cdd"]
+
+
+def weekday_weekend_elec_cdd_frames(
+    daily_kwh: pd.Series,
+    daily_cdd: pd.Series,
+) -> dict[str, pd.DataFrame]:
+    """Join daily electric kWh to daily CDD; split weekday vs weekend.
+
+    Returns ``{"weekday": DataFrame, "weekend": DataFrame}`` with columns
+    ``date``, ``kwh``, ``cdd``, ``day_type``.
+    """
+    kwh = daily_kwh.astype(float).copy()
+    cdd = daily_cdd.astype(float).copy()
+    kwh.index = pd.DatetimeIndex(kwh.index).floor("D")
+    cdd.index = pd.DatetimeIndex(cdd.index).floor("D")
+    joined = pd.DataFrame({"kwh": kwh, "cdd": cdd}).dropna()
+    if joined.empty:
+        empty = pd.DataFrame(columns=["date", "kwh", "cdd", "day_type"])
+        return {"weekday": empty.copy(), "weekend": empty.copy()}
+    dow = joined.index.dayofweek  # Mon=0 … Sun=6
+    joined = joined.assign(
+        day_type=np.where(dow >= 5, "weekend", "weekday"),
+        date=joined.index.strftime("%Y-%m-%d"),
+    )
+    out: dict[str, pd.DataFrame] = {}
+    for kind in ("weekday", "weekend"):
+        sub = joined[joined["day_type"] == kind][["date", "kwh", "cdd", "day_type"]].reset_index(
+            drop=True
+        )
+        out[kind] = sub
+    return out
+
+
 def gas_usage_therms(usage: float, unit: str) -> float:
     u = (unit or "").lower()
     if u in ("therm", "therms"):
@@ -317,12 +435,19 @@ def build_fuel_weather_report(
 
 
 __all__ = [
+    "FIT_VIEW_BOTH",
+    "FIT_VIEW_ELECTRIC",
+    "FIT_VIEW_GAS",
+    "FIT_VIEW_OPTIONS",
     "FuelFit",
     "MIN_OVERLAP_MONTHS",
     "align_fuel_and_degree_days",
     "bill_overlap_months",
     "build_fuel_weather_report",
     "campus_fuel_totals",
+    "cooling_season_avg_high_by_year",
+    "daily_cdd_from_hourly",
+    "daily_max_oat_f",
     "demand_heatmap_frame",
     "fit_weather_responses",
     "fit_window_choices",
@@ -331,5 +456,8 @@ __all__ = [
     "meter_monthly_long",
     "months_for_fit_years",
     "ols_fit",
+    "pearson_corr",
     "residual_frame",
+    "select_fits_for_view",
+    "weekday_weekend_elec_cdd_frames",
 ]

--- a/vibe_code_apps_20/wattlab/seed/bundle.py
+++ b/vibe_code_apps_20/wattlab/seed/bundle.py
@@ -90,9 +90,20 @@ def _load_manifest(path: Path) -> dict[str, Any]:
     schema_s = str(schema)
     if schema_s not in _KNOWN_MANIFEST_SCHEMAS:
         known = ", ".join(sorted(_KNOWN_MANIFEST_SCHEMAS))
+        hint = ""
+        if "openfdd" in schema_s.lower() or schema_s.startswith("openfdd"):
+            hint = (
+                " This looks like an OpenFDD package (`openfdd_package_v1`), not a "
+                "WattLab dump. In vibe19 use Export → WattLab dump (MANIFEST "
+                f"`wattlab_dump_v2`/`v3`), not the raw OpenFDD zip. Accepted: {known}."
+            )
+        else:
+            hint = (
+                f" Accepted: {known} (or omit schema_version / MANIFEST). "
+                "Need vibe19 Export → WattLab dump, not an unrelated zip."
+            )
         raise ValueError(
-            f"Unsupported WattLab MANIFEST schema_version {schema_s!r} "
-            f"({path}); accepted: {known} (or omit schema_version / MANIFEST)"
+            f"Unsupported WattLab MANIFEST schema_version {schema_s!r} ({path}).{hint}"
         )
     return payload
 

--- a/vibe_code_apps_20/wattlab/studio/eui_charts.py
+++ b/vibe_code_apps_20/wattlab/studio/eui_charts.py
@@ -102,7 +102,7 @@ def eui_peer_bullet_figure(
 
     rows = [s for s in series if s.get("eui") is not None and s.get("label")]
     if not rows:
-        rows = [{"label": "Peers only", "eui": peer_p50, "color": "#888", "symbol": "circle"}]
+        rows = [{"label": "Same-type band only", "eui": peer_p50, "color": "#888", "symbol": "circle"}]
 
     labels = [str(r["label"]) for r in rows]
     n = len(labels)
@@ -153,14 +153,14 @@ def eui_peer_bullet_figure(
         y=[None],
         mode="markers",
         marker=dict(size=12, color="rgba(44,160,44,0.5)", symbol="square"),
-        name=f"Peer p20–p80 ({peer_p20:.0f}–{peer_p80:.0f})",
+        name=f"Same-type band p20–p80 ({peer_p20:.0f}–{peer_p80:.0f})",
     )
     fig.add_scatter(
         x=[None],
         y=[None],
         mode="lines",
         line=dict(color="#2ca02c", width=2, dash="dash"),
-        name=f"Peer p50 ({peer_p50:.1f})",
+        name=f"Typical same-type (p50={peer_p50:.1f})",
     )
 
     h = height or max(420, 360 + 20 * max(0, n - 2))

--- a/vibe_code_apps_20/wattlab/studio/g14_history.py
+++ b/vibe_code_apps_20/wattlab/studio/g14_history.py
@@ -93,6 +93,67 @@ def iter_g14_history(runs_root: Path | str, *, limit: int = 30) -> list[dict[str
     return rows
 
 
+def assign_run_numbers(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Add chronological ``run`` 1…N (oldest → newest). Mutates copies."""
+    out: list[dict[str, Any]] = []
+    for i, r in enumerate(rows, start=1):
+        out.append({**r, "run": i})
+    return out
+
+
+def _g14_error_score(row: dict[str, Any]) -> float:
+    """Lower is better: |NMBE|+CVRMSE elec (+ gas when present)."""
+    total = 0.0
+    n = 0
+    for nk, ck in (
+        ("nmbe_elec_pct", "cvrmse_elec_pct"),
+        ("nmbe_gas_pct", "cvrmse_gas_pct"),
+    ):
+        try:
+            nmbe = row.get(nk)
+            cv = row.get(ck)
+            if nmbe is None and cv is None:
+                continue
+            part = 0.0
+            if nmbe is not None:
+                part += abs(float(nmbe))
+            if cv is not None:
+                part += abs(float(cv))
+            total += part
+            n += 1
+        except (TypeError, ValueError):
+            continue
+    if n == 0:
+        return float("inf")
+    return total
+
+
+def _is_g14_pass(row: dict[str, Any]) -> bool:
+    pf = str(row.get("pass_fail") or "").strip().upper()
+    return pf in {"PASS", "PASSED", "OK", "SUCCESS"}
+
+
+def pick_best_g14_run(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Choose best published Twin run for ECM baseline.
+
+    Prefer G14 PASS; else minimize |NMBE|+CVRMSE (elec, plus gas when present).
+    """
+    if not rows:
+        return None
+    numbered = rows if all("run" in r for r in rows) else assign_run_numbers(list(rows))
+    with_metrics = [
+        r
+        for r in numbered
+        if r.get("nmbe_elec_pct") is not None
+        or r.get("cvrmse_elec_pct") is not None
+        or r.get("nmbe_gas_pct") is not None
+    ]
+    pool = with_metrics or numbered
+    passes = [r for r in pool if _is_g14_pass(r)]
+    candidates = passes if passes else pool
+    return min(candidates, key=_g14_error_score)
+
+
 def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
     """Plot |NMBE| and CV(RMSE) vs iteration index (training-loss style)."""
     import plotly.graph_objects as go

--- a/vibe_code_apps_20/wattlab/studio/model_summary.py
+++ b/vibe_code_apps_20/wattlab/studio/model_summary.py
@@ -658,6 +658,59 @@ def build_assumption_rows(
     return rows
 
 
+def build_dial_knobs_rows(
+    answers: dict[str, Any] | None,
+    run_dir: Path | str | None,
+    *,
+    profile: dict[str, Any] | None = None,
+    summary: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Compact dial / hypothesis knobs for Twin Inspect (above full assumptions)."""
+    answers = answers if isinstance(answers, dict) else {}
+    profile = profile if isinstance(profile, dict) else {}
+    summary = summary or build_model_summary(answers, run_dir, profile=profile)
+    meta = summary.get("meta") or {}
+    loads = summary.get("loads") or {}
+    geom = summary.get("geometry") or {}
+    run = summary.get("run") or {}
+    hvac = summary.get("hvac") or {}
+
+    def _val(*keys: str, default: Any = None) -> Any:
+        for src in (meta, loads, geom, answers, profile, hvac, run):
+            if not isinstance(src, dict):
+                continue
+            for k in keys:
+                if src.get(k) is not None and src.get(k) != "":
+                    return src[k]
+        return default
+
+    knobs = [
+        ("lights_w_per_m2", _val("lights_w_per_m2", "lights"), "W/m²"),
+        ("equip_w_per_m2", _val("equip_w_per_m2", "equip"), "W/m²"),
+        ("infil_mult", _val("infil_mult"), ""),
+        ("shgc", _val("shgc"), ""),
+        ("wwr", _val("wwr", "wwr_target", "wwr_from_idf_pct"), ""),
+        ("u_value", _val("u_value", "wall_u", "u_factor"), ""),
+        ("ach", _val("ach", "infil_ach", "ach50"), ""),
+        ("sat", _val("sat", "supply_air_temp_f", "sat_f"), "°F"),
+        ("oa", _val("oa", "design_oa", "oa_cfm_per_person", "oa_hint"), ""),
+        ("hypothesis", _val("hypothesis", "note"), ""),
+    ]
+    rows: list[dict[str, Any]] = []
+    for param, value, unit in knobs:
+        rows.append(
+            {
+                "knob": param,
+                "value": "—" if value is None or value == "" else value,
+                "unit": unit,
+                "source": "dial_meta / geo meta / answers"
+                if value is not None and value != ""
+                else "missing",
+            }
+        )
+    return rows
+
+
 def build_model_at_a_glance(
     summary: dict[str, Any],
     rows: list[dict[str, Any]] | None = None,

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -11,8 +11,96 @@ import streamlit as st
 
 from wattlab.finance import capital_plan, measure_economics, plan_to_csv
 from wattlab.measures.measure_sets import expand_measure_set, list_measure_sets
+from wattlab.studio.g14_history import assign_run_numbers, iter_g14_history, pick_best_g14_run
 from wattlab.studio.proxies import DEFAULT_MEASURE_COSTS, estimate_proxy_savings
-from wattlab.studio.workspace import reports_dir
+from wattlab.studio.workspace import reports_dir, runs_dir
+
+
+def _load_run_report(run_dir: Path | str | None) -> dict[str, Any]:
+    if not run_dir:
+        return {}
+    root = Path(run_dir)
+    for name in ("report.json", "wattlab_report.json", "calibration_scorecard.json"):
+        p = root / name
+        if p.is_file():
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+                return data if isinstance(data, dict) else {}
+            except (OSError, json.JSONDecodeError, TypeError):
+                continue
+    return {}
+
+
+def _render_baseline_run_picker() -> None:
+    """Selectbox of Twin runs; default = best G14; store studio_ecm_baseline_run."""
+    st.subheader("Twin baseline run")
+    st.caption(
+        "ECMs savings/deliverable context follows the selected Twin publish. "
+        "Default is best G14 (PASS preferred, else lowest |NMBE|+CVRMSE)."
+    )
+    try:
+        rows = assign_run_numbers(iter_g14_history(runs_dir(), limit=40))
+    except Exception:
+        rows = []
+    if not rows:
+        st.info("No published Twin runs yet — calibrate on Twin first.")
+        return
+
+    best = pick_best_g14_run(rows)
+    opts = [str(r["dir"]) for r in rows if r.get("dir")]
+    by_dir = {str(r["dir"]): r for r in rows if r.get("dir")}
+
+    stored = st.session_state.get("studio_ecm_baseline_run")
+    if stored and str(stored) in opts:
+        default_dir = str(stored)
+    elif best and best.get("dir"):
+        default_dir = str(best["dir"])
+    else:
+        default_dir = opts[-1] if opts else None
+
+    if default_dir and "studio_ecm_baseline_pick" not in st.session_state:
+        st.session_state["studio_ecm_baseline_pick"] = default_dir
+    cur = st.session_state.get("studio_ecm_baseline_pick")
+    if cur is not None and cur not in opts:
+        st.session_state.pop("studio_ecm_baseline_pick", None)
+        if default_dir:
+            st.session_state["studio_ecm_baseline_pick"] = default_dir
+
+    def _label(d: str) -> str:
+        r = by_dir.get(d) or {}
+        n = r.get("run")
+        rid = r.get("run_id") or Path(d).name
+        pf = r.get("pass_fail") or "—"
+        tag = " · best G14" if best and str(best.get("dir")) == d else ""
+        return f"#{n} · {rid} · {pf}{tag}" if n is not None else f"{rid} · {pf}{tag}"
+
+    pick = st.selectbox(
+        "Baseline Twin run",
+        options=opts,
+        format_func=_label,
+        key="studio_ecm_baseline_pick",
+    )
+    if pick:
+        st.session_state["studio_ecm_baseline_run"] = pick
+        report = _load_run_report(pick)
+        score = {}
+        sp = Path(pick) / "calibration_scorecard.json"
+        if sp.is_file():
+            try:
+                score = json.loads(sp.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError, TypeError):
+                score = {}
+        if report:
+            st.session_state["studio_report"] = {
+                **(st.session_state.get("studio_report") or {}),
+                **report,
+            }
+        meta = by_dir.get(pick) or {}
+        st.caption(
+            f"Active ECM baseline: #{meta.get('run')} · {meta.get('run_id')} · "
+            f"G14={meta.get('pass_fail') or (score.get('utility_bills') or {}).get('pass_fail') or '—'} "
+            f"· `{Path(pick).name}`"
+        )
 
 
 def render() -> None:
@@ -37,6 +125,9 @@ def render() -> None:
                 f"city={answers.get('city')}) — Re-apply bootstrap to unlock ECMs."
             )
         return
+
+    _render_baseline_run_picker()
+    st.divider()
 
     # --- Easy Buttons catalog ---
     from wattlab.studio.pages.ecm_easy_buttons import render as render_easy

--- a/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/fuel_dashboard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -10,14 +11,23 @@ import pandas as pd
 import streamlit as st
 
 from wattlab.benchmarks import Campus, annual_summary, compare_eui
+from wattlab.benchmarks.eui import load_registry, normalize_property_type
 from wattlab.benchmarks.fuel_weather import (
+    FIT_VIEW_BOTH,
+    FIT_VIEW_OPTIONS,
     align_fuel_and_degree_days,
     build_fuel_weather_report,
     campus_fuel_totals,
+    cooling_season_avg_high_by_year,
+    daily_cdd_from_hourly,
     demand_heatmap_frame,
     fit_weather_responses,
     intensity_heatmap_frame,
+    ols_fit,
+    pearson_corr,
     residual_frame,
+    select_fits_for_view,
+    weekday_weekend_elec_cdd_frames,
 )
 from wattlab.benchmarks.meters import ALLOCATION_METHODS, year_month_matrix
 from wattlab.config import ARTIFACTS
@@ -92,14 +102,93 @@ def _fetch_open_meteo(campus: Campus, lat: float, lon: float) -> tuple[pd.DataFr
     return df, meta.model_dump(mode="json")
 
 
-def _peer_rows(summary: dict[str, Any]) -> list[dict[str, Any]]:
+def _same_type_rows(summary: dict[str, Any], property_type_override: str | None = None) -> list[dict[str, Any]]:
     rows = []
     for b in summary["buildings"]:
-        cmp = compare_eui(b["site_eui_kbtu_ft2"], b["property_type"])
+        ptype = property_type_override or b["property_type"]
+        cmp = compare_eui(b["site_eui_kbtu_ft2"], ptype)
         rows.append(
-            {**b, **{f"peer_{k}": cmp[k] for k in ("p20", "p50", "p80", "band", "vs_median_pct")}}
+            {
+                **b,
+                "property_type_used": cmp["property_type"],
+                **{f"peer_{k}": cmp[k] for k in ("p20", "p50", "p80", "band", "vs_median_pct")},
+            }
         )
     return rows
+
+
+def _property_type_choices() -> list[str]:
+    types = sorted(
+        {
+            str(r.get("property_type"))
+            for r in load_registry()
+            if r.get("property_type") and r.get("property_type") != "commercial_all"
+        }
+    )
+    return types or ["office"]
+
+
+def _resolve_building_type(campus: Campus, summary: dict[str, Any]) -> str:
+    answers = st.session_state.get("studio_answers")
+    if isinstance(answers, dict) and answers.get("building_type"):
+        return normalize_property_type(str(answers["building_type"]))
+    if campus.buildings:
+        return normalize_property_type(campus.buildings[0].property_type or "office")
+    if summary.get("buildings"):
+        return normalize_property_type(str(summary["buildings"][0].get("property_type") or "office"))
+    return "office"
+
+
+def _interval_electric_daily_kwh() -> pd.Series | None:
+    """Daily electric kWh from session/uploads interval meters, if present."""
+    ds = st.session_state.get("studio_interval")
+    frame = None
+    if ds is not None and getattr(ds, "frame", None) is not None:
+        frame = ds.frame
+    if frame is None:
+        path = None
+        answers = st.session_state.get("studio_answers")
+        if isinstance(answers, dict):
+            path = answers.get("interval_meters") or answers.get("interval_data_path")
+        if not path:
+            path = st.session_state.get("studio_interval_path")
+        if path:
+            p = Path(str(path))
+            if p.is_file():
+                try:
+                    from wattlab.existing_building.interval_meters import load_interval_csv
+
+                    loaded = load_interval_csv(p)
+                    st.session_state["studio_interval"] = loaded
+                    frame = loaded.frame
+                except Exception:
+                    return None
+    if frame is None or "electric_kwh" not in getattr(frame, "columns", []):
+        return None
+    s = frame["electric_kwh"].astype(float)
+    if not isinstance(s.index, pd.DatetimeIndex):
+        return None
+    daily = s.groupby(s.index.floor("D")).sum()
+    if daily.dropna().empty:
+        return None
+    return daily
+
+
+def _cache_hourly_wx(df: pd.DataFrame | pd.Series) -> None:
+    """Persist hourly weather for Weather + Demand tabs (plan key + legacy)."""
+    if isinstance(df, pd.Series):
+        frame = df.to_frame(name="dry_bulb_f")
+    else:
+        frame = df
+    st.session_state["fuel_dash_hourly"] = frame
+    st.session_state["fuel_dash_hourly_wx"] = frame
+
+
+def _hourly_wx_from_session() -> pd.DataFrame | pd.Series | None:
+    wx = st.session_state.get("fuel_dash_hourly_wx")
+    if wx is not None:
+        return wx
+    return st.session_state.get("fuel_dash_hourly")
 
 
 def _render_portfolio(summary: dict[str, Any], campus: Campus, px, go) -> None:
@@ -113,16 +202,36 @@ def _render_portfolio(summary: dict[str, Any], campus: Campus, px, go) -> None:
         "Cost / carbon / anomaly KPIs: **NEEDS_INPUT** (not in monthly campus package)."
     )
 
-    st.subheader("Site EUI vs peers (same property type)")
+    choices = _property_type_choices()
+    current = _resolve_building_type(campus, summary)
+    if current not in choices:
+        choices = [current, *choices]
+    ix = choices.index(current) if current in choices else 0
+    override = st.selectbox(
+        "Building type (benchmark override)",
+        choices,
+        index=ix,
+        key="fuel_dash_building_type",
+        help="Writes studio_answers['building_type'] and refreshes same-type EUI compare.",
+    )
+    answers = st.session_state.get("studio_answers")
+    if not isinstance(answers, dict):
+        answers = {}
+    if str(answers.get("building_type") or "") != override:
+        answers = {**answers, "building_type": override}
+        st.session_state["studio_answers"] = answers
+
+    st.subheader("Site EUI vs other buildings (same type)")
     with st.expander("How buildings are benchmarked", expanded=False):
         st.markdown(
             "Site EUI is annualized utility energy ÷ floor area (kBtu/ft²·yr). "
-            "Peer **p20 / p50 / p80** come from a public EPA/CBECS-style registry "
-            "keyed by each building's `property_type` (office, school, …). "
-            "Below p20 ≈ efficient vs peers; above p80 ≈ needs attention. "
+            "Typical same-type EUI uses a public EPA/CBECS-style registry keyed by "
+            "`building_type` / `property_type` (office, school, …). "
+            "Same-type band (efficient…attention): below registry **p20** ≈ efficient; "
+            "above **p80** ≈ needs attention. "
             "This is a screening band — not ENERGY STAR scores or calibrated models."
         )
-    rows = _peer_rows(summary)
+    rows = _same_type_rows(summary, property_type_override=override)
     dfb = pd.DataFrame(rows)
     b0 = rows[0]
     p1, p2, p3, p4 = st.columns(4)
@@ -132,24 +241,23 @@ def _render_portfolio(summary: dict[str, Any], campus: Campus, px, go) -> None:
         help="Annualized campus/building bills ÷ floor area (kBtu/ft²·yr).",
     )
     p2.metric(
-        "Peer typical (p50)",
+        "Typical same-type EUI (p50)",
         f"{b0['peer_p50']} kBtu/ft²",
-        help="Median peer site EUI for this property_type (EPA/CBECS-style registry).",
+        help="Median site EUI for this building type (EPA/CBECS-style registry).",
     )
     p3.metric(
-        "Peer p20–p80",
+        "Same-type band (p20–p80)",
         f"{b0['peer_p20']} – {b0['peer_p80']}",
-        help="Typical peer band: p20 (efficient side) to p80 (high side).",
+        help="Efficient side (p20) to attention side (p80) for this building type.",
     )
     p4.metric(
-        "vs median",
+        "vs typical",
         f"{b0['peer_vs_median_pct']:+.1f}% · {b0['peer_band']}",
-        help="Percent vs peer p50 and band label (efficient / typical / high).",
+        help="Percent vs registry p50 and band label (efficient / typical / high).",
     )
 
     from wattlab.studio.eui_charts import eui_peer_bullet_figure
 
-    # One band per property type when mixed; else shared band + one row per building
     series = []
     for _, r in dfb.iterrows():
         series.append(
@@ -160,20 +268,56 @@ def _render_portfolio(summary: dict[str, Any], campus: Campus, px, go) -> None:
                 "symbol": "diamond",
             }
         )
-    # Use first building's peers as the screening band (same-type campuses);
-    # per-building bands still show in the metrics / attention table.
     fig_peer = eui_peer_bullet_figure(
         peer_p20=float(dfb["peer_p20"].iloc[0]),
         peer_p50=float(dfb["peer_p50"].iloc[0]),
         peer_p80=float(dfb["peer_p80"].iloc[0]),
         series=series,
-        title="Site EUI vs peer p20–p80 band",
+        title="Site EUI vs same-type band (efficient…attention)",
         height=440,
     )
     st.caption(
-        "Upright peer band (green = p20–p80, dashed = p50). Diamonds = building site EUI from bills."
+        "Upright same-type band (green = p20–p80, dashed = p50). "
+        "Diamonds = building site EUI from bills."
     )
     st.plotly_chart(fig_peer, width="stretch", key="fuel_peer_eui_chart")
+
+    st.subheader("Intensity heatmaps")
+    h1, h2 = st.columns(2)
+    with h1:
+        mat = intensity_heatmap_frame(campus, fuel="electricity")
+        if not mat.empty:
+            from wattlab.studio.eui_charts import month_abbrev_columns
+
+            st.plotly_chart(
+                px.imshow(
+                    month_abbrev_columns(mat),
+                    aspect="auto",
+                    color_continuous_scale="YlOrRd",
+                    title="Elec kBtu/ft²",
+                ),
+                width="stretch",
+                key="fuel_heat_elec",
+            )
+        else:
+            st.caption("No electric intensity months.")
+    with h2:
+        mat = intensity_heatmap_frame(campus, fuel="gas")
+        if not mat.empty:
+            from wattlab.studio.eui_charts import month_abbrev_columns
+
+            st.plotly_chart(
+                px.imshow(
+                    month_abbrev_columns(mat),
+                    aspect="auto",
+                    color_continuous_scale="Blues",
+                    title="Gas kBtu/ft²",
+                ),
+                width="stretch",
+                key="fuel_heat_gas",
+            )
+        else:
+            st.caption("No gas intensity months.")
 
     # Stacked monthly by commodity
     totals = campus_fuel_totals(campus)
@@ -207,7 +351,13 @@ def _render_portfolio(summary: dict[str, Any], campus: Campus, px, go) -> None:
                 "peer_band",
                 "peer_vs_median_pct",
             ]
-        ],
+        ].rename(
+            columns={
+                "peer_p50": "typical_same_type_p50",
+                "peer_band": "same_type_band",
+                "peer_vs_median_pct": "vs_typical_pct",
+            }
+        ),
         width="stretch",
         hide_index=True,
     )
@@ -359,18 +509,18 @@ def _render_weather(campus: Campus, px, go) -> None:
             else:
                 with st.spinner("Open-Meteo (full bill span)…"):
                     df, meta = _fetch_open_meteo(campus, lat_u, lon_u)
-                st.session_state["fuel_dash_hourly"] = df
+                _cache_hourly_wx(df)
                 st.session_state["fuel_dash_meta"] = meta
                 st.success(f"Open-Meteo OK — {meta.get('rows')} rows (all bill years)")
         except Exception as exc:
             st.error(f"Open-Meteo failed: {exc}")
     if w2.button("Synthetic seasonal OAT (offline)", key="fuel_dash_synth"):
         s = _synthetic_hourly(campus)
-        st.session_state["fuel_dash_hourly"] = s.to_frame(name="dry_bulb_f")
+        _cache_hourly_wx(s)
         st.session_state["fuel_dash_meta"] = {"source": "synthetic_seasonal", "rows": int(len(s))}
         st.warning("Synthetic OAT — prefer Open-Meteo for real R².")
 
-    hourly = st.session_state.get("fuel_dash_hourly")
+    hourly = _hourly_wx_from_session()
     meta = st.session_state.get("fuel_dash_meta") or {}
     if hourly is None:
         st.info("Fetch Open-Meteo or use synthetic OAT for degree-day fits.")
@@ -388,11 +538,23 @@ def _render_weather(campus: Campus, px, go) -> None:
     if not fits:
         st.warning("Need ≥6 overlapping months for R².")
         return
-    mcols = st.columns(len(fits))
-    for col, fit in zip(mcols, fits):
+
+    view = st.selectbox(
+        "Fit view",
+        list(FIT_VIEW_OPTIONS),
+        index=list(FIT_VIEW_OPTIONS).index(FIT_VIEW_BOTH),
+        key="fuel_dash_fit_view",
+        help="Show electric×CDD, gas×HDD, or both OLS scatters.",
+    )
+    shown = select_fits_for_view(fits, view)
+    if not shown:
+        st.warning(f"No fit available for view “{view}” in this window.")
+        return
+    mcols = st.columns(len(shown))
+    for col, fit in zip(mcols, shown):
         col.metric(f"{fit.fuel} R² ({fit.x_name.upper()})", f"{fit.r2:.3f}")
 
-    for fit in fits:
+    for fit in shown:
         sub = aligned[aligned["fuel"] == fit.fuel]
         fig = go.Figure()
         fig.add_scatter(
@@ -421,6 +583,56 @@ def _render_weather(campus: Campus, px, go) -> None:
             key=f"fuel_wx_resid_{fit.fuel}",
         )
 
+    interval_daily = _interval_electric_daily_kwh()
+    has_interval = interval_daily is not None
+    weekends = st.checkbox(
+        "Weekends vs weekdays (electric × daily CDD)",
+        value=False,
+        key="fuel_dash_weekday_weekend",
+        disabled=not has_interval,
+    )
+    if not has_interval:
+        st.caption(
+            "Needs interval electric meters; monthly bills cannot split weekdays/weekends."
+        )
+    elif weekends:
+        try:
+            cdd = daily_cdd_from_hourly(hourly)
+            frames = weekday_weekend_elec_cdd_frames(interval_daily, cdd)
+            for kind, sub in frames.items():
+                if sub.empty or len(sub) < 3:
+                    st.caption(f"{kind.title()}: not enough overlapping days.")
+                    continue
+                fig_d = go.Figure()
+                fig_d.add_scatter(
+                    x=sub["cdd"],
+                    y=sub["kwh"],
+                    mode="markers",
+                    text=sub["date"],
+                    name=kind,
+                )
+                slope, intercept, r2 = ols_fit(
+                    sub["cdd"].to_numpy(), sub["kwh"].to_numpy()
+                )
+                if np.isfinite(r2):
+                    xs = np.linspace(float(sub["cdd"].min()), float(sub["cdd"].max()), 40)
+                    fig_d.add_scatter(
+                        x=xs,
+                        y=slope * xs + intercept,
+                        mode="lines",
+                        name=f"R²={r2:.3f}",
+                    )
+                fig_d.update_layout(
+                    title=f"{kind.title()} electric kWh vs daily CDD",
+                    height=320,
+                    margin=dict(l=10, r=10, t=40, b=10),
+                    xaxis_title="CDD",
+                    yaxis_title="kWh/day",
+                )
+                st.plotly_chart(fig_d, width="stretch", key=f"fuel_wx_daytype_{kind}")
+        except Exception as exc:
+            st.warning(f"Weekday/weekend chart failed: {exc}")
+
     report = build_fuel_weather_report(
         campus, hourly, weather_source=str(meta.get("source") or "unknown"), months=fit_months
     )
@@ -429,6 +641,8 @@ def _render_weather(campus: Campus, px, go) -> None:
 
 
 def _render_demand(campus: Campus, px) -> None:
+    import plotly.graph_objects as go
+
     from wattlab.studio.eui_charts import month_abbrev_columns
 
     st.subheader("Demand & peak analysis")
@@ -443,16 +657,71 @@ def _render_demand(campus: Campus, px) -> None:
         width="stretch",
         key="fuel_heat_demand",
     )
-    # Monthly peak bars when heatmap has numeric values
     peaks = mat.max(axis=1)
-    if not peaks.empty:
-        fig = px.bar(
-            x=peaks.index.astype(str),
-            y=peaks.values,
-            labels={"x": "year", "y": "peak_kw"},
-            title="Peak demand by year (from bill demand_kw)",
+    if peaks.empty:
+        return
+
+    hourly = _hourly_wx_from_session()
+    cool_by_year = cooling_season_avg_high_by_year(hourly) if hourly is not None else {}
+
+    years = [int(y) for y in peaks.index]
+    peak_vals = [float(peaks.loc[y]) for y in peaks.index]
+    cool_vals = [cool_by_year.get(int(y)) for y in years]
+
+    fig = go.Figure()
+    fig.add_bar(x=[str(y) for y in years], y=peak_vals, name="Peak kW", marker_color="#1f77b4")
+    if any(v is not None for v in cool_vals):
+        fig.add_scatter(
+            x=[str(y) for y in years],
+            y=cool_vals,
+            mode="lines+markers",
+            name="Cooling-season avg high °F (May–Sep)",
+            yaxis="y2",
+            line=dict(color="#d62728", width=2),
         )
-        st.plotly_chart(fig, width="stretch", key="fuel_monthly_peak")
+        fig.update_layout(
+            yaxis2=dict(
+                title="Avg daily-max °F",
+                overlaying="y",
+                side="right",
+                showgrid=False,
+            ),
+        )
+    else:
+        st.caption("Fetch Open-Meteo on Weather & Baseline first.")
+    fig.update_layout(
+        title="Peak demand by year + cooling-season avg high",
+        height=380,
+        margin=dict(l=10, r=10, t=40, b=10),
+        yaxis_title="peak_kw",
+        legend=dict(orientation="h", y=1.12),
+    )
+    st.plotly_chart(fig, width="stretch", key="fuel_monthly_peak")
+
+    pairs_x = []
+    pairs_y = []
+    for y, pk, cool in zip(years, peak_vals, cool_vals):
+        if cool is None or not np.isfinite(cool) or not np.isfinite(pk):
+            continue
+        pairs_x.append(float(cool))
+        pairs_y.append(float(pk))
+    if len(pairs_x) >= 2:
+        r = pearson_corr(pairs_x, pairs_y)
+        c1, c2 = st.columns(2)
+        c1.metric(
+            "r(peak kW, cool-season avg high)",
+            f"{r:.3f}" if np.isfinite(r) else "—",
+            help="Pearson correlation across bill years with weather cache.",
+        )
+        scatter = px.scatter(
+            x=pairs_x,
+            y=pairs_y,
+            labels={"x": "Cooling-season avg high °F", "y": "Peak kW"},
+            title="Peak kW vs cooling-season avg high",
+        )
+        c2.plotly_chart(scatter, width="stretch", key="fuel_peak_cool_scatter")
+    elif hourly is not None:
+        st.caption("Need ≥2 years with both peak kW and cooling-season highs for correlation.")
 
 
 def _render_data_quality(campus: Campus, summary: dict[str, Any]) -> None:
@@ -472,39 +741,7 @@ def _render_data_quality(campus: Campus, summary: dict[str, Any]) -> None:
         f"Allocation method is a scenario (not meter truth). Shared meters: "
         f"{[m.meter_id for m in campus.meters if m.shared] or 'none'}."
     )
-    h1, h2 = st.columns(2)
-    with h1:
-        mat = intensity_heatmap_frame(campus, fuel="electricity")
-        if not mat.empty:
-            import plotly.express as px
-            from wattlab.studio.eui_charts import month_abbrev_columns
-
-            st.plotly_chart(
-                px.imshow(
-                    month_abbrev_columns(mat),
-                    aspect="auto",
-                    color_continuous_scale="YlOrRd",
-                    title="Elec kBtu/ft²",
-                ),
-                width="stretch",
-                key="fuel_heat_elec",
-            )
-    with h2:
-        mat = intensity_heatmap_frame(campus, fuel="gas")
-        if not mat.empty:
-            import plotly.express as px
-            from wattlab.studio.eui_charts import month_abbrev_columns
-
-            st.plotly_chart(
-                px.imshow(
-                    month_abbrev_columns(mat),
-                    aspect="auto",
-                    color_continuous_scale="Blues",
-                    title="Gas kBtu/ft²",
-                ),
-                width="stretch",
-                key="fuel_heat_gas",
-            )
+    st.caption("Intensity heatmaps moved to **Portfolio Overview**.")
 
 
 def render(*, campus: Campus | None = None) -> None:

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -50,12 +50,13 @@ def _render_eui_index(
     run_dir: Path | None = None,
     chart_key: str = "twin_eui_index",
 ) -> None:
-    """Bills vs peer typical EUI vs EnergyPlus model — always visible when data exists."""
+    """Bills vs typical same-type EUI vs EnergyPlus model — always visible when data exists."""
     with st.container(border=True):
-        st.subheader("EUI index — bills vs peers vs model")
+        st.subheader("EUI index — bills vs other buildings (same type) vs model")
         st.caption(
-            "Upright peer band (p20–p80, dashed p50). **Bills** = annualized site EUI from utilities. "
-            "**Peers** = public registry for this property type. **Model** = EnergyPlus site intensity "
+            "Upright same-type band (p20–p80, dashed p50). **Bills** = annualized site EUI from utilities. "
+            "**Other buildings (same type)** = public registry for this property type. "
+            "**Model** = EnergyPlus site intensity "
             "(comparable as EUI; absolute kWh needs site-scale geometry + area_scale=1)."
         )
         bill_eui = None
@@ -97,7 +98,7 @@ def _render_eui_index(
         if bill_eui is None and model_eui is None:
             st.info(
                 "Load Fuel campus bills and/or publish a Twin run with report.json to see "
-                "bill EUI vs peer p20/p50/p80 vs model."
+                "bill EUI vs typical same-type (p20/p50/p80) vs model."
             )
             return
 
@@ -116,9 +117,9 @@ def _render_eui_index(
             help="Annualized utility bills ÷ floor area (kBtu/ft²·yr).",
         )
         m2.metric(
-            "Peer typical (p50)",
+            "Typical same-type EUI (p50)",
             f"{idx['peer_p50']} kBtu/ft²",
-            help="Median peer site EUI for this property type (public registry).",
+            help="Median site EUI for this property type (public registry).",
         )
         m3.metric(
             "Model EUI (prototype)",
@@ -126,9 +127,9 @@ def _render_eui_index(
             help="EnergyPlus site EUI on prototype area (intensity comparable; scale absolute kWh).",
         )
         m4.metric(
-            "Peer band",
+            "Same-type band",
             f"p20={idx['peer_p20']} · p80={idx['peer_p80']}",
-            help="Peer p20–p80 screening band for this property type.",
+            help="Same-type band (efficient…attention) p20–p80 for this property type.",
         )
 
         df = pd.DataFrame(idx["rows"])
@@ -158,7 +159,7 @@ def _render_eui_index(
             peer_p50=float(idx["peer_p50"]),
             peer_p80=float(idx["peer_p80"]),
             series=series,
-            title=f"{idx.get('benchmark_name') or idx['property_type']} — bills vs peers vs model",
+            title=f"{idx.get('benchmark_name') or idx['property_type']} — bills vs same-type vs model",
             height=440,
         )
         st.plotly_chart(fig, width="stretch", key=chart_key)
@@ -831,22 +832,24 @@ def render() -> None:
 
         bdf = pd.DataFrame(bills_rows)
         st.dataframe(bdf, width="stretch", hide_index=True)
-        if "observed_kwh" in bdf.columns and "modeled_kwh" in bdf.columns:
+
+        def _month_labels(plot_df: pd.DataFrame) -> list[Any]:
+            if "month" not in plot_df.columns:
+                return list(range(len(plot_df)))
+            mo = plot_df["month"].astype(str)
+            if mo.str.fullmatch(r"\d{1,2}").all():
+                return [month_abbrev(m) for m in mo]
+            if mo.str.fullmatch(r"\d{4}-\d{2}").all():
+                return [f"{m[:4]}-{month_abbrev(m[5:7])}" if len(m) >= 7 else m for m in mo]
+            return mo.tolist()
+
+        if "observed_kwh" in bdf.columns and (
+            "modeled_kwh" in bdf.columns or "simulated_kwh" in bdf.columns
+        ):
             plot_df = bdf.copy()
-            if "month" in plot_df.columns:
-                # Prefer Jan…Dec labels when values look like month numbers / MM
-                mo = plot_df["month"].astype(str)
-                if mo.str.fullmatch(r"\d{1,2}").all() or mo.str.fullmatch(r"\d{4}-\d{2}").all():
-                    if mo.str.fullmatch(r"\d{1,2}").all():
-                        x_labels = [month_abbrev(m) for m in mo]
-                    else:
-                        x_labels = [
-                            f"{m[:4]}-{month_abbrev(m[5:7])}" if len(m) >= 7 else m for m in mo
-                        ]
-                else:
-                    x_labels = mo.tolist()
-            else:
-                x_labels = list(range(len(plot_df)))
+            if "modeled_kwh" not in plot_df.columns:
+                plot_df["modeled_kwh"] = plot_df.get("simulated_kwh")
+            x_labels = _month_labels(plot_df)
             fig_cal = go.Figure()
             fig_cal.add_scatter(
                 x=x_labels,
@@ -870,13 +873,50 @@ def render() -> None:
                 legend=dict(orientation="h", y=1.12),
             )
             st.plotly_chart(fig_cal, width="stretch", key="twin_cal_overlay")
+
+        has_gas_obs = "observed_therms" in bdf.columns and bdf["observed_therms"].notna().any()
+        has_gas_mod = (
+            ("modeled_therms" in bdf.columns and bdf["modeled_therms"].notna().any())
+            or ("simulated_therms" in bdf.columns and bdf["simulated_therms"].notna().any())
+        )
+        if has_gas_obs and has_gas_mod:
+            plot_g = bdf.copy()
+            if "modeled_therms" not in plot_g.columns:
+                plot_g["modeled_therms"] = plot_g.get("simulated_therms")
+            x_labels = _month_labels(plot_g)
+            fig_gas = go.Figure()
+            fig_gas.add_scatter(
+                x=x_labels,
+                y=plot_g["observed_therms"],
+                mode="lines+markers",
+                name="Bills (observed)",
+                line=dict(color="#1f77b4"),
+            )
+            fig_gas.add_scatter(
+                x=x_labels,
+                y=plot_g["modeled_therms"],
+                mode="lines+markers",
+                name="Model (calibrated)",
+                line=dict(color="#2ca02c"),
+            )
+            fig_gas.update_layout(
+                title="Monthly gas — bills vs model",
+                height=360,
+                margin=dict(l=10, r=10, t=40, b=10),
+                yaxis_title="therms",
+                legend=dict(orientation="h", y=1.12),
+            )
+            st.plotly_chart(fig_gas, width="stretch", key="twin_cal_overlay_gas")
+
         ubills = scorecard.get("utility_bills") or {}
-        stats = ubills.get("stats_electricity") or ubills.get("stats") or {}
-        if stats:
-            g1, g2, g3 = st.columns(3)
-            g1.metric("G14 NMBE %", f"{stats.get('nmbe_pct', '—')}")
-            g2.metric("G14 CV(RMSE) %", f"{stats.get('cvrmse_pct', '—')}")
-            g3.metric("Pass/fail", str(ubills.get("pass_fail") or "—"))
+        stats_e = ubills.get("stats_electricity") or ubills.get("stats") or {}
+        stats_g = ubills.get("stats_natural_gas") or ubills.get("stats_gas") or {}
+        g1, g2, g3, g4, g5 = st.columns(5)
+        g1.metric("G14 NMBE % (elec)", f"{stats_e.get('nmbe_pct', '—')}")
+        g2.metric("G14 CV(RMSE) % (elec)", f"{stats_e.get('cvrmse_pct', '—')}")
+        g3.metric("G14 NMBE % (gas)", f"{stats_g.get('nmbe_pct', '—')}" if stats_g else "—")
+        g4.metric("G14 CV(RMSE) % (gas)", f"{stats_g.get('cvrmse_pct', '—')}" if stats_g else "—")
+        g5.metric("Pass/fail", str(ubills.get("pass_fail") or "—"))
         from wattlab.studio.monthly_pct_off import (
             build_monthly_pct_off,
             render_monthly_pct_off_panel,
@@ -991,9 +1031,10 @@ def render() -> None:
             "Each published `runs/<id>/` after agent/CLI EnergyPlus. "
             "Timestamps from `run_manifest.json`. G14 columns need `calibration_scorecard.json` per run."
         )
-        from wattlab.studio.g14_history import g14_epoch_figure, iter_g14_history
+        from wattlab.studio.g14_history import assign_run_numbers, g14_epoch_figure, iter_g14_history
         from wattlab.studio.model_summary import (
             build_assumption_rows,
+            build_dial_knobs_rows,
             build_model_summary,
             render_model_summary_panel,
         )
@@ -1022,13 +1063,24 @@ def render() -> None:
             st.caption("No prior runs in workspace runs/.")
         else:
             st.metric("Published iterations shown", len(hist))
-            g14_rows = iter_g14_history(runs_dir(), limit=30)
+            g14_rows = assign_run_numbers(iter_g14_history(runs_dir(), limit=30))
             g14_by_dir = {str(r.get("dir")): r for r in g14_rows if r.get("dir")}
+
+            def _hist_sort_key(h: dict[str, Any]) -> tuple:
+                g = g14_by_dir.get(str(h.get("dir") or "")) or {}
+                ts = h.get("started_at") or g.get("started_at") or ""
+                if ts:
+                    return (0, str(ts), str(h.get("run_id") or ""))
+                mt = h.get("mtime") or g.get("mtime")
+                return (1, float(mt) if mt is not None else 0.0, str(h.get("run_id") or ""))
+
+            hist_chrono = sorted(hist, key=_hist_sort_key)
             enriched = []
-            for h in hist:
+            for i, h in enumerate(hist_chrono, start=1):
                 dkey = str(h.get("dir") or "")
                 g = g14_by_dir.get(dkey) or {}
                 row = {
+                    "run": g.get("run") or i,
                     "started_at": h.get("started_at") or g.get("started_at"),
                     "run_id": h.get("run_id"),
                     "hypothesis": h.get("hypothesis"),
@@ -1061,6 +1113,7 @@ def render() -> None:
             show_cols = [
                 c
                 for c in (
+                    "run",
                     "started_at",
                     "run_id",
                     "hypothesis",
@@ -1091,7 +1144,7 @@ def render() -> None:
                 "Lower |NMBE| / CV(RMSE) is better. "
                 "**Dashed legend entries** are ASHRAE G14 monthly gates "
                 "(±5% |NMBE|, ≤15% CVRMSE) — not extra model series. "
-                "Missing scorecards skip that point."
+                "Missing scorecards skip that point. X-axis run # matches the table (oldest → newest)."
             )
             st.plotly_chart(
                 g14_epoch_figure(g14_rows, height=440),
@@ -1099,7 +1152,8 @@ def render() -> None:
                 key="twin_g14_epoch",
             )
 
-            pick_opts = [h.get("dir") for h in hist if h.get("dir")]
+            pick_opts = [h.get("dir") for h in hist_chrono if h.get("dir")]
+            run_by_dir = {str(r.get("dir")): r for r in enriched if r.get("dir")}
             active_now = _resolve_active_run()
             default_ix = 0
             if active_now is not None:
@@ -1120,10 +1174,20 @@ def render() -> None:
             if "twin_iter_pick" not in st.session_state and pick_opts:
                 st.session_state["twin_iter_pick"] = pick_opts[default_ix]
 
+            def _inspect_label(d: str | None) -> str:
+                if not d:
+                    return ""
+                meta = run_by_dir.get(str(d)) or {}
+                n = meta.get("run")
+                rid = meta.get("run_id") or Path(str(d)).name
+                if n is not None:
+                    return f"#{n} · {rid}"
+                return str(rid)
+
             pick = st.selectbox(
                 "Inspect iteration",
                 options=pick_opts,
-                format_func=lambda d: Path(str(d)).name if d else "",
+                format_func=_inspect_label,
                 key="twin_iter_pick",
             )
             if pick:
@@ -1142,6 +1206,11 @@ def render() -> None:
                 )
                 with st.expander("Model assumptions (selected iteration)", expanded=True):
                     st.caption(pin_note)
+                    dial_rows = build_dial_knobs_rows(
+                        answers, Path(str(pick)), profile=profile, summary=summary
+                    )
+                    st.markdown("**Dial / hypothesis knobs**")
+                    st.dataframe(pd.DataFrame(dial_rows), width="stretch", hide_index=True)
                     render_model_summary_panel(summary, rows)
                     from wattlab.studio.monthly_pct_off import (
                         build_monthly_pct_off,

--- a/vibe_code_apps_20/wattlab/studio/pages/uploads.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/uploads.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,33 @@ from wattlab.studio.workspace import (
     save_upload_bytes,
     workspace_root,
 )
+
+
+def _resolve_upload_path(raw: str, *, root: Path) -> Path:
+    """Resolve path box input under Studio workspace (BUG-001).
+
+    Relative paths join ``workspace_root()``. Absolute paths keep as-is.
+    Missing paths raise ``FileNotFoundError`` with a Docker / workspace hint.
+    """
+    text = (raw or "").strip().strip('"').strip("'")
+    if not text:
+        raise FileNotFoundError("Empty path")
+    p = Path(text).expanduser()
+    if not p.is_absolute():
+        p = (root / p).resolve()
+    else:
+        p = p.resolve()
+    if p.exists():
+        return p
+    host = (os.environ.get("WATTLAB_HOST_WORKSPACE") or "").strip()
+    hint = (
+        f" Studio workspace is `{root}`"
+        + (f" (host bind `{host}` → `/data`)." if host else ".")
+        + " Use a path under that root (e.g. `uploads/dump/….zip` or "
+        f"`{root.as_posix()}/uploads/dump/….zip`), or the file picker — "
+        "host paths like `/home/…` are not mounted into the container."
+    )
+    raise FileNotFoundError(f"Path not found: {p}.{hint}")
 
 
 def _hints_from_bundle() -> dict[str, Any]:
@@ -78,13 +106,26 @@ def render() -> None:
     st.header("Uploads — dump + energy use")
     st.caption(
         "Drop a vibe19 **wattlab_dump_*.zip** (v3) and an **energy-use** package: "
-        "`campus.json` + bill CSVs, Haystack `column_map`, **or** Liberty-style monthly "
+        "`campus.json` + bill CSVs, Haystack `column_map`, **or** monthly "
         "Excel workbooks (auto-derived to campus). "
+        "Need vibe19 **Export → WattLab dump** (not `openfdd_package_v1`). "
         "Chat with any AI agent on this workspace folder — Studio only displays results."
     )
 
     root = ensure_workspace()
-    st.info(f"Workspace: `{root}`")
+    host = (os.environ.get("WATTLAB_HOST_WORKSPACE") or "").strip()
+    if host:
+        st.info(
+            f"Workspace: `{root}` · host bind: `{host}` → container `/data`. "
+            f"Process cwd is usually `/app` — relative paths resolve under `{root}` "
+            "(not `/app`). Prefer the **file picker**, or paste "
+            f"`{root.as_posix()}/uploads/dump/<file>.zip` / `uploads/dump/<file>.zip`."
+        )
+    else:
+        st.info(
+            f"Workspace: `{root}`. Relative paths join this root. "
+            "Prefer the file picker when unsure."
+        )
 
     c1, c2 = st.columns(2)
     with c1:
@@ -93,7 +134,11 @@ def render() -> None:
         dump_path = st.text_input(
             "…or path to dump zip/folder",
             key="uploads_dump_path",
-            help="Local path visible to this process (host Studio or bind-mounted /data).",
+            help=(
+                f"Relative paths join workspace `{root}` "
+                "(e.g. uploads/dump/wattlab_dump_….zip). Absolute paths must be "
+                "visible to this process (Docker: /data/…, not host /home/…)."
+            ),
         )
         if st.button("Load dump", key="uploads_load_dump"):
             try:
@@ -102,7 +147,7 @@ def render() -> None:
                     bundle = load_bundle(saved)
                     st.session_state["studio_dump_path"] = str(saved)
                 elif dump_path.strip():
-                    p = Path(dump_path.strip())
+                    p = _resolve_upload_path(dump_path, root=root)
                     if p.is_file() and p.suffix.lower() == ".zip":
                         saved = save_upload_bytes("dump", p.name, p.read_bytes())
                         bundle = load_bundle(saved)
@@ -126,7 +171,10 @@ def render() -> None:
         energy_path = st.text_input(
             "…or path to campus folder / zip",
             key="uploads_energy_path",
-            help="campus.json + meter CSVs, Excel monthly fuel workbooks, or Haystack maps.",
+            help=(
+                f"Relative paths join workspace `{root}`. "
+                "campus.json + meter CSVs, Excel monthly fuel workbooks, or Haystack maps."
+            ),
         )
         if st.button("Load energy use", key="uploads_load_energy"):
             try:
@@ -135,7 +183,7 @@ def render() -> None:
                     pkg = _load_energy(saved)
                     st.session_state["studio_energy_path"] = str(saved)
                 elif energy_path.strip():
-                    p = Path(energy_path.strip())
+                    p = _resolve_upload_path(energy_path, root=root)
                     if p.is_file() and p.suffix.lower() == ".zip":
                         saved = save_upload_bytes("energy", p.name, p.read_bytes())
                         pkg = _load_energy(saved)
@@ -173,6 +221,16 @@ def render() -> None:
 
     summary = st.session_state.get("studio_ws_summary") or list_workspace_summary()
     st.subheader("Workspace files")
+    dump_abs = summary.get("dumps_abs") or []
+    if dump_abs:
+        st.caption("Dump paths visible to Studio (copy into the path box if needed):")
+        for abs_p in dump_abs[:12]:
+            st.code(abs_p, language=None)
+    energy_abs = summary.get("energy_abs") or []
+    if energy_abs:
+        st.caption("Energy paths:")
+        for abs_p in energy_abs[:12]:
+            st.code(abs_p, language=None)
     st.json(summary)
 
     bundle = st.session_state.get("studio_bundle")

--- a/vibe_code_apps_20/wattlab/studio/workspace.py
+++ b/vibe_code_apps_20/wattlab/studio/workspace.py
@@ -86,10 +86,16 @@ def list_workspace_summary() -> dict[str, Any]:
     energy = sorted((root / "uploads" / "energy").glob("*"))
     runs = sorted((root / "runs").glob("*"))
     reports = sorted((root / "reports").glob("*"))
+    host = (os.environ.get("WATTLAB_HOST_WORKSPACE") or "").strip() or None
+    dump_paths = [str(p) for p in dumps if p.is_file() or p.is_dir()]
+    energy_paths = [str(p) for p in energy if p.is_file() or p.is_dir()]
     return {
         "root": str(root),
+        "host_workspace": host,
         "dumps": [p.name for p in dumps if p.is_file() or p.is_dir()],
+        "dumps_abs": dump_paths,
         "energy": [p.name for p in energy if p.is_file() or p.is_dir()],
+        "energy_abs": energy_paths,
         "runs": [p.name for p in runs],
         "reports": [p.name for p in reports],
     }


### PR DESCRIPTION
## Summary
- Fuel Weather/Demand overlays, Portfolio heatmaps + same-type EUI language, Twin run#/gas charts/dial knobs, ECMs best-G14 picker
- Agent tools context: `TWIN_DIAL_PLAYBOOK`, `wattlab-twin-calibrate-dial` skill, expanded `AGENT_TOOLS.md` (BUG-009)
- Fix Uploads workspace-relative paths + Docker path teaching + OpenFDD schema hint (BUG-001–003)
- vibe19: turnkey HTML smoke uses `sys.executable` (BUG-006)

## Test plan
- [x] `pytest` uploads path resolve + fuel/twin unit + Fuel AppTest smoke
- [ ] GHCR vibe19 + vibe20 rebuild green
- [ ] Local pull + recreate containers; Uploads relative `uploads/dump/…` loads
- [ ] Twin dial skill present under `/app/vibe20_agent_spec/skills/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added same-type benchmarking views, fit filtering, weather analytics, and expanded demand and fuel dashboards.
  * Added Twin calibration workflow guidance, dial tools, iteration history improvements, baseline-run selection, and dial/hypothesis details.
  * Improved upload path handling and workspace file visibility.
* **Bug Fixes**
  * Streamlit smoke tests now use the active Python interpreter.
  * Added clearer guidance for unsupported upload package formats.
* **Documentation**
  * Added comprehensive Twin calibration playbooks and updated workspace and agent guidance.
* **Tests**
  * Expanded coverage for weather analytics, calibration runs, dial summaries, and upload path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->