### PR TITLE
feat(vibe19): Overview + day-zoom plots in FDD Engineering Findings DOCX

### DIFF
--- a/vibe_code_apps_19/Dockerfile
+++ b/vibe_code_apps_19/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /app
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt \
- && python -c "import docx, kaleido; print('engineering-report extras ok')"
+ && python -c "import docx, kaleido, matplotlib; print('engineering-report extras ok')"
 
 # Includes .streamlit/config.toml (maxUploadSize=500) — do not lower OPENFDD_MAX_* here.
 COPY . .

--- a/vibe_code_apps_19/app/report_downloads.py
+++ b/vibe_code_apps_19/app/report_downloads.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import streamlit as st
 
@@ -39,11 +40,48 @@ def report_download_button(
     return True
 
 
+def overview_context_from_session() -> dict[str, Any]:
+    """Build overview_context from Streamlit session for Engineering Findings charts."""
+    from app.analytics import dataset_time_span
+    from app.occupancy import OccupancySchedule, occupied_hours_per_week
+    from app.reporting.overview_export import build_overview_context
+
+    frames = st.session_state.get("equipment_frames") or {}
+    span = dataset_time_span(frames) if frames else {}
+    oat_err = 5.0
+    try:
+        oat_err = float(
+            (st.session_state.get("params") or {}).get("OAT-METEO", {}).get("oat_err", 5.0)
+        )
+    except (TypeError, ValueError):
+        oat_err = 5.0
+    sched = OccupancySchedule.from_dict(st.session_state.get("occupancy_schedule"))
+    return build_overview_context(
+        frames=frames,
+        role_map=st.session_state.get("role_map") or {},
+        weather=st.session_state.get("weather"),
+        prefer_web_oat=bool(st.session_state.get("prefer_web_oat", True)),
+        oat_err=oat_err,
+        chw_leave_max_f=float(st.session_state.get("chw_leave_max_f", 48.0)),
+        use_status_proof=bool(
+            st.session_state.get("use_mech_cooling_status_proof", True)
+        ),
+        zone_lo_f=float(st.session_state.get("zone_lo_f", 70.0)),
+        zone_hi_f=float(st.session_state.get("zone_hi_f", 75.0)),
+        bare_min_occ_hours=float(occupied_hours_per_week(sched)),
+        occupancy_schedule=sched.to_dict(),
+        dataset_start=span.get("start"),
+        dataset_end=span.get("end"),
+        span_hours=span.get("span_hours"),
+    )
+
+
 def render_engineering_findings_panel(
     *,
     batch_results: list | None = None,
     building_name: str = "",
     analysis_period: str = "",
+    overview_context: dict[str, Any] | None = None,
     key_prefix: str = "eng_findings",
 ) -> None:
     """Generate FDD Engineering Findings Report (button-triggered; never on section visit)."""
@@ -73,22 +111,43 @@ def render_engineering_findings_panel(
             return
         with st.spinner("Evidence review + charts…"):
             try:
-                from app.reporting.pipeline import build_engineering_findings, render_engineering_report
+                from app.reporting.pipeline import (
+                    build_engineering_findings,
+                    render_engineering_report,
+                )
 
+                ctx = overview_context
+                if ctx is None:
+                    try:
+                        ctx = overview_context_from_session()
+                    except Exception:
+                        ctx = None
                 art = build_engineering_findings(
                     building=building_name or "Building",
                     analysis_period=analysis_period,
                     rule_results=list(batch_results),
+                    overview_context=ctx,
                 )
-                buf_dir = Path(st.session_state.get("_eng_findings_tmpdir") or "/tmp/vibe19_eng_findings")
+                buf_dir = Path(
+                    st.session_state.get("_eng_findings_tmpdir")
+                    or "/tmp/vibe19_eng_findings"
+                )
                 buf_dir.mkdir(parents=True, exist_ok=True)
                 st.session_state["_eng_findings_tmpdir"] = str(buf_dir)
                 written = render_engineering_report(
-                    art, buf_dir, docx=True, json_out=True, charts=True
+                    art,
+                    buf_dir,
+                    docx=True,
+                    json_out=True,
+                    charts=True,
+                    overview_context=ctx,
+                    rule_results=list(batch_results),
                 )
                 st.session_state[f"{key_prefix}_artifacts"] = art
-                st.session_state[f"{key_prefix}_written"] = {k: str(v) for k, v in written.items()}
-            except Exception as exc:  # noqa: BLE001 — show friendly error, not Streamlit Traceback page
+                st.session_state[f"{key_prefix}_written"] = {
+                    k: str(v) for k, v in written.items()
+                }
+            except Exception as exc:  # noqa: BLE001 — show friendly error, not Traceback page
                 st.error(f"Engineering Findings report failed: {exc}")
                 return
 

--- a/vibe_code_apps_19/app/reporting/charts.py
+++ b/vibe_code_apps_19/app/reporting/charts.py
@@ -13,8 +13,10 @@ def build_report_charts(
     *,
     out_dir: Path | None = None,
     comfort_rows: list[dict[str, Any]] | None = None,
+    overview_context: dict[str, Any] | None = None,
+    rule_results: list | None = None,
 ) -> list[dict[str, Any]]:
-    """Attach chart metadata (and PNG paths when Kaleido works)."""
+    """Attach chart metadata (and PNG paths when Kaleido / matplotlib works)."""
     try:
         import plotly.graph_objects as go
     except ImportError:
@@ -25,6 +27,27 @@ def build_report_charts(
         out_dir.mkdir(parents=True, exist_ok=True)
 
     charts: list[dict[str, Any]] = []
+
+    # 0) Overview analytics (Plotly → Kaleido) when frames present
+    if out_dir is not None and overview_context:
+        try:
+            from app.reporting.overview_export import (
+                build_overview_charts,
+                overview_settings_from_context,
+            )
+
+            if not artifacts.overview_settings:
+                artifacts.overview_settings = overview_settings_from_context(
+                    overview_context
+                )
+            overview_meta = build_overview_charts(
+                artifacts, overview_context, out_dir=out_dir / "overview"
+            )
+            charts.extend(overview_meta)
+        except Exception as exc:
+            charts.append(
+                {"name": "overview_export", "path": None, "export_error": str(exc)}
+            )
 
     # 1) Confidence summary
     from collections import Counter
@@ -102,7 +125,7 @@ def build_report_charts(
         )
         charts.append(_export(fig2, "comfort_ranking", out_dir))
 
-    # 3) Per priority finding chart
+    # 3) Per priority finding chart (scalar fallback)
     for f in artifacts.findings:
         if not f.include_in_report or not f.chart_spec:
             continue
@@ -113,9 +136,24 @@ def build_report_charts(
         f.chart_path = meta.get("path")
         charts.append({**meta, "finding_id": f.finding_id})
 
+    # 4) Day-zoom matplotlib PNGs from RuleResult series
+    if out_dir is not None and rule_results:
+        try:
+            from app.reporting.day_zoom import attach_day_zoom_to_findings
+
+            day_meta = attach_day_zoom_to_findings(
+                artifacts.findings,
+                rule_results,
+                out_dir=out_dir / "day_zoom",
+            )
+            charts.extend(day_meta)
+        except Exception as exc:
+            charts.append(
+                {"name": "day_zoom", "path": None, "export_error": str(exc)}
+            )
+
     artifacts.charts = charts
     return charts
-
 
 def _figure_for_finding(f: EngineeringFinding, go):
     spec = f.chart_spec or {}

--- a/vibe_code_apps_19/app/reporting/day_zoom.py
+++ b/vibe_code_apps_19/app/reporting/day_zoom.py
@@ -1,0 +1,243 @@
+"""Per-finding worst-fault-day zoom plots (matplotlib → PNG)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from app.reporting.models import EngineeringFinding
+from app.rules.base import RuleResult
+
+
+def index_rule_results(rule_results: list[RuleResult] | None) -> dict[str, RuleResult]:
+    """Map ``equipment_id|rule_id`` → RuleResult (last write wins)."""
+    out: dict[str, RuleResult] = {}
+    for r in rule_results or []:
+        eid = getattr(r, "equipment_id", None) or ""
+        rid = getattr(r, "rule_id", None) or ""
+        if eid and rid:
+            out[f"{eid}|{rid}"] = r
+    return out
+
+
+def resolve_result_for_finding(
+    finding: EngineeringFinding, by_key: dict[str, RuleResult]
+) -> RuleResult | None:
+    """Prefer first candidate_key, else first equipment×rule combo."""
+    for key in finding.candidate_keys or []:
+        if key in by_key:
+            return by_key[key]
+    for eid in finding.equipment_ids or []:
+        for rid in finding.rule_ids or []:
+            hit = by_key.get(f"{eid}|{rid}")
+            if hit is not None:
+                return hit
+    return None
+
+
+def worst_fault_day(fault: pd.Series | None) -> date | None:
+    """Calendar day with the most fault samples (True / 1)."""
+    if fault is None or len(fault) == 0:
+        return None
+    s = fault.dropna()
+    if s.empty:
+        return None
+    # Coerce to 0/1
+    try:
+        numeric = s.astype(float)
+    except (TypeError, ValueError):
+        numeric = s.map(lambda v: 1.0 if bool(v) else 0.0)
+    if not isinstance(s.index, pd.DatetimeIndex):
+        try:
+            idx = pd.to_datetime(s.index)
+            numeric.index = idx
+        except Exception:
+            return None
+    daily = numeric.groupby(numeric.index.normalize()).sum()
+    if daily.empty or float(daily.max()) <= 0:
+        return None
+    day_ts = daily.idxmax()
+    if isinstance(day_ts, datetime):
+        return day_ts.date()
+    if isinstance(day_ts, pd.Timestamp):
+        return day_ts.date()
+    if isinstance(day_ts, date):
+        return day_ts
+    try:
+        return pd.Timestamp(day_ts).date()
+    except Exception:
+        return None
+
+
+def render_day_zoom_png(
+    result: RuleResult,
+    day: date,
+    out_path: Path,
+    *,
+    max_series: int = 4,
+) -> tuple[Path, float] | None:
+    """Matplotlib day zoom: plot_series + fault lane for ``day``.
+
+    Returns ``(path, fault_hours_that_day)`` or None.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return None
+
+    fault = getattr(result, "confirmed_fault", None)
+    if fault is None or (hasattr(fault, "empty") and fault.empty):
+        fault = getattr(result, "raw_fault", None)
+    plot_series = getattr(result, "plot_series", None) or {}
+
+    day_start = pd.Timestamp(day)
+    day_end = day_start + pd.Timedelta(days=1)
+
+    def _slice(ser: pd.Series | None) -> pd.Series | None:
+        if ser is None or len(ser) == 0:
+            return None
+        s = ser.copy()
+        if not isinstance(s.index, pd.DatetimeIndex):
+            try:
+                s.index = pd.to_datetime(s.index)
+            except Exception:
+                return None
+        return s[(s.index >= day_start) & (s.index < day_end)]
+
+    fault_day = _slice(fault)
+    series_day: list[tuple[str, pd.Series]] = []
+    for name, ser in list(plot_series.items())[:max_series]:
+        sl = _slice(ser if isinstance(ser, pd.Series) else None)
+        if sl is not None and not sl.empty:
+            series_day.append((str(name), sl))
+
+    if (fault_day is None or fault_day.empty) and not series_day:
+        return None
+
+    fig, (ax, ax_f) = plt.subplots(
+        2,
+        1,
+        figsize=(9.0, 4.2),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3.2, 0.8], "hspace": 0.08},
+    )
+    colors = ["#2b6cb0", "#c05621", "#2f855a", "#805ad5"]
+    for i, (name, sl) in enumerate(series_day):
+        try:
+            y = pd.to_numeric(sl, errors="coerce")
+        except Exception:
+            y = sl
+        ax.plot(y.index, y.values, label=name, color=colors[i % len(colors)], lw=1.4)
+    if series_day:
+        ax.legend(loc="upper left", fontsize=8, frameon=False)
+    ax.set_ylabel("Value")
+    ax.grid(axis="y", alpha=0.3)
+    ax.set_title(
+        f"{getattr(result, 'equipment_id', '')} · {getattr(result, 'rule_id', '')} — {day.isoformat()}",
+        fontsize=11,
+    )
+
+    # Fault lane
+    ax_f.set_ylim(-0.1, 1.1)
+    ax_f.set_yticks([0, 1])
+    ax_f.set_yticklabels(["ok", "fault"])
+    ax_f.set_xlabel("Time")
+    if fault_day is not None and not fault_day.empty:
+        try:
+            fnum = fault_day.astype(float).clip(0, 1)
+        except Exception:
+            fnum = fault_day.map(lambda v: 1.0 if bool(v) else 0.0)
+        ax_f.fill_between(
+            fnum.index,
+            0,
+            fnum.values,
+            step="mid",
+            color="#c53030",
+            alpha=0.55,
+            label="fault",
+        )
+        ax.fill_between(
+            fnum.index,
+            0,
+            1,
+            where=fnum.values > 0.5,
+            transform=ax.get_xaxis_transform(),
+            color="#c53030",
+            alpha=0.08,
+            step="mid",
+        )
+
+    fault_hours = 0.0
+    if fault_day is not None and not fault_day.empty:
+        try:
+            vals = fault_day.astype(float)
+            n_true = float((vals > 0.5).sum())
+            if len(vals) > 1:
+                dt_h = (
+                    (vals.index.max() - vals.index.min()).total_seconds() / 3600.0
+                ) / max(len(vals) - 1, 1)
+                fault_hours = n_true * dt_h
+            else:
+                fault_hours = n_true
+        except Exception:
+            fault_hours = float(fault_day.astype(bool).sum())
+
+    fig.subplots_adjust(hspace=0.12)
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    buf = BytesIO()
+    fig.savefig(buf, format="png", dpi=140, bbox_inches="tight")
+    plt.close(fig)
+    out_path.write_bytes(buf.getvalue())
+    return out_path, round(fault_hours, 2)
+
+
+def attach_day_zoom_to_findings(
+    findings: list[EngineeringFinding],
+    rule_results: list[RuleResult] | None,
+    *,
+    out_dir: Path,
+) -> list[dict[str, Any]]:
+    """Write day-zoom PNGs and set ``day_zoom_path`` / ``day_zoom_label`` on findings."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    by_key = index_rule_results(rule_results)
+    metas: list[dict[str, Any]] = []
+    for f in findings:
+        if not f.include_in_report:
+            continue
+        result = resolve_result_for_finding(f, by_key)
+        if result is None:
+            continue
+        fault = getattr(result, "confirmed_fault", None)
+        if fault is None or (hasattr(fault, "empty") and fault.empty):
+            fault = getattr(result, "raw_fault", None)
+        day = worst_fault_day(fault if isinstance(fault, pd.Series) else None)
+        if day is None:
+            continue
+        png = out_dir / f"day_zoom_{f.finding_id}.png"
+        rendered = render_day_zoom_png(result, day, png)
+        if rendered is None:
+            continue
+        path, hours = rendered
+        if not path.is_file():
+            continue
+        label = f"{day.isoformat()} · ~{hours:g} fault-h that day"
+        f.day_zoom_path = str(path)
+        f.day_zoom_label = label
+        metas.append(
+            {
+                "name": f"day_zoom_{f.finding_id}",
+                "path": str(path),
+                "finding_id": f.finding_id,
+                "title": label,
+            }
+        )
+    return metas

--- a/vibe_code_apps_19/app/reporting/docx.py
+++ b/vibe_code_apps_19/app/reporting/docx.py
@@ -77,11 +77,12 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
 
     # Building at a glance
     doc.add_heading("2. Building at a glance", level=1)
+    _add_overview_settings(doc, artifacts)
     doc.add_paragraph(
-        "Charts below are generated from this evidence review (Plotly → PNG). "
-        "They mirror Overview-style summaries where data is available; interactive "
-        "Overview session figures are not auto-copied into the Word file."
+        "Overview analytics below reuse the same Plotly builders as the live Overview tab "
+        "(exported via Kaleido when available). Data inspection and role tables are omitted."
     )
+    _add_overview_charts(doc, artifacts)
     _add_chart_if_any(doc, artifacts, "confidence_summary")
     _add_chart_if_any(doc, artifacts, "top_detections")
     _add_chart_if_any(doc, artifacts, "comfort_ranking")
@@ -99,11 +100,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
         doc.add_paragraph("Evidence:")
         for b in f.evidence_bullets:
             doc.add_paragraph(b, style="List Bullet")
-        if f.chart_path and Path(f.chart_path).is_file():
-            try:
-                doc.add_picture(f.chart_path, width=Inches(5.8))
-            except Exception:
-                pass
+        _add_finding_picture(doc, f)
         doc.add_paragraph("Contradicting evidence:")
         for b in f.contradicting_evidence:
             doc.add_paragraph(b, style="List Bullet")
@@ -320,3 +317,81 @@ def _add_chart_if_any(doc, artifacts: ReportArtifacts, name: str) -> None:
             except Exception:
                 pass
             return
+
+
+def _add_overview_settings(doc, artifacts: ReportArtifacts) -> None:
+    s = artifacts.overview_settings or {}
+    if not s:
+        doc.add_paragraph(
+            "Dataset window and Overview schedule/zone settings were not available "
+            "for this run (generate from Run Rules with a loaded package)."
+        )
+        return
+    start = s.get("dataset_start") or "—"
+    end = s.get("dataset_end") or "—"
+    span = s.get("span_hours")
+    span_s = f"{float(span):.1f} h" if isinstance(span, (int, float)) else "—"
+    doc.add_paragraph(f"Dataset window: {start} → {end} (span {span_s}).")
+    lo = s.get("zone_lo_f")
+    hi = s.get("zone_hi_f")
+    bare = s.get("bare_min_occ_hours")
+    bits = []
+    if lo is not None and hi is not None:
+        bits.append(f"zone band {float(lo):.0f}–{float(hi):.0f} °F")
+    if bare is not None:
+        bits.append(f"bare-min occupied hours/week ≈ {float(bare):.0f}")
+    oat_err = s.get("oat_err")
+    if oat_err is not None:
+        bits.append(f"OAT-METEO tolerance ±{float(oat_err):g} °F")
+    if bits:
+        doc.add_paragraph("Overview settings: " + "; ".join(bits) + ".")
+    sched = s.get("occupancy_schedule")
+    if isinstance(sched, dict) and sched:
+        doc.add_paragraph(
+            "Occupancy schedule is configured in the Overview weekly calendar "
+            "(same schedule applied to SCHED-1 / comfort occupied hours)."
+        )
+
+
+def _add_overview_charts(doc, artifacts: ReportArtifacts) -> None:
+    from docx.shared import Inches
+
+    charts = list(artifacts.overview_charts or [])
+    if not charts:
+        # Fall back to overview_* entries on charts list
+        charts = [
+            c
+            for c in (artifacts.charts or [])
+            if str(c.get("name") or "").startswith("overview_") and c.get("path")
+        ]
+    for ch in charts:
+        path = ch.get("path")
+        if not path or not Path(path).is_file():
+            continue
+        title = ch.get("title") or ch.get("name")
+        if title:
+            doc.add_paragraph(str(title))
+        try:
+            doc.add_picture(str(path), width=Inches(5.8))
+        except Exception:
+            pass
+
+
+def _add_finding_picture(doc, f) -> None:
+    from docx.shared import Inches
+
+    path = None
+    caption = None
+    if getattr(f, "day_zoom_path", None) and Path(f.day_zoom_path).is_file():
+        path = f.day_zoom_path
+        caption = getattr(f, "day_zoom_label", None)
+    elif getattr(f, "chart_path", None) and Path(f.chart_path).is_file():
+        path = f.chart_path
+    if not path:
+        return
+    try:
+        doc.add_picture(str(path), width=Inches(5.8))
+    except Exception:
+        return
+    if caption:
+        _muted(doc, str(caption))

--- a/vibe_code_apps_19/app/reporting/models.py
+++ b/vibe_code_apps_19/app/reporting/models.py
@@ -148,6 +148,8 @@ class EngineeringFinding:
     systems: list[str]
     chart_spec: dict[str, Any] | None = None
     chart_path: str | None = None
+    day_zoom_path: str | None = None
+    day_zoom_label: str | None = None
     candidate_keys: list[str] = field(default_factory=list)
     automated_assessment: dict[str, Any] = field(default_factory=dict)
     engineer_override: dict[str, Any] | None = None
@@ -186,6 +188,8 @@ class ReportArtifacts:
     assumptions: dict[str, Any]
     quality_gate: dict[str, Any]
     charts: list[dict[str, Any]] = field(default_factory=list)
+    overview_settings: dict[str, Any] = field(default_factory=dict)
+    overview_charts: list[dict[str, Any]] = field(default_factory=list)
     disclaimer: str = (
         "Open-FDD / Vibe 19 educational analysis. Findings are telemetry-based "
         "and advisory; physical verification remains a human/field activity."
@@ -207,5 +211,7 @@ class ReportArtifacts:
             "assumptions": self.assumptions,
             "quality_gate": self.quality_gate,
             "charts": self.charts,
+            "overview_settings": self.overview_settings,
+            "overview_charts": self.overview_charts,
             "disclaimer": self.disclaimer,
         }

--- a/vibe_code_apps_19/app/reporting/overview_export.py
+++ b/vibe_code_apps_19/app/reporting/overview_export.py
@@ -1,0 +1,219 @@
+"""Overview analytics → PNG for Engineering Findings DOCX (Plotly + Kaleido)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from app.reporting.models import ReportArtifacts
+
+
+def overview_settings_from_context(ctx: dict[str, Any] | None) -> dict[str, Any]:
+    """Lean settings block for DOCX §2 (no frames)."""
+    ctx = ctx or {}
+
+    def _ts(v: Any) -> str | None:
+        if v is None:
+            return None
+        if hasattr(v, "strftime"):
+            try:
+                return v.strftime("%Y-%m-%d %H:%M")
+            except Exception:
+                return str(v)
+        return str(v)
+
+    return {
+        "dataset_start": _ts(ctx.get("dataset_start")),
+        "dataset_end": _ts(ctx.get("dataset_end")),
+        "span_hours": ctx.get("span_hours"),
+        "zone_lo_f": ctx.get("zone_lo_f"),
+        "zone_hi_f": ctx.get("zone_hi_f"),
+        "bare_min_occ_hours": ctx.get("bare_min_occ_hours"),
+        "occupancy_schedule": ctx.get("occupancy_schedule"),
+        "oat_err": ctx.get("oat_err"),
+        "prefer_web_oat": ctx.get("prefer_web_oat"),
+    }
+
+
+def build_overview_context(
+    *,
+    frames: dict | None = None,
+    role_map: dict | None = None,
+    weather=None,
+    prefer_web_oat: bool = True,
+    oat_err: float = 5.0,
+    chw_leave_max_f: float = 48.0,
+    use_status_proof: bool = True,
+    zone_lo_f: float = 70.0,
+    zone_hi_f: float = 75.0,
+    bare_min_occ_hours: float | None = None,
+    occupancy_schedule: dict | None = None,
+    dataset_start=None,
+    dataset_end=None,
+    span_hours: float | None = None,
+) -> dict[str, Any]:
+    """Assemble overview_context for reporting (may include heavy frames)."""
+    return {
+        "frames": frames or {},
+        "role_map": role_map or {},
+        "weather": weather,
+        "prefer_web_oat": prefer_web_oat,
+        "oat_err": oat_err,
+        "chw_leave_max_f": chw_leave_max_f,
+        "use_status_proof": use_status_proof,
+        "zone_lo_f": zone_lo_f,
+        "zone_hi_f": zone_hi_f,
+        "bare_min_occ_hours": bare_min_occ_hours,
+        "occupancy_schedule": occupancy_schedule,
+        "dataset_start": dataset_start,
+        "dataset_end": dataset_end,
+        "span_hours": span_hours,
+    }
+
+
+def build_overview_charts(
+    artifacts: ReportArtifacts,
+    overview_context: dict[str, Any] | None,
+    *,
+    out_dir: Path,
+) -> list[dict[str, Any]]:
+    """Render Overview-tab analytics as PNGs when frames are present."""
+    ctx = overview_context or {}
+    frames = ctx.get("frames")
+    if not frames:
+        return []
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    role_map = ctx.get("role_map") or {}
+    weather = ctx.get("weather")
+    prefer_web = bool(ctx.get("prefer_web_oat", True))
+    oat_err = float(ctx.get("oat_err") or 5.0)
+    chw_leave = float(ctx.get("chw_leave_max_f") or 48.0)
+    use_status = bool(ctx.get("use_status_proof", True))
+    bare_min = ctx.get("bare_min_occ_hours")
+    bare_min_f = float(bare_min) if bare_min is not None else None
+
+    charts: list[dict[str, Any]] = []
+
+    # BAS vs web OAT
+    try:
+        from app.charts import bas_vs_web_oat_overlay
+
+        fig = bas_vs_web_oat_overlay(
+            frames, role_map, weather=weather, oat_err=oat_err
+        )
+        if fig is not None:
+            charts.append(
+                _export_plotly(
+                    fig,
+                    "overview_bas_vs_web_oat",
+                    out_dir,
+                    title="BAS vs web outdoor-air temperature",
+                )
+            )
+    except Exception as exc:
+        charts.append(
+            {"name": "overview_bas_vs_web_oat", "path": None, "export_error": str(exc)}
+        )
+
+    # Motor weekly by plant group
+    try:
+        from app.analytics import motor_run_hours_weekly
+        from app.charts import motor_weekly_runtime_chart
+
+        weekly = motor_run_hours_weekly(
+            frames,
+            role_map,
+            weather=weather,
+            prefer_web_oat=prefer_web,
+            chw_leave_max_f=chw_leave,
+        )
+        titles = {
+            "air": "Air side — supply fans",
+            "boiler": "Boiler plant — HW pumps",
+            "chiller": "Chiller plant — chillers, CHW/CW pumps, towers",
+        }
+        for plant, title in titles.items():
+            sub = weekly[weekly["plant_group"] == plant] if weekly is not None and not weekly.empty else None
+            if sub is None or sub.empty:
+                continue
+            fig = motor_weekly_runtime_chart(
+                sub,
+                title=title,
+                min_hours_line=bare_min_f if plant == "air" else None,
+                show_avg_oat=True,
+            )
+            if fig is None:
+                continue
+            charts.append(
+                _export_plotly(
+                    fig,
+                    f"overview_motor_weekly_{plant}",
+                    out_dir,
+                    title=title,
+                )
+            )
+    except Exception as exc:
+        charts.append(
+            {
+                "name": "overview_motor_weekly",
+                "path": None,
+                "export_error": str(exc),
+            }
+        )
+
+    # Mech cooling OAT bins
+    try:
+        from app.analytics import mech_cooling_oat_bins
+        from app.charts import mech_cooling_oat_histogram
+
+        bins = mech_cooling_oat_bins(
+            frames,
+            role_map,
+            weather=weather,
+            prefer_web_oat=prefer_web,
+            chw_leave_max_f=chw_leave,
+            use_status_proof=use_status,
+        )
+        fig = mech_cooling_oat_histogram(bins)
+        if fig is not None:
+            charts.append(
+                _export_plotly(
+                    fig,
+                    "overview_mech_cooling_oat_bins",
+                    out_dir,
+                    title="Mechanical cooling run hours by outdoor-air temperature",
+                )
+            )
+    except Exception as exc:
+        charts.append(
+            {
+                "name": "overview_mech_cooling_oat_bins",
+                "path": None,
+                "export_error": str(exc),
+            }
+        )
+
+    artifacts.overview_charts = [c for c in charts if c.get("path")]
+    return charts
+
+
+def _export_plotly(
+    fig: Any, name: str, out_dir: Path, *, title: str | None = None
+) -> dict[str, Any]:
+    meta: dict[str, Any] = {"name": name, "path": None, "title": title or name}
+    png = out_dir / f"{name}.png"
+    try:
+        fig.write_image(str(png), scale=2, width=900, height=480)
+        meta["path"] = str(png)
+    except Exception as exc:
+        meta["export_error"] = str(exc)
+        try:
+            html = out_dir / f"{name}.html"
+            fig.write_html(str(html), include_plotlyjs="cdn")
+            meta["html"] = str(html)
+        except Exception:
+            pass
+    return meta

--- a/vibe_code_apps_19/app/reporting/pipeline.py
+++ b/vibe_code_apps_19/app/reporting/pipeline.py
@@ -35,11 +35,15 @@ def build_engineering_findings(
     rule_results: list[RuleResult] | None = None,
     checklist: dict[str, Any] | Path | str | None = None,
     context: dict[str, Any] | None = None,
+    overview_context: dict[str, Any] | None = None,
     max_findings: int = 7,
 ) -> ReportArtifacts:
     """Calculate assessments and prioritized findings (no DOCX yet)."""
     ctx = dict(context or {})
     cands = list(candidates or [])
+    from app.reporting.overview_export import overview_settings_from_context
+
+    overview_settings = overview_settings_from_context(overview_context)
 
     if checklist is not None:
         loaded, cctx = candidates_from_checklist_json(checklist, building=building or None)
@@ -132,6 +136,7 @@ def build_engineering_findings(
             "detection_vs_finding": "Rule hits are candidates until evidence review",
         },
         quality_gate={},
+        overview_settings=overview_settings,
     )
     artifacts.quality_gate = run_quality_gate(artifacts)
     return artifacts
@@ -145,6 +150,8 @@ def render_engineering_report(
     json_out: bool = True,
     charts: bool = True,
     basename: str | None = None,
+    overview_context: dict[str, Any] | None = None,
+    rule_results: list[RuleResult] | None = None,
 ) -> dict[str, Path]:
     """Write JSON / DOCX / chart assets. Raises if quality gate fails critically."""
     out_dir = Path(out_dir)
@@ -158,6 +165,8 @@ def render_engineering_report(
             artifacts,
             out_dir=chart_dir,
             comfort_rows=(artifacts.comfort_summary or {}).get("rows"),
+            overview_context=overview_context,
+            rule_results=rule_results,
         )
         # re-run gate after charts attached
         artifacts.quality_gate = run_quality_gate(artifacts)

--- a/vibe_code_apps_19/pyproject.toml
+++ b/vibe_code_apps_19/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "playwright>=1.40"]
 sqlserver = ["sqlalchemy>=2.0", "pyodbc>=5.0"]
-engineering-report = ["python-docx>=1.1", "kaleido>=0.2.1"]
+engineering-report = ["python-docx>=1.1", "kaleido>=0.2.1", "matplotlib>=3.8"]
 
 [tool.setuptools.packages.find]
 include = ["app*"]

--- a/vibe_code_apps_19/requirements.txt
+++ b/vibe_code_apps_19/requirements.txt
@@ -9,3 +9,4 @@ requests>=2.31
 # Engineering Findings DOCX + Plotly→PNG (Overview / Run Rules report)
 python-docx>=1.1
 kaleido>=0.2.1
+matplotlib>=3.8

--- a/vibe_code_apps_19/streamlit_app.py
+++ b/vibe_code_apps_19/streamlit_app.py
@@ -2809,14 +2809,23 @@ def main() -> None:
             )
 
         st.divider()
-        from app.report_downloads import render_engineering_findings_panel
+        from app.report_downloads import (
+            overview_context_from_session,
+            render_engineering_findings_panel,
+        )
 
+        _ov_ctx = None
+        try:
+            _ov_ctx = overview_context_from_session()
+        except Exception:
+            _ov_ctx = None
         render_engineering_findings_panel(
             batch_results=st.session_state.get("batch_results") or [],
             building_name=str(
                 st.session_state.get("building_id") or st.session_state.get("site_id") or ""
             ),
             analysis_period="",
+            overview_context=_ov_ctx,
             key_prefix="run_rules_eng_findings",
         )
 

--- a/vibe_code_apps_19/tests/test_report_day_zoom.py
+++ b/vibe_code_apps_19/tests/test_report_day_zoom.py
@@ -1,0 +1,108 @@
+"""Day-zoom worst-fault day picker + PNG + DOCX media."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+from app.reporting.day_zoom import (
+    attach_day_zoom_to_findings,
+    render_day_zoom_png,
+    worst_fault_day,
+)
+from app.reporting.docx import render_docx
+from app.reporting.models import Classification, EngineeringFinding, ReportArtifacts
+from app.rules.base import RuleResult
+
+
+def test_worst_fault_day_picks_peak_day():
+    idx = pd.date_range("2026-06-27", periods=72, freq="h", tz="UTC")
+    # Day 28 has 20 fault hours; day 27 has 5; day 29 has 10
+    vals = [0] * 24 + [1] * 20 + [0] * 4 + [1] * 10 + [0] * 14
+    fault = pd.Series(vals, index=idx)
+    assert worst_fault_day(fault) == date(2026, 6, 28)
+
+
+def test_worst_fault_day_empty():
+    assert worst_fault_day(None) is None
+    assert worst_fault_day(pd.Series(dtype=float)) is None
+    idx = pd.date_range("2026-01-01", periods=5, freq="h")
+    assert worst_fault_day(pd.Series([0, 0, 0, 0, 0], index=idx)) is None
+
+
+def test_render_day_zoom_png(tmp_path):
+    idx = pd.date_range("2026-06-28", periods=24, freq="h")
+    fault = pd.Series([0, 0, 1, 1, 1, 0] + [0] * 18, index=idx)
+    series = {"zone_t": pd.Series(range(24), index=idx, dtype=float)}
+    result = RuleResult(
+        rule_id="VAV-5",
+        equipment_id="VAV_22",
+        status="FAULT",
+        applicable=True,
+        confirmed_fault=fault,
+        plot_series=series,
+    )
+    out = tmp_path / "zoom.png"
+    rendered = render_day_zoom_png(result, date(2026, 6, 28), out)
+    assert rendered is not None
+    path, hours = rendered
+    assert path.is_file()
+    assert path.stat().st_size > 500
+    assert hours >= 0
+
+
+def test_docx_embeds_day_zoom_media(tmp_path):
+    idx = pd.date_range("2026-06-28", periods=24, freq="h")
+    fault = pd.Series([1] * 12 + [0] * 12, index=idx)
+    result = RuleResult(
+        rule_id="VAV-5",
+        equipment_id="VAV_22",
+        status="FAULT",
+        applicable=True,
+        confirmed_fault=fault,
+        plot_series={"zone_t": pd.Series(range(24), index=idx, dtype=float)},
+    )
+    finding = EngineeringFinding(
+        finding_id="F01",
+        title="Test finding",
+        classification=Classification.PROBABLE,
+        priority=1,
+        why_it_matters="x",
+        observed_behavior="y",
+        evidence_bullets=["e"],
+        contradicting_evidence=[],
+        likely_causes=["c"],
+        field_verification=["f"],
+        possible_corrective=["p"],
+        rule_ids=["VAV-5"],
+        equipment_ids=["VAV_22"],
+        systems=["VAV"],
+        candidate_keys=["VAV_22|VAV-5"],
+        include_in_report=True,
+    )
+    attach_day_zoom_to_findings([finding], [result], out_dir=tmp_path / "dz")
+    assert finding.day_zoom_path and Path(finding.day_zoom_path).is_file()
+
+    art = ReportArtifacts(
+        building="Test",
+        analysis_period="",
+        generated_at="2026-01-01T00:00:00Z",
+        findings=[finding],
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={"n_candidates": 1},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={"ok": True},
+    )
+    docx_path = render_docx(art, tmp_path / "out.docx")
+    import zipfile
+
+    with zipfile.ZipFile(docx_path) as zf:
+        media = [n for n in zf.namelist() if n.startswith("word/media/")]
+    assert media, "expected day-zoom PNG in word/media"

--- a/vibe_code_apps_19/tests/test_report_docx.py
+++ b/vibe_code_apps_19/tests/test_report_docx.py
@@ -71,6 +71,86 @@ def test_report_json_and_docx(tmp_path):
     assert written["docx"].read_bytes()[:2] == b"PK"
 
 
+def test_docx_embeds_overview_and_finding_pictures(tmp_path):
+    """With mocked chart paths on artifacts, §2/§3 pictures land in word/media."""
+    import zipfile
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    from app.reporting.docx import render_docx
+    from app.reporting.models import Classification, EngineeringFinding, ReportArtifacts
+
+    def _write_png(path: Path, color: str) -> None:
+        fig, ax = plt.subplots(figsize=(2, 1))
+        ax.set_facecolor(color)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        fig.savefig(path, dpi=80)
+        plt.close(fig)
+
+    png = tmp_path / "fake.png"
+    png2 = tmp_path / "fake2.png"
+    _write_png(png, "#2b6cb0")
+    _write_png(png2, "#c53030")
+    finding = EngineeringFinding(
+        finding_id="F01",
+        title="Mock finding",
+        classification=Classification.PROBABLE,
+        priority=1,
+        why_it_matters="w",
+        observed_behavior="o",
+        evidence_bullets=["e"],
+        contradicting_evidence=[],
+        likely_causes=[],
+        field_verification=[],
+        possible_corrective=[],
+        rule_ids=["VAV-5"],
+        equipment_ids=["VAV_22"],
+        systems=["VAV"],
+        day_zoom_path=str(png2),
+        day_zoom_label="2026-06-28 · peak fault day",
+        include_in_report=True,
+    )
+    art = ReportArtifacts(
+        building="Liberty",
+        analysis_period="",
+        generated_at="2026-01-01T00:00:00Z",
+        findings=[finding],
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={"ok": True},
+        overview_settings={
+            "dataset_start": "2026-06-01 00:00",
+            "dataset_end": "2026-06-30 23:00",
+            "span_hours": 720.0,
+            "zone_lo_f": 70.0,
+            "zone_hi_f": 75.0,
+            "bare_min_occ_hours": 50.0,
+        },
+        overview_charts=[
+            {"name": "overview_bas_vs_web_oat", "path": str(png), "title": "BAS vs web"}
+        ],
+        charts=[],
+    )
+    out = render_docx(art, tmp_path / "with_pics.docx")
+    with zipfile.ZipFile(out) as zf:
+        media = [n for n in zf.namelist() if n.startswith("word/media/")]
+        xml = zf.read("word/document.xml").decode("utf-8")
+    assert len(media) >= 2
+    assert "Dataset window" in xml
+    assert "BAS vs web" in xml
+    assert "peak fault day" in xml
+
+
 def test_docx_has_rule_descriptions_and_fp_appendix(tmp_path):
     checklist = _mini_checklist()
     checklist["fdd"]["all_faults"].append(
@@ -93,8 +173,6 @@ def test_docx_has_rule_descriptions_and_fp_appendix(tmp_path):
         joined = " ".join(oat.evidence_bullets).lower()
         assert "fan-off" not in joined and "duct static fan-off" not in joined
     written = render_engineering_report(art, tmp_path, docx=True, json_out=False, charts=False)
-    # Spot-check document.xml for legend / description / FP appendix headings
-    import io
     import zipfile
 
     with zipfile.ZipFile(written["docx"]) as zf:

--- a/vibe_code_apps_19/tests/test_report_overview_export.py
+++ b/vibe_code_apps_19/tests/test_report_overview_export.py
@@ -1,0 +1,91 @@
+"""Overview export settings + optional Kaleido PNGs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.reporting.models import ReportArtifacts
+from app.reporting.overview_export import (
+    build_overview_charts,
+    build_overview_context,
+    overview_settings_from_context,
+)
+
+
+def test_overview_settings_lean():
+    ctx = build_overview_context(
+        frames={"AHU_1": pd.DataFrame()},
+        zone_lo_f=70,
+        zone_hi_f=75,
+        bare_min_occ_hours=50,
+        oat_err=5.0,
+        dataset_start=pd.Timestamp("2026-06-01"),
+        dataset_end=pd.Timestamp("2026-06-30"),
+        span_hours=720.0,
+        occupancy_schedule={"mon": {"start": "08:00", "end": "17:00"}},
+    )
+    settings = overview_settings_from_context(ctx)
+    assert "frames" not in settings
+    assert settings["zone_lo_f"] == 70
+    assert settings["bare_min_occ_hours"] == 50
+    assert settings["dataset_start"] == "2026-06-01 00:00"
+    assert settings["span_hours"] == 720.0
+
+
+def test_overview_export_registers_or_skips(tmp_path):
+    """Tiny frames: soft-fail if Kaleido missing; register chart names when export works."""
+    idx = pd.date_range("2026-06-01", periods=48, freq="h")
+    ahu = pd.DataFrame(
+        {
+            "supply-fan-status": [1, 0] * 24,
+            "bas-outside-air-temp": [70.0] * 48,
+            "outside-air-temp": [70.0] * 48,
+        },
+        index=idx,
+    )
+    weather = pd.DataFrame(
+        {"web-outside-air-temp": [68.0 + (i % 5) for i in range(48)]}, index=idx
+    )
+    ctx = build_overview_context(
+        frames={"AHU_1": ahu},
+        role_map={},
+        weather=weather,
+        prefer_web_oat=True,
+        bare_min_occ_hours=40.0,
+    )
+    art = ReportArtifacts(
+        building="T",
+        analysis_period="",
+        generated_at="2026-01-01T00:00:00Z",
+        findings=[],
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={"ok": True},
+    )
+    metas = build_overview_charts(art, ctx, out_dir=tmp_path)
+    assert isinstance(metas, list)
+    assert metas, "expected at least one overview chart attempt"
+    names = {m.get("name") for m in metas}
+    assert names & {
+        "overview_bas_vs_web_oat",
+        "overview_motor_weekly_air",
+        "overview_motor_weekly_boiler",
+        "overview_motor_weekly_chiller",
+        "overview_mech_cooling_oat_bins",
+        "overview_motor_weekly",
+    }
+    pngs = [m for m in metas if m.get("path")]
+    if not pngs:
+        pytest.skip("Kaleido/Plotly PNG export unavailable in this environment")
+    assert any(
+        Path(p["path"]).is_file() and Path(p["path"]).stat().st_size > 100 for p in pngs
+    )


### PR DESCRIPTION
## Summary
- Enrich Engineering Findings DOCX section 2 with dataset window / schedule-zone settings and Overview Plotly-to-Kaleido PNGs (BAS vs web OAT, motor weekly, mech-cooling bins)
- Add matplotlib peak-fault-day zoom per section 3 prioritized finding from RuleResult series
- Bake matplotlib into vibe19 requirements/Docker smoke; unit tests for day picker, overview export, and DOCX media

## Test plan
- [ ] pytest vibe_code_apps_19/tests/test_report_day_zoom.py vibe_code_apps_19/tests/test_report_overview_export.py vibe_code_apps_19/tests/test_report_docx.py
- [ ] Run Rules → Generate FDD Engineering Findings Report with loaded package; confirm DOCX has Overview figures + day-zoom captions
- [ ] After merge: pull/recreate vibe19 GHCR and verify import matplotlib, docx, kaleido