### PR TITLE
fix(vibe19): turnkey Eng Findings Overview/day-zoom DOCX (BUG-011..015)

### DIFF
--- a/.github/workflows/vibe20-ghcr.yml
+++ b/.github/workflows/vibe20-ghcr.yml
@@ -1,5 +1,5 @@
-# Build and publish vibe_code_apps_20 (WattLab Studio) Docker image to GHCR.
-# Image: ghcr.io/<owner>/vibe20
+# GHCR rebuild note (BUG-013): if :latest points at a missing blob, re-run
+# workflow_dispatch with no_cache=true so multi-arch tags are republished cleanly.
 # Multi-arch via QEMU + Buildx:
 #   - linux/amd64  (x86_64 desktops / most cloud hosts)
 #   - linux/arm64  (Raspberry Pi 4/5 64-bit, Apple Silicon)

--- a/vibe_code_apps_19/Dockerfile
+++ b/vibe_code_apps_19/Dockerfile
@@ -26,9 +26,35 @@ LABEL org.opencontainers.image.title="vibe19" \
 
 WORKDIR /app
 
+# Chrome/Chromium shared libs required by Kaleido ≥1 (Plotly PNG export → DOCX).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      fonts-liberation \
+      libasound2 \
+      libatk-bridge2.0-0 \
+      libatk1.0-0 \
+      libcups2 \
+      libdbus-1-3 \
+      libdrm2 \
+      libgbm1 \
+      libgtk-3-0 \
+      libnspr4 \
+      libnss3 \
+      libpango-1.0-0 \
+      libx11-xcb1 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxfixes3 \
+      libxkbcommon0 \
+      libxrandr2 \
+      xdg-utils \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt \
- && python -c "import docx, kaleido, matplotlib; print('engineering-report extras ok')"
+ && python -c "import kaleido; kaleido.get_chrome_sync()" \
+ && python -c "import docx, kaleido, matplotlib; print('engineering-report extras ok')" \
+ && python -c "import plotly.graph_objects as go; from pathlib import Path; p=Path('/tmp/kaleido_smoke.png'); fig=go.Figure(data=[go.Bar(x=['a'], y=[1])]); fig.write_image(str(p)); assert p.is_file() and p.stat().st_size>100; print('kaleido png ok', p.stat().st_size)"
 
 # Includes .streamlit/config.toml (maxUploadSize=500) — do not lower OPENFDD_MAX_* here.
 COPY . .

--- a/vibe_code_apps_19/app/package_io.py
+++ b/vibe_code_apps_19/app/package_io.py
@@ -551,13 +551,30 @@ def load_package_from_dir(
 
     from app.sidecar_maps import SidecarMapError, merge_package_column_maps
 
+    role_map_fallback: dict[str, Any] | None = None
+    if session_cfg is not None and getattr(session_cfg, "role_map", None):
+        role_map_fallback = {
+            str(k): dict(v) for k, v in session_cfg.role_map.items() if isinstance(v, dict)
+        }
+    # Optional package-root role_map.yaml (WattLab dumps)
+    rm_yaml = building_root / "role_map.yaml"
+    if role_map_fallback is None and rm_yaml.is_file():
+        try:
+            from app.role_map import load_role_map
+
+            role_map_fallback = load_role_map(rm_yaml)
+        except Exception as exc:
+            warnings.append(f"role_map.yaml unreadable: {exc}")
+
     try:
-        column_map = merge_package_column_maps(
+        column_map, map_warnings = merge_package_column_maps(
             building_root,
             equipment,
             building_id=manifest.building_id,
             root_column_map=root_map,
+            role_map_fallback=role_map_fallback,
         )
+        warnings.extend(map_warnings)
     except SidecarMapError as exc:
         raise PackageError(str(exc)) from exc
 

--- a/vibe_code_apps_19/app/reporting/charts.py
+++ b/vibe_code_apps_19/app/reporting/charts.py
@@ -219,7 +219,10 @@ def _export(fig, name: str, out_dir: Path | None) -> dict[str, Any]:
         return meta
     png = out_dir / f"{name}.png"
     try:
-        fig.write_image(str(png), scale=2, width=900, height=420)
+        from app.reporting.overview_export import _fig_for_kaleido
+
+        export_fig = _fig_for_kaleido(fig)
+        export_fig.write_image(str(png), scale=2, width=900, height=420)
         meta["path"] = str(png)
     except Exception as exc:  # kaleido optional / may fail headless
         meta["export_error"] = str(exc)

--- a/vibe_code_apps_19/app/reporting/cli.py
+++ b/vibe_code_apps_19/app/reporting/cli.py
@@ -8,6 +8,48 @@ import sys
 from pathlib import Path
 
 
+def _overview_context_from_dataset(ds) -> dict:
+    """Build overview_context from an AgentDataset (frames + session knobs)."""
+    from app.analytics import dataset_time_span
+    from app.occupancy import OccupancySchedule, occupied_hours_per_week
+    from app.reporting.overview_export import build_overview_context
+
+    frames = getattr(ds, "frames", None) or {}
+    span = dataset_time_span(frames) if frames else {}
+    session = getattr(ds, "session_config", None) or {}
+    params = getattr(ds, "params", None) or session.get("params") or {}
+    oat_err = 5.0
+    try:
+        oat_err = float((params.get("OAT-METEO") or {}).get("oat_err", 5.0))
+    except (TypeError, ValueError):
+        oat_err = 5.0
+    sched = OccupancySchedule.from_dict(session.get("occupancy_schedule"))
+    return build_overview_context(
+        frames=frames,
+        role_map=getattr(ds, "role_map", None) or {},
+        weather=getattr(ds, "weather", None),
+        prefer_web_oat=bool(getattr(ds, "prefer_web_oat", session.get("prefer_web_oat", True))),
+        oat_err=oat_err,
+        chw_leave_max_f=float(
+            getattr(ds, "chw_leave_max_f", None) or session.get("chw_leave_max_f", 48.0)
+        ),
+        use_status_proof=bool(
+            getattr(
+                ds,
+                "use_mech_cooling_status_proof",
+                session.get("use_mech_cooling_status_proof", True),
+            )
+        ),
+        zone_lo_f=float(session.get("zone_lo_f", 70.0)),
+        zone_hi_f=float(session.get("zone_hi_f", 75.0)),
+        bare_min_occ_hours=float(occupied_hours_per_week(sched)),
+        occupancy_schedule=sched.to_dict(),
+        dataset_start=span.get("start"),
+        dataset_end=span.get("end"),
+        span_hours=span.get("span_hours"),
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(
         description=(
@@ -32,18 +74,27 @@ def main(argv: list[str] | None = None) -> int:
     from app.reporting.pipeline import build_engineering_findings, render_engineering_report
 
     rule_results = None
+    overview_context = None
+    building = args.building
     if args.dump:
         from app.agent_api import load_package_path, run_rules
 
         ds = load_package_path(args.dump)
+        building = building or getattr(ds, "building_id", "") or ""
+        try:
+            overview_context = _overview_context_from_dataset(ds)
+        except Exception as exc:  # soft-fail Overview export path
+            print(f"overview_context unavailable: {exc}", file=sys.stderr)
+            overview_context = None
         if args.run_rules:
             run = run_rules(ds)
             rule_results = run.results
 
     artifacts = build_engineering_findings(
-        building=args.building,
+        building=building,
         checklist=args.checklist_json,
         rule_results=rule_results,
+        overview_context=overview_context,
         max_findings=args.max_findings,
     )
     written = render_engineering_report(
@@ -52,6 +103,8 @@ def main(argv: list[str] | None = None) -> int:
         docx=args.docx,
         json_out=args.json_out or not args.docx,
         charts=not args.no_charts,
+        overview_context=overview_context,
+        rule_results=rule_results,
     )
     print(json.dumps({k: str(v) for k, v in written.items()}, indent=2))
     print("metrics", json.dumps(artifacts.metrics))

--- a/vibe_code_apps_19/app/reporting/day_zoom.py
+++ b/vibe_code_apps_19/app/reporting/day_zoom.py
@@ -39,6 +39,24 @@ def resolve_result_for_finding(
     return None
 
 
+def _day_bounds(day: date, index: pd.DatetimeIndex) -> tuple[pd.Timestamp, pd.Timestamp]:
+    """Inclusive start / exclusive end for ``day``, timezone-aligned to ``index``."""
+    start = pd.Timestamp(day)
+    end = start + pd.Timedelta(days=1)
+    tz = getattr(index, "tz", None)
+    if tz is not None:
+        if start.tzinfo is None:
+            start = start.tz_localize(tz)
+            end = end.tz_localize(tz)
+        else:
+            start = start.tz_convert(tz)
+            end = end.tz_convert(tz)
+    elif start.tzinfo is not None:
+        start = start.tz_convert("UTC").tz_localize(None)
+        end = end.tz_convert("UTC").tz_localize(None)
+    return start, end
+
+
 def worst_fault_day(fault: pd.Series | None) -> date | None:
     """Calendar day with the most fault samples (True / 1)."""
     if fault is None or len(fault) == 0:
@@ -57,6 +75,8 @@ def worst_fault_day(fault: pd.Series | None) -> date | None:
             numeric.index = idx
         except Exception:
             return None
+    else:
+        numeric.index = s.index
     daily = numeric.groupby(numeric.index.normalize()).sum()
     if daily.empty or float(daily.max()) <= 0:
         return None
@@ -97,9 +117,6 @@ def render_day_zoom_png(
         fault = getattr(result, "raw_fault", None)
     plot_series = getattr(result, "plot_series", None) or {}
 
-    day_start = pd.Timestamp(day)
-    day_end = day_start + pd.Timedelta(days=1)
-
     def _slice(ser: pd.Series | None) -> pd.Series | None:
         if ser is None or len(ser) == 0:
             return None
@@ -109,6 +126,7 @@ def render_day_zoom_png(
                 s.index = pd.to_datetime(s.index)
             except Exception:
                 return None
+        day_start, day_end = _day_bounds(day, s.index)
         return s[(s.index >= day_start) & (s.index < day_end)]
 
     fault_day = _slice(fault)

--- a/vibe_code_apps_19/app/reporting/overview_export.py
+++ b/vibe_code_apps_19/app/reporting/overview_export.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
+
 from app.reporting.models import ReportArtifacts
 
 
@@ -200,13 +202,54 @@ def build_overview_charts(
     return charts
 
 
+def _json_safe(obj: Any) -> Any:
+    """Recursively convert pandas/numpy datetimes so Kaleido's orjson can encode."""
+    import numpy as np
+
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return obj
+    if isinstance(obj, pd.Timestamp):
+        return obj.isoformat()
+    if isinstance(obj, np.datetime64):
+        return pd.Timestamp(obj).isoformat()
+    if isinstance(obj, np.ndarray):
+        return [_json_safe(v) for v in obj.tolist()]
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(v) for v in obj]
+    if isinstance(obj, dict):
+        return {str(k): _json_safe(v) for k, v in obj.items()}
+    if hasattr(obj, "tolist"):
+        try:
+            return _json_safe(obj.tolist())
+        except Exception:
+            pass
+    # Fallback: stringify unknown scalars (keeps export from soft-failing)
+    try:
+        if pd.isna(obj):
+            return None
+    except Exception:
+        pass
+    return str(obj)
+
+
+def _fig_for_kaleido(fig: Any) -> Any:
+    """Re-encode figure so Kaleido never sees pandas Timestamp / numpy datetime."""
+    try:
+        from plotly.graph_objects import Figure
+
+        return Figure(_json_safe(fig.to_plotly_json()))
+    except Exception:
+        return fig
+
+
 def _export_plotly(
     fig: Any, name: str, out_dir: Path, *, title: str | None = None
 ) -> dict[str, Any]:
     meta: dict[str, Any] = {"name": name, "path": None, "title": title or name}
     png = out_dir / f"{name}.png"
+    export_fig = _fig_for_kaleido(fig)
     try:
-        fig.write_image(str(png), scale=2, width=900, height=480)
+        export_fig.write_image(str(png), scale=2, width=900, height=480)
         meta["path"] = str(png)
     except Exception as exc:
         meta["export_error"] = str(exc)

--- a/vibe_code_apps_19/app/sidecar_maps.py
+++ b/vibe_code_apps_19/app/sidecar_maps.py
@@ -151,6 +151,59 @@ def load_equipment_sidecar_map(
     return data
 
 
+def column_map_from_role_map(
+    role_map: dict[str, Any],
+    *,
+    building_id: str = "",
+    site_ref: str = "default_site",
+    equipment_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Synthesize a package column_map from session_config / role_map.yaml style maps."""
+    from app.site_model import equipment_type_from_id
+
+    data = empty_column_map(
+        building_id=building_id or "UNNAMED_BUILDING",
+        site_ref=site_ref,
+        generated_by="session-role-map-fallback",
+    )
+    wanted = set(equipment_ids or []) or set(role_map or {})
+    for eq_id in sorted(wanted):
+        raw = role_map.get(eq_id) if isinstance(role_map, dict) else None
+        if not isinstance(raw, dict):
+            continue
+        # Drop non-point metadata keys commonly stored alongside roles
+        skip = {
+            "equipment_type",
+            "equipType",
+            "plant_group",
+            "device",
+            "notes",
+            "siteRef",
+            "building_id",
+        }
+        roles = {
+            str(k): str(v)
+            for k, v in raw.items()
+            if k not in skip and isinstance(v, str) and v.strip()
+        }
+        roles = normalize_point_roles(roles)
+        if not roles:
+            continue
+        etype = str(
+            raw.get("equipment_type")
+            or raw.get("equipType")
+            or equipment_type_from_id(eq_id)
+            or "UNKNOWN"
+        )
+        etype = haystack_equip_type_to_cookbook(etype, eq_id)
+        data["equipment"][eq_id] = {
+            "equipment_type": etype,
+            "device": eq_id,
+            "column_roles": roles,
+        }
+    return normalize_column_map(data)
+
+
 def merge_package_column_maps(
     building_root: Path,
     equipment: list[dict[str, Any]],
@@ -158,9 +211,48 @@ def merge_package_column_maps(
     building_id: str = "",
     site_ref: str = "default_site",
     root_column_map: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Require per-equip sidecars; merge them (+ optional root map as supplement)."""
-    require_equipment_sidecar_maps(equipment)
+    role_map_fallback: dict[str, Any] | None = None,
+    allow_role_map_fallback: bool = True,
+) -> tuple[dict[str, Any], list[str]]:
+    """Merge per-equip sidecars (+ optional root).
+
+    When sidecars are missing but ``role_map_fallback`` (session_config.role_map
+    or role_map.yaml) covers equipment, synthesize maps and return a warning
+    instead of rejecting the package (BUG-014 practice packages).
+    """
+    warnings: list[str] = []
+    try:
+        require_equipment_sidecar_maps(equipment)
+    except SidecarMapError as exc:
+        if not allow_role_map_fallback or not role_map_fallback:
+            raise
+        eq_ids = [str(e["equipment_id"]) for e in equipment]
+        synthesized = column_map_from_role_map(
+            role_map_fallback,
+            building_id=building_id or building_root.name,
+            site_ref=site_ref,
+            equipment_ids=eq_ids,
+        )
+        covered = set((synthesized.get("equipment") or {}).keys())
+        missing = [eid for eid in eq_ids if eid not in covered]
+        if missing:
+            raise SidecarMapError(
+                f"{exc} Also session/role_map fallback missing bindings for: "
+                + ", ".join(missing[:12])
+                + (f" … +{len(missing) - 12} more" if len(missing) > 12 else "")
+            ) from exc
+        warnings.append(
+            "No per-equip Haystack sidecar JSON; using session_config/role_map "
+            f"fallback for {len(covered)} equipment (prefer sibling column_map.json)."
+        )
+        if root_column_map:
+            # Root supplements; role_map-derived blocks already present
+            merged = normalize_column_map(root_column_map)
+            for eq_id, block in (synthesized.get("equipment") or {}).items():
+                merged.setdefault("equipment", {})[eq_id] = block
+            return normalize_column_map(merged), warnings
+        return synthesized, warnings
+
     merged = empty_column_map(
         building_id=building_id or building_root.name,
         site_ref=site_ref,
@@ -180,7 +272,7 @@ def merge_package_column_maps(
         )
         block = piece["equipment"][eq_id]
         merged["equipment"][eq_id] = block
-    return normalize_column_map(merged)
+    return normalize_column_map(merged), warnings
 
 
 def sidecar_maps_to_role_map(

--- a/vibe_code_apps_19/scripts/docker_update_vibe19.ps1
+++ b/vibe_code_apps_19/scripts/docker_update_vibe19.ps1
@@ -28,4 +28,4 @@ if ($LASTEXITCODE -ne 0) { throw "docker run failed" }
 Write-Host "==> Running:"
 docker ps --filter "name=$Name"
 Write-Host "Open http://localhost:${HostPort}  (or http://<host-ip>:${HostPort})"
-Write-Host "Note: a running container never auto-updates — re-run this script after GHCR builds."
+Write-Host "Note: a running container never auto-updates - re-run this script after GHCR builds."

--- a/vibe_code_apps_19/scripts/validate_eng_findings_docx_media.py
+++ b/vibe_code_apps_19/scripts/validate_eng_findings_docx_media.py
@@ -1,0 +1,101 @@
+"""Run inside vibe19 image: Overview PNG + UTC day-zoom → DOCX media."""
+from __future__ import annotations
+
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+
+from app.reporting.day_zoom import attach_day_zoom_to_findings
+from app.reporting.docx import render_docx
+from app.reporting.models import Classification, EngineeringFinding, ReportArtifacts
+from app.reporting.overview_export import build_overview_charts, build_overview_context
+from app.rules.base import RuleResult
+
+
+def main() -> None:
+    td = Path(tempfile.mkdtemp())
+    idx = pd.date_range("2026-06-01", periods=48, freq="h", tz="UTC")
+    ahu = pd.DataFrame(
+        {
+            "supply-fan-status": [1, 0] * 24,
+            "bas-outside-air-temp": [70.0] * 48,
+            "outside-air-temp": [70.0] * 48,
+        },
+        index=idx,
+    )
+    weather = pd.DataFrame(
+        {"web-outside-air-temp": [68.0 + (i % 5) for i in range(48)]}, index=idx
+    )
+    ctx = build_overview_context(
+        frames={"AHU_1": ahu}, role_map={}, weather=weather, bare_min_occ_hours=40.0
+    )
+    art = ReportArtifacts(
+        building="E2E",
+        analysis_period="",
+        generated_at="2026-01-01T00:00:00Z",
+        findings=[],
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={"ok": True},
+        overview_settings={
+            "dataset_start": "2026-06-01",
+            "dataset_end": "2026-06-02",
+            "span_hours": 47.0,
+            "zone_lo_f": 70.0,
+            "zone_hi_f": 75.0,
+            "bare_min_occ_hours": 40.0,
+        },
+    )
+    metas = build_overview_charts(art, ctx, out_dir=td / "ov")
+    pngs = [m for m in metas if m.get("path")]
+    assert pngs, f"no overview PNGs: {metas}"
+    fault_idx = pd.date_range("2026-06-28", periods=24, freq="h", tz="UTC")
+    fault = pd.Series([1] * 10 + [0] * 14, index=fault_idx)
+    result = RuleResult(
+        rule_id="VAV-5",
+        equipment_id="VAV_1",
+        status="FAULT",
+        applicable=True,
+        confirmed_fault=fault,
+        plot_series={"zone_t": pd.Series(range(24), index=fault_idx, dtype=float)},
+    )
+    finding = EngineeringFinding(
+        finding_id="F01",
+        title="UTC",
+        classification=Classification.PROBABLE,
+        priority=1,
+        why_it_matters="w",
+        observed_behavior="o",
+        evidence_bullets=["e"],
+        contradicting_evidence=[],
+        likely_causes=[],
+        field_verification=[],
+        possible_corrective=[],
+        rule_ids=["VAV-5"],
+        equipment_ids=["VAV_1"],
+        systems=["VAV"],
+        candidate_keys=["VAV_1|VAV-5"],
+        include_in_report=True,
+    )
+    attach_day_zoom_to_findings([finding], [result], out_dir=td / "dz")
+    assert finding.day_zoom_path
+    art.findings = [finding]
+    art.overview_charts = pngs
+    docx = render_docx(art, td / "e2e.docx")
+    with zipfile.ZipFile(docx) as zf:
+        media = [n for n in zf.namelist() if n.startswith("word/media/")]
+    print("media", len(media), "overview_pngs", len(pngs), "day_zoom", finding.day_zoom_label)
+    assert len(media) >= 2
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/vibe_code_apps_19/tests/test_eng_findings_apptest.py
+++ b/vibe_code_apps_19/tests/test_eng_findings_apptest.py
@@ -1,0 +1,109 @@
+"""AppTest: Run Rules Engineering Findings panel renders without Streamlit errors."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _pkg_zip(path: Path, *, with_sidecar: bool = False) -> None:
+    hist = "timestamp_utc,fan_status,oa_t,sat\n"
+    for i in range(12):
+        hist += f"2024-06-01T12:{i:02d}:00Z,1,70,55\n"
+    session = {
+        "schema_version": "openfdd_session_v1",
+        "unit_system": "imperial",
+        "prefer_web_oat": False,
+        "role_map": {
+            "AHU_1": {
+                "supply-fan-status": "fan_status",
+                "outside-air-temp": "oa_t",
+                "discharge-air-temp": "sat",
+            }
+        },
+    }
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(
+            "manifest.json",
+            json.dumps(
+                {
+                    "schema_version": "openfdd_package_v1",
+                    "building_id": "UI_B1",
+                    "grid_minutes": 5,
+                    "timezone": "UTC",
+                }
+            ),
+        )
+        zf.writestr("session_config.json", json.dumps(session))
+        zf.writestr("AHU_1/history_wide.csv", hist)
+        if with_sidecar:
+            zf.writestr(
+                "AHU_1/column_map.json",
+                json.dumps(
+                    {
+                        "equipType": "ahu",
+                        "points": {
+                            "fan-status": "fan_status",
+                            "outside-air-temp": "oa_t",
+                            "discharge-air-temp": "sat",
+                        },
+                    }
+                ),
+            )
+
+
+def test_run_rules_eng_findings_panel_no_streamlit_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    pytest.importorskip("streamlit")
+    from streamlit.testing.v1 import AppTest
+
+    zpath = tmp_path / "ui_pkg.zip"
+    _pkg_zip(zpath)  # no sidecar — exercises BUG-014 fallback
+    boot = {
+        "schema_version": "openfdd_bootstrap_v1",
+        "package_path": str(zpath.resolve()),
+        "auto_run_rules": True,
+        "session_config": {
+            "schema_version": "openfdd_session_v1",
+            "unit_system": "imperial",
+            "prefer_web_oat": False,
+        },
+    }
+    boot_path = tmp_path / "boot.json"
+    boot_path.write_text(json.dumps(boot), encoding="utf-8")
+    monkeypatch.setenv("VIBE19_BOOTSTRAP_JSON", str(boot_path))
+    monkeypatch.chdir(ROOT)
+
+    at = AppTest.from_file(str(ROOT / "streamlit_app.py"), default_timeout=120)
+    at.run()
+    assert not at.exception, f"Streamlit exception on load: {at.exception}"
+
+    # Switch to Run Rules if section radio exists
+    for radio in at.radio:
+        labels = list(getattr(radio, "options", []) or [])
+        if "Run Rules" in labels:
+            radio.set_value("Run Rules")
+            at.run()
+            break
+    assert not at.exception, f"Streamlit exception on Run Rules: {at.exception}"
+
+    # Generate Engineering Findings if the button is present
+    clicked = False
+    for btn in at.button:
+        label = str(getattr(btn, "label", "") or "")
+        if "Engineering Findings" in label or "Generate FDD" in label:
+            btn.click()
+            at.run(timeout=180)
+            clicked = True
+            break
+    assert not at.exception, f"Streamlit exception on generate: {at.exception}"
+    if clicked:
+        # Soft assert success message / download availability — no Traceback text
+        page = " ".join(str(x) for x in at.markdown) + " ".join(str(x) for x in at.success)
+        assert "Traceback" not in page

--- a/vibe_code_apps_19/tests/test_report_cli_overview_context.py
+++ b/vibe_code_apps_19/tests/test_report_cli_overview_context.py
@@ -1,0 +1,43 @@
+"""CLI overview_context wiring (BUG-015)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pandas as pd
+
+from app.reporting.cli import _overview_context_from_dataset
+
+
+@dataclass
+class _FakeDS:
+    building_id: str = "B1"
+    frames: dict = field(default_factory=dict)
+    weather: Any = None
+    role_map: dict = field(default_factory=dict)
+    params: dict = field(default_factory=dict)
+    prefer_web_oat: bool = True
+    chw_leave_max_f: float = 48.0
+    use_mech_cooling_status_proof: bool = True
+    session_config: dict | None = None
+
+
+def test_overview_context_from_dataset_includes_frames_and_settings():
+    idx = pd.date_range("2026-06-01", periods=3, freq="h", tz="UTC")
+    frames = {"AHU_1": pd.DataFrame({"x": [1, 2, 3]}, index=idx)}
+    ds = _FakeDS(
+        frames=frames,
+        role_map={"AHU_1": {"supply-fan-status": "fan"}},
+        session_config={"zone_lo_f": 68.0, "zone_hi_f": 76.0},
+        params={"OAT-METEO": {"oat_err": 4.0}},
+    )
+    ctx = _overview_context_from_dataset(ds)
+    assert ctx["frames"] is frames
+    assert ctx["role_map"]["AHU_1"]["supply-fan-status"] == "fan"
+    assert ctx["zone_lo_f"] == 68.0
+    assert ctx["oat_err"] == 4.0
+    assert ctx["span_hours"] is not None
+    assert "frames" not in __import__(
+        "app.reporting.overview_export", fromlist=["overview_settings_from_context"]
+    ).overview_settings_from_context(ctx)

--- a/vibe_code_apps_19/tests/test_report_day_zoom.py
+++ b/vibe_code_apps_19/tests/test_report_day_zoom.py
@@ -53,6 +53,27 @@ def test_render_day_zoom_png(tmp_path):
     assert hours >= 0
 
 
+def test_render_day_zoom_png_utc_aware_index(tmp_path):
+    """BUG-012: UTC-aware DatetimeIndex must not crash against naive day bounds."""
+    idx = pd.date_range("2026-06-28", periods=24, freq="h", tz="UTC")
+    fault = pd.Series([0, 0, 1, 1, 1, 0] + [0] * 18, index=idx)
+    series = {"zone_t": pd.Series(range(24), index=idx, dtype=float)}
+    result = RuleResult(
+        rule_id="VAV-5",
+        equipment_id="VAV_22",
+        status="FAULT",
+        applicable=True,
+        confirmed_fault=fault,
+        plot_series=series,
+    )
+    day = worst_fault_day(fault)
+    assert day == date(2026, 6, 28)
+    rendered = render_day_zoom_png(result, day, tmp_path / "utc_zoom.png")
+    assert rendered is not None
+    path, _hours = rendered
+    assert path.is_file() and path.stat().st_size > 500
+
+
 def test_docx_embeds_day_zoom_media(tmp_path):
     idx = pd.date_range("2026-06-28", periods=24, freq="h")
     fault = pd.Series([1] * 12 + [0] * 12, index=idx)

--- a/vibe_code_apps_19/tests/test_report_e2e_docx_media.py
+++ b/vibe_code_apps_19/tests/test_report_e2e_docx_media.py
@@ -1,0 +1,109 @@
+"""End-to-end: Overview PNGs + UTC day-zoom land in DOCX (BUG-011/012)."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.reporting.models import Classification, EngineeringFinding, ReportArtifacts
+from app.reporting.overview_export import build_overview_charts, build_overview_context
+from app.reporting.day_zoom import attach_day_zoom_to_findings
+from app.reporting.docx import render_docx
+from app.rules.base import RuleResult
+
+
+def test_overview_and_day_zoom_embed_in_docx(tmp_path):
+    idx = pd.date_range("2026-06-01", periods=48, freq="h", tz="UTC")
+    ahu = pd.DataFrame(
+        {
+            "supply-fan-status": [1, 0] * 24,
+            "bas-outside-air-temp": [70.0] * 48,
+            "outside-air-temp": [70.0] * 48,
+        },
+        index=idx,
+    )
+    weather = pd.DataFrame(
+        {"web-outside-air-temp": [68.0 + (i % 5) for i in range(48)]}, index=idx
+    )
+    ctx = build_overview_context(
+        frames={"AHU_1": ahu},
+        role_map={},
+        weather=weather,
+        bare_min_occ_hours=40.0,
+        dataset_start=idx.min(),
+        dataset_end=idx.max(),
+        span_hours=47.0,
+        zone_lo_f=70.0,
+        zone_hi_f=75.0,
+    )
+    art = ReportArtifacts(
+        building="E2E",
+        analysis_period="",
+        generated_at="2026-01-01T00:00:00Z",
+        findings=[],
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={"ok": True},
+        overview_settings={
+            "dataset_start": "2026-06-01 00:00",
+            "dataset_end": "2026-06-02 23:00",
+            "span_hours": 47.0,
+            "zone_lo_f": 70.0,
+            "zone_hi_f": 75.0,
+            "bare_min_occ_hours": 40.0,
+        },
+    )
+    metas = build_overview_charts(art, ctx, out_dir=tmp_path / "ov")
+    png_overview = [m for m in metas if m.get("path")]
+    if not png_overview:
+        pytest.skip("Kaleido PNG export unavailable in this environment")
+
+    fault_idx = pd.date_range("2026-06-28", periods=24, freq="h", tz="UTC")
+    fault = pd.Series([1] * 10 + [0] * 14, index=fault_idx)
+    result = RuleResult(
+        rule_id="VAV-5",
+        equipment_id="VAV_1",
+        status="FAULT",
+        applicable=True,
+        confirmed_fault=fault,
+        plot_series={"zone_t": pd.Series(range(24), index=fault_idx, dtype=float)},
+    )
+    finding = EngineeringFinding(
+        finding_id="F01",
+        title="UTC day zoom",
+        classification=Classification.PROBABLE,
+        priority=1,
+        why_it_matters="w",
+        observed_behavior="o",
+        evidence_bullets=["e"],
+        contradicting_evidence=[],
+        likely_causes=[],
+        field_verification=[],
+        possible_corrective=[],
+        rule_ids=["VAV-5"],
+        equipment_ids=["VAV_1"],
+        systems=["VAV"],
+        candidate_keys=["VAV_1|VAV-5"],
+        include_in_report=True,
+    )
+    attach_day_zoom_to_findings([finding], [result], out_dir=tmp_path / "dz")
+    assert finding.day_zoom_path and Path(finding.day_zoom_path).is_file()
+    art.findings = [finding]
+    art.overview_charts = png_overview
+
+    docx_path = render_docx(art, tmp_path / "e2e.docx")
+    with zipfile.ZipFile(docx_path) as zf:
+        media = [n for n in zf.namelist() if n.startswith("word/media/")]
+        xml = zf.read("word/document.xml").decode("utf-8")
+    assert len(media) >= 2
+    assert "Dataset window" in xml
+    assert "fault-h that day" in xml or "peak fault" in xml

--- a/vibe_code_apps_19/tests/test_sidecar_maps.py
+++ b/vibe_code_apps_19/tests/test_sidecar_maps.py
@@ -50,6 +50,34 @@ def test_rejects_package_without_sidecar(tmp_path: Path):
         load_package_from_dir(root)
 
 
+def test_accepts_session_role_map_without_sidecars(tmp_path: Path):
+    """BUG-014: practice packages with session_config.role_map load without per-equip JSON."""
+    root = tmp_path / "pkg"
+    root.mkdir()
+    (root / "manifest.json").write_text(_manifest(), encoding="utf-8")
+    (root / "session_config.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "openfdd_session_v1",
+                "role_map": {
+                    "AHU_1": {
+                        "supply-fan-status": "fan_status",
+                        "outside-air-temp": "oa_t",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    eq = root / "AHU_1"
+    eq.mkdir()
+    (eq / "history_wide.csv").write_text(_hist(), encoding="utf-8")
+    result = load_package_from_dir(root)
+    assert "AHU_1" in result.frames
+    assert result.column_map is not None
+    assert any("role_map" in w.lower() or "sidecar" in w.lower() for w in result.warnings)
+
+
 def test_accepts_history_wide_json_and_column_map_json(tmp_path: Path):
     root = tmp_path / "pkg"
     root.mkdir()


### PR DESCRIPTION
## Summary
- BUG-011: Bake Chrome + OS libs for Kaleido; sanitize Plotly Timestamp arrays so Overview PNGs embed in DOCX
- BUG-012: Align day-zoom day bounds to tz-aware DatetimeIndex (UTC)
- BUG-014: Accept `session_config.role_map` / `role_map.yaml` when per-equip Haystack sidecars are missing
- BUG-015: Pass `overview_context` from reporting CLI `--dump`
- BUG-013: Note + path touch so vibe20-ghcr can republish with `no_cache=true`

Validated locally: Docker Kaleido PNG smoke, `validate_eng_findings_docx_media.py` (media>=2), AppTest Run Rules panel with no Streamlit exceptions, unit tests green.

## Test plan
- [x] pytest day_zoom / sidecar / cli / apptest / docx suites
- [x] Docker `scripts/validate_eng_findings_docx_media.py`
- [ ] After merge: pull vibe19:latest; generate Eng Findings DOCX; confirm `word/media` > 0
- [ ] `workflow_dispatch` vibe20-ghcr with `no_cache=true`; `docker pull ghcr.io/bbartling/vibe20:latest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports can now use role-map information when equipment sidecar files are unavailable.
  * Engineering reports include richer overview context and support DOCX charts and day-zoom media.
* **Bug Fixes**
  * Improved PNG export reliability for Plotly charts, including date/time data.
  * Corrected day-based charting for timezone-aware datasets.
  * Improved handling of missing or unreadable mapping files with warnings instead of failures.
* **Tests**
  * Added coverage for Streamlit findings, report generation, chart exports, timezone handling, and DOCX media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->