### PR TITLE
fix(vibe19): Eng Findings day-zoom, quality gate, period, DOCX UX

### DIFF
--- a/vibe_code_apps_19/app/reporting/day_zoom.py
+++ b/vibe_code_apps_19/app/reporting/day_zoom.py
@@ -226,8 +226,9 @@ def attach_day_zoom_to_findings(
     """Write day-zoom PNGs and set ``day_zoom_path`` / ``day_zoom_label`` on findings.
 
     Always records a meta per included finding. Successful zooms include ``path``;
-    skips include ``skip_reason`` in ``{excluded, no_result, no_fault_day, render_failed}``
-    and set ``EngineeringFinding.day_zoom_skip_reason``.
+    skips include ``skip_reason`` in ``{no_result, no_fault_day, render_failed}``
+    and set ``EngineeringFinding.day_zoom_skip_reason``. Findings with
+    ``include_in_report=False`` are ignored (no meta).
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -261,7 +262,11 @@ def attach_day_zoom_to_findings(
             _skip(f, "no_fault_day")
             continue
         png = out_dir / f"day_zoom_{f.finding_id}.png"
-        rendered = render_day_zoom_png(result, day, png)
+        try:
+            rendered = render_day_zoom_png(result, day, png)
+        except Exception:
+            _skip(f, "render_failed")
+            continue
         if rendered is None:
             _skip(f, "render_failed")
             continue

--- a/vibe_code_apps_19/app/reporting/day_zoom.py
+++ b/vibe_code_apps_19/app/reporting/day_zoom.py
@@ -223,33 +223,56 @@ def attach_day_zoom_to_findings(
     *,
     out_dir: Path,
 ) -> list[dict[str, Any]]:
-    """Write day-zoom PNGs and set ``day_zoom_path`` / ``day_zoom_label`` on findings."""
+    """Write day-zoom PNGs and set ``day_zoom_path`` / ``day_zoom_label`` on findings.
+
+    Always records a meta per included finding. Successful zooms include ``path``;
+    skips include ``skip_reason`` in ``{excluded, no_result, no_fault_day, render_failed}``
+    and set ``EngineeringFinding.day_zoom_skip_reason``.
+    """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     by_key = index_rule_results(rule_results)
     metas: list[dict[str, Any]] = []
+
+    def _skip(f: EngineeringFinding, reason: str) -> None:
+        f.day_zoom_path = None
+        f.day_zoom_skip_reason = reason
+        f.day_zoom_label = f"Day-zoom unavailable: {reason}"
+        metas.append(
+            {
+                "name": f"day_zoom_{f.finding_id}",
+                "finding_id": f.finding_id,
+                "skip_reason": reason,
+            }
+        )
+
     for f in findings:
         if not f.include_in_report:
             continue
         result = resolve_result_for_finding(f, by_key)
         if result is None:
+            _skip(f, "no_result")
             continue
         fault = getattr(result, "confirmed_fault", None)
         if fault is None or (hasattr(fault, "empty") and fault.empty):
             fault = getattr(result, "raw_fault", None)
         day = worst_fault_day(fault if isinstance(fault, pd.Series) else None)
         if day is None:
+            _skip(f, "no_fault_day")
             continue
         png = out_dir / f"day_zoom_{f.finding_id}.png"
         rendered = render_day_zoom_png(result, day, png)
         if rendered is None:
+            _skip(f, "render_failed")
             continue
         path, hours = rendered
         if not path.is_file():
+            _skip(f, "render_failed")
             continue
         label = f"{day.isoformat()} · ~{hours:g} fault-h that day"
         f.day_zoom_path = str(path)
         f.day_zoom_label = label
+        f.day_zoom_skip_reason = None
         metas.append(
             {
                 "name": f"day_zoom_{f.finding_id}",

--- a/vibe_code_apps_19/app/reporting/docx.py
+++ b/vibe_code_apps_19/app/reporting/docx.py
@@ -400,26 +400,29 @@ def _add_overview_charts(doc, artifacts: ReportArtifacts) -> None:
 def _add_finding_picture(doc, f) -> None:
     from docx.shared import Inches
 
+    skip_reason = getattr(f, "day_zoom_skip_reason", None)
+    skip_note = getattr(f, "day_zoom_label", None)
+    if skip_reason or (skip_note and "unavailable" in str(skip_note).lower()):
+        _muted(doc, str(skip_note or f"Day-zoom unavailable: {skip_reason}"))
+
     path = None
     caption = None
     if getattr(f, "day_zoom_path", None) and Path(f.day_zoom_path).is_file():
         path = f.day_zoom_path
         caption = getattr(f, "day_zoom_label", None)
+        if caption and "unavailable" in str(caption).lower():
+            caption = None
     elif getattr(f, "chart_path", None) and Path(f.chart_path).is_file():
         path = f.chart_path
     if not path:
-        reason = getattr(f, "day_zoom_skip_reason", None)
-        note = getattr(f, "day_zoom_label", None)
-        if reason or (note and "unavailable" in str(note).lower()):
-            _muted(doc, str(note or f"Day-zoom unavailable: {reason}"))
-        elif reason is None and note is None:
+        if not (skip_reason or (skip_note and "unavailable" in str(skip_note).lower())):
             _muted(doc, "Day-zoom unavailable: no chart")
         return
     try:
         doc.add_picture(str(path), width=Inches(5.8))
     except Exception:
-        reason = getattr(f, "day_zoom_skip_reason", None) or "render_failed"
-        _muted(doc, f"Day-zoom unavailable: {reason}")
+        if not skip_reason:
+            _muted(doc, "Day-zoom unavailable: render_failed")
         return
     if caption:
         _muted(doc, str(caption))

--- a/vibe_code_apps_19/app/reporting/docx.py
+++ b/vibe_code_apps_19/app/reporting/docx.py
@@ -12,8 +12,7 @@ from app.reporting.rule_meta import legend_rows, rule_label
 def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
     try:
         from docx import Document
-        from docx.enum.text import WD_ALIGN_PARAGRAPH
-        from docx.shared import Inches, Pt
+        from docx.shared import Inches, Pt  # noqa: F401 — Pt used by helpers
     except ImportError as exc:
         raise RuntimeError(
             "python-docx is required for Engineering Findings DOCX. "
@@ -24,27 +23,23 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     doc = Document()
 
-    # Cover
-    title = doc.add_heading("FDD Engineering Findings Report", 0)
-    title.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    p = doc.add_paragraph()
-    p.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    run = p.add_run(artifacts.building)
-    run.bold = True
-    run.font.size = Pt(16)
-    _muted(doc, f"Analysis period: {artifacts.analysis_period or 'see assumptions'}")
-    _muted(doc, f"Generated: {artifacts.generated_at}")
-    disc = doc.add_paragraph()
-    run = disc.add_run(
-        "Open-FDD advisory analysis. Findings are telemetry-based; physical verification "
-        "remains a field activity. Detection ≠ finding."
+    _cover(
+        doc,
+        title="FDD Engineering Findings Report",
+        subtitle=artifacts.building,
+        meta_lines=[
+            f"Analysis period: {artifacts.analysis_period or 'see assumptions'}",
+            f"Generated: {artifacts.generated_at}",
+        ],
+        advisory=(
+            "Open-FDD advisory analysis. Findings are telemetry-based; physical verification "
+            "remains a field activity. Detection ≠ finding."
+        ),
     )
-    run.italic = True
-    run.font.size = Pt(10)
     doc.add_page_break()
 
     # Executive summary
-    doc.add_heading("1. Executive summary", level=1)
+    _section_h1(doc, "1. Executive summary")
     m = artifacts.metrics or {}
     doc.add_paragraph(
         f"Detections reviewed: {m.get('n_candidates', '—')}. "
@@ -63,11 +58,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
         doc.add_heading("Priority index", level=2)
         table = doc.add_table(rows=1, cols=4)
         table.style = "Table Grid"
-        hdr = table.rows[0].cells
-        hdr[0].text = "Priority"
-        hdr[1].text = "Finding"
-        hdr[2].text = "Status"
-        hdr[3].text = "First field check"
+        _style_table_header(table, ["Priority", "Finding", "Status", "First field check"])
         for f in included:
             row = table.add_row().cells
             row[0].text = str(f.priority)
@@ -76,7 +67,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
             row[3].text = (f.field_verification or ["—"])[0]
 
     # Building at a glance
-    doc.add_heading("2. Building at a glance", level=1)
+    _section_h1(doc, "2. Building at a glance")
     _add_overview_settings(doc, artifacts)
     doc.add_paragraph(
         "Overview analytics below reuse the same Plotly builders as the live Overview tab "
@@ -88,7 +79,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
     _add_chart_if_any(doc, artifacts, "comfort_ranking")
 
     # Prioritized findings detail
-    doc.add_heading("3. Prioritized engineering findings", level=1)
+    _section_h1(doc, "3. Prioritized engineering findings")
     for f in included:
         doc.add_heading(f"{f.finding_id}: {f.title}", level=2)
         doc.add_paragraph(f"Status: {confidence_badge(f.effective_classification)}")
@@ -122,7 +113,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
             )
 
     # Comfort
-    doc.add_heading("4. Comfort / zone performance", level=1)
+    _section_h1(doc, "4. Comfort / zone performance")
     cs = artifacts.comfort_summary or {}
     doc.add_paragraph(
         f"VAVs: {cs.get('n_vav', '—')}; below threshold: {cs.get('n_below', '—')}. "
@@ -143,7 +134,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
             )
 
     # Systems
-    doc.add_heading("5. AHU / plant / system findings", level=1)
+    _section_h1(doc, "5. AHU / plant / system findings")
     sys_findings = [
         f for f in included if any(s in f.systems for s in ("AHU", "CHW", "HW"))
     ]
@@ -158,7 +149,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
             )
 
     # Data quality
-    doc.add_heading("6. Data quality", level=1)
+    _section_h1(doc, "6. Data quality")
     if not artifacts.data_quality:
         doc.add_paragraph("No major data-quality exclusions beyond suppressed rows.")
     for r in artifacts.data_quality[:15]:
@@ -170,7 +161,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
         )
 
     # Field checklist
-    doc.add_heading("7. Recommended field checklist", level=1)
+    _section_h1(doc, "7. Recommended field checklist")
     for item in artifacts.field_checklist[:12]:
         doc.add_paragraph(f"[ ] {item}", style="List Bullet")
 
@@ -185,13 +176,9 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
     class_by_key = _class_by_candidate_key(artifacts)
     table = doc.add_table(rows=1, cols=6)
     table.style = "Table Grid"
-    hdr = table.rows[0].cells
-    hdr[0].text = "Equipment"
-    hdr[1].text = "Rule ID"
-    hdr[2].text = "Description"
-    hdr[3].text = "Hours"
-    hdr[4].text = "Pct"
-    hdr[5].text = "Class"
+    _style_table_header(
+        table, ["Equipment", "Rule ID", "Description", "Hours", "Pct", "Class"]
+    )
     ranked = sorted(
         artifacts.candidates or [],
         key=lambda c: -(float(c.get("fault_hours") or 0)),
@@ -224,10 +211,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
     if legend:
         ltab = doc.add_table(rows=1, cols=3)
         ltab.style = "Table Grid"
-        lh = ltab.rows[0].cells
-        lh[0].text = "Rule ID"
-        lh[1].text = "Title"
-        lh[2].text = "Summary"
+        _style_table_header(ltab, ["Rule ID", "Title", "Summary"])
         for row_data in legend:
             row = ltab.add_row().cells
             row[0].text = row_data["rule_id"]
@@ -254,11 +238,7 @@ def render_docx(artifacts: ReportArtifacts, path: Path | str) -> Path:
     else:
         ftab = doc.add_table(rows=1, cols=4)
         ftab.style = "Table Grid"
-        fh = ftab.rows[0].cells
-        fh[0].text = "Equipment"
-        fh[1].text = "Rule ID"
-        fh[2].text = "Description"
-        fh[3].text = "Class"
+        _style_table_header(ftab, ["Equipment", "Rule ID", "Description", "Class"])
         for s in fp_only + other_suppressed:
             rid = str(s.get("rule_id") or "")
             desc = ", ".join(rule_label(p.strip()) for p in rid.split(",") if p.strip()) or ""
@@ -290,6 +270,46 @@ def _muted(doc, text: str) -> None:
     run = p.add_run(text)
     run.font.size = Pt(10)
     run.font.color.rgb = RGBColor(0x4A, 0x55, 0x68)
+
+
+def _cover(
+    doc,
+    *,
+    title: str,
+    subtitle: str,
+    meta_lines: list[str],
+    advisory: str,
+) -> None:
+    """Shared WattLab / Open-FDD client cover (centered title, muted meta, italic advisory)."""
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.shared import Pt
+
+    h = doc.add_heading(title, 0)
+    h.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    p = doc.add_paragraph()
+    p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = p.add_run(subtitle or "—")
+    run.bold = True
+    run.font.size = Pt(16)
+    for line in meta_lines:
+        _muted(doc, line)
+    disc = doc.add_paragraph()
+    run = disc.add_run(advisory)
+    run.italic = True
+    run.font.size = Pt(10)
+
+
+def _section_h1(doc, text: str) -> None:
+    doc.add_heading(text, level=1)
+
+
+def _style_table_header(table, headers: list[str]) -> None:
+    hdr = table.rows[0].cells
+    for i, label in enumerate(headers):
+        hdr[i].text = label
+        for paragraph in hdr[i].paragraphs:
+            for run in paragraph.runs:
+                run.bold = True
 
 
 def _class_by_candidate_key(artifacts: ReportArtifacts) -> dict[str, str]:
@@ -388,10 +408,18 @@ def _add_finding_picture(doc, f) -> None:
     elif getattr(f, "chart_path", None) and Path(f.chart_path).is_file():
         path = f.chart_path
     if not path:
+        reason = getattr(f, "day_zoom_skip_reason", None)
+        note = getattr(f, "day_zoom_label", None)
+        if reason or (note and "unavailable" in str(note).lower()):
+            _muted(doc, str(note or f"Day-zoom unavailable: {reason}"))
+        elif reason is None and note is None:
+            _muted(doc, "Day-zoom unavailable: no chart")
         return
     try:
         doc.add_picture(str(path), width=Inches(5.8))
     except Exception:
+        reason = getattr(f, "day_zoom_skip_reason", None) or "render_failed"
+        _muted(doc, f"Day-zoom unavailable: {reason}")
         return
     if caption:
         _muted(doc, str(caption))

--- a/vibe_code_apps_19/app/reporting/models.py
+++ b/vibe_code_apps_19/app/reporting/models.py
@@ -150,6 +150,7 @@ class EngineeringFinding:
     chart_path: str | None = None
     day_zoom_path: str | None = None
     day_zoom_label: str | None = None
+    day_zoom_skip_reason: str | None = None
     candidate_keys: list[str] = field(default_factory=list)
     automated_assessment: dict[str, Any] = field(default_factory=dict)
     engineer_override: dict[str, Any] | None = None

--- a/vibe_code_apps_19/app/reporting/overview_export.py
+++ b/vibe_code_apps_19/app/reporting/overview_export.py
@@ -10,23 +10,27 @@ import pandas as pd
 from app.reporting.models import ReportArtifacts
 
 
+def _ts_label(v: Any, *, date_only: bool = False) -> str | None:
+    if v is None:
+        return None
+    if hasattr(v, "strftime"):
+        try:
+            return v.strftime("%Y-%m-%d") if date_only else v.strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            return str(v)
+    s = str(v).strip()
+    if date_only and len(s) >= 10 and s[4] == "-" and s[7] == "-":
+        return s[:10]
+    return s or None
+
+
 def overview_settings_from_context(ctx: dict[str, Any] | None) -> dict[str, Any]:
     """Lean settings block for DOCX §2 (no frames)."""
     ctx = ctx or {}
 
-    def _ts(v: Any) -> str | None:
-        if v is None:
-            return None
-        if hasattr(v, "strftime"):
-            try:
-                return v.strftime("%Y-%m-%d %H:%M")
-            except Exception:
-                return str(v)
-        return str(v)
-
     return {
-        "dataset_start": _ts(ctx.get("dataset_start")),
-        "dataset_end": _ts(ctx.get("dataset_end")),
+        "dataset_start": _ts_label(ctx.get("dataset_start")),
+        "dataset_end": _ts_label(ctx.get("dataset_end")),
         "span_hours": ctx.get("span_hours"),
         "zone_lo_f": ctx.get("zone_lo_f"),
         "zone_hi_f": ctx.get("zone_hi_f"),
@@ -35,6 +39,24 @@ def overview_settings_from_context(ctx: dict[str, Any] | None) -> dict[str, Any]
         "oat_err": ctx.get("oat_err"),
         "prefer_web_oat": ctx.get("prefer_web_oat"),
     }
+
+
+def format_analysis_period(ctx: dict[str, Any] | None) -> str:
+    """Human cover line from overview / dataset span (BUG-018)."""
+    ctx = ctx or {}
+    start = _ts_label(ctx.get("dataset_start"), date_only=True)
+    end = _ts_label(ctx.get("dataset_end"), date_only=True)
+    span = ctx.get("span_hours")
+    span_s = None
+    if isinstance(span, (int, float)) and span > 0:
+        span_s = f"{span:.0f}" if float(span).is_integer() else f"{float(span):.1f}"
+    if start and end and span_s:
+        return f"{start} → {end} (~{span_s} h)"
+    if start and end:
+        return f"{start} → {end}"
+    if span_s:
+        return f"~{span_s} h window"
+    return ""
 
 
 def build_overview_context(

--- a/vibe_code_apps_19/app/reporting/pipeline.py
+++ b/vibe_code_apps_19/app/reporting/pipeline.py
@@ -41,9 +41,16 @@ def build_engineering_findings(
     """Calculate assessments and prioritized findings (no DOCX yet)."""
     ctx = dict(context or {})
     cands = list(candidates or [])
-    from app.reporting.overview_export import overview_settings_from_context
+    from app.reporting.overview_export import (
+        format_analysis_period,
+        overview_settings_from_context,
+    )
 
     overview_settings = overview_settings_from_context(overview_context)
+    if not analysis_period:
+        analysis_period = format_analysis_period(overview_context) or format_analysis_period(
+            overview_settings
+        )
 
     if checklist is not None:
         loaded, cctx = candidates_from_checklist_json(checklist, building=building or None)

--- a/vibe_code_apps_19/app/reporting/pipeline.py
+++ b/vibe_code_apps_19/app/reporting/pipeline.py
@@ -47,10 +47,6 @@ def build_engineering_findings(
     )
 
     overview_settings = overview_settings_from_context(overview_context)
-    if not analysis_period:
-        analysis_period = format_analysis_period(overview_context) or format_analysis_period(
-            overview_settings
-        )
 
     if checklist is not None:
         loaded, cctx = candidates_from_checklist_json(checklist, building=building or None)
@@ -59,6 +55,11 @@ def build_engineering_findings(
             ctx.setdefault(k, v)
         building = building or cctx.get("building") or building
         analysis_period = analysis_period or cctx.get("analysis_period") or analysis_period
+
+    if not analysis_period:
+        analysis_period = format_analysis_period(overview_context) or format_analysis_period(
+            overview_settings
+        )
 
     if rule_results:
         cands.extend(

--- a/vibe_code_apps_19/app/reporting/quality_gate.py
+++ b/vibe_code_apps_19/app/reporting/quality_gate.py
@@ -14,34 +14,35 @@ CLIENT_OK = {
     Classification.DATA_QUALITY,
 }
 
-# Negations that contain the substring "replace" but are honesty language, not a fix action.
+# Negations / soft-denials that mention replace but are not a fix action.
 _ANTI_REPLACE = re.compile(
-    r"\b(?:do\s+not|don't|dont|never|avoid)\s+replace\b",
+    r"\b(?:do\s+not|don't|dont|never|avoid|no\s+need\s+to|without)\s+"
+    r"(?:\w+\s+){0,3}replac(?:e|ement)\b"
+    r"|\breplac(?:e|ement)\b\s+(?:is\s+)?(?:not|unnecessary|unwarranted)\b",
     re.IGNORECASE,
 )
-# Proactive replace of equipment / instrumentation (weak classes need stronger evidence).
+# Proactive replace / replacement of equipment / instrumentation.
 _PROACTIVE_REPLACE = re.compile(
-    r"\breplace\b.{0,40}\b(?:equipment|sensor|actuator|damper|valve|transmitter|transducer)\b"
-    r"|\b(?:equipment|sensor|actuator|damper|valve|transmitter|transducer)\b.{0,40}\breplace\b",
+    r"\breplac(?:e|ement)\b.{0,48}\b(?:equipment|sensor|actuator|damper|valve|transmitter|transducer)\b"
+    r"|\b(?:equipment|sensor|actuator|damper|valve|transmitter|transducer)\b.{0,48}\breplac(?:e|ement)\b"
+    r"|\breplacement\s+of\b",
     re.IGNORECASE,
 )
 
 
 def _has_proactive_replace(corrective: list[str] | None) -> bool:
-    """True when corrective text recommends replacing hardware (not 'do not replace…')."""
+    """True when corrective text recommends replacing hardware (not honesty language)."""
     for raw in corrective or []:
         text = str(raw or "").strip()
         if not text:
             continue
-        if _ANTI_REPLACE.search(text):
-            # Strip anti-replace clauses; leftover may still recommend replace.
-            text = _ANTI_REPLACE.sub(" ", text)
-        if "replace" not in text.lower():
+        # Drop negated clauses before matching proactive language.
+        cleaned = _ANTI_REPLACE.sub(" ", text)
+        if not re.search(r"replac", cleaned, re.IGNORECASE):
             continue
-        if _PROACTIVE_REPLACE.search(text):
+        if _PROACTIVE_REPLACE.search(cleaned):
             return True
-        # Bare "replace …" without gear noun still counts if not anti-replace only.
-        if re.search(r"\breplace\b", text, re.IGNORECASE):
+        if re.search(r"\breplace\b", cleaned, re.IGNORECASE):
             return True
     return False
 

--- a/vibe_code_apps_19/app/reporting/quality_gate.py
+++ b/vibe_code_apps_19/app/reporting/quality_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from app.reporting.models import Classification, EngineeringFinding, ReportArtifacts
@@ -12,6 +13,37 @@ CLIENT_OK = {
     Classification.INCONCLUSIVE,
     Classification.DATA_QUALITY,
 }
+
+# Negations that contain the substring "replace" but are honesty language, not a fix action.
+_ANTI_REPLACE = re.compile(
+    r"\b(?:do\s+not|don't|dont|never|avoid)\s+replace\b",
+    re.IGNORECASE,
+)
+# Proactive replace of equipment / instrumentation (weak classes need stronger evidence).
+_PROACTIVE_REPLACE = re.compile(
+    r"\breplace\b.{0,40}\b(?:equipment|sensor|actuator|damper|valve|transmitter|transducer)\b"
+    r"|\b(?:equipment|sensor|actuator|damper|valve|transmitter|transducer)\b.{0,40}\breplace\b",
+    re.IGNORECASE,
+)
+
+
+def _has_proactive_replace(corrective: list[str] | None) -> bool:
+    """True when corrective text recommends replacing hardware (not 'do not replace…')."""
+    for raw in corrective or []:
+        text = str(raw or "").strip()
+        if not text:
+            continue
+        if _ANTI_REPLACE.search(text):
+            # Strip anti-replace clauses; leftover may still recommend replace.
+            text = _ANTI_REPLACE.sub(" ", text)
+        if "replace" not in text.lower():
+            continue
+        if _PROACTIVE_REPLACE.search(text):
+            return True
+        # Bare "replace …" without gear noun still counts if not anti-replace only.
+        if re.search(r"\breplace\b", text, re.IGNORECASE):
+            return True
+    return False
 
 
 def run_quality_gate(artifacts: ReportArtifacts) -> dict[str, Any]:
@@ -37,7 +69,7 @@ def run_quality_gate(artifacts: ReportArtifacts) -> dict[str, Any]:
             # dead sensor comfort
             if any("implausible" in (b or "").lower() or "instrumentation" in (b or "").lower() for b in f.evidence_bullets):
                 errors.append(f"{f.finding_id}: dead/impossible sensor described as comfort problem")
-        if "replace" in " ".join(f.possible_corrective).lower() and cls not in {
+        if _has_proactive_replace(f.possible_corrective) and cls not in {
             Classification.STRONGLY_SUPPORTED,
             Classification.PROBABLE,
         }:

--- a/vibe_code_apps_19/docs/superpowers/plans/2026-07-25-eng-findings-hardening-docx-ux.md
+++ b/vibe_code_apps_19/docs/superpowers/plans/2026-07-25-eng-findings-hardening-docx-ux.md
@@ -1,0 +1,148 @@
+# vibe19 Eng Findings Hardening + DOCX UX — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix BUG-016/017/018 and restyle the FDD Engineering Findings DOCX to share cover/section/table/caption language with the vibe20 ECM client package.
+
+**Architecture:** Harden day-zoom + quality gate + analysis_period in `app/reporting/`; restyle `docx.py` helpers to a shared visual token set documented in the design spec; update `vibe19_agent_spec`.
+
+**Tech Stack:** Python, pytest, python-docx, matplotlib (day-zoom), Plotly/Kaleido (overview), Streamlit.
+
+**Design:** [`vibe_code_apps_20/docs/superpowers/specs/2026-07-25-occ-standby-dcv-eng-findings-hardening-design.md`](../../../vibe_code_apps_20/docs/superpowers/specs/2026-07-25-occ-standby-dcv-eng-findings-hardening-design.md) §3–4.
+
+## Global Constraints
+
+- Detection ≠ finding; do not add cookbook rules.
+- Do not merge Generic RCx static DOCX with Engineering Findings.
+- Kaleido/Chromium path already fixed (BUG-011); do not regress.
+- Anti-replace narrative must remain in default corrective text; fix the gate, not by deleting honesty language.
+- Follow existing test patterns in `tests/test_report_*.py`.
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `app/reporting/day_zoom.py` | Skip reasons + metas |
+| `app/reporting/models.py` | `day_zoom_skip_reason` field |
+| `app/reporting/docx.py` | Cover/section helpers + skip note + UX |
+| `app/reporting/quality_gate.py` | Proactive-replace detection |
+| `app/reporting/pipeline.py` / `overview_export.py` | Format + fill `analysis_period` |
+| `streamlit_app.py` | Stop hardcoding `analysis_period=""` |
+| `app/reporting/cli.py` | Same period derivation when context exists |
+| `vibe19_agent_spec/*` | SESSION_LOG, engineering-report skill, PLOTS_DOCX_VALIDATION |
+| `tests/test_report_{day_zoom,docx,quality_gate,overview_export}.py` | Regressions |
+
+---
+
+### Task 1: BUG-017 quality gate anti-replace
+
+**Files:**
+- Modify: `app/reporting/quality_gate.py`
+- Test: `tests/test_report_quality_gate.py`
+
+**Interfaces:**
+- Produces: `run_quality_gate` ignores `do not replace` / `don't replace` / `never replace`; still errors on weak-class proactive replace.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_quality_gate_allows_do_not_replace_on_inconclusive():
+    # finding with possible_corrective containing "Do not replace equipment solely..."
+    # classification INCONCLUSIVE → gate ok
+
+def test_quality_gate_rejects_proactive_replace_on_inconclusive():
+    # possible_corrective = ["Replace the outdoor-air damper actuator"]
+    # → errors mention replace
+```
+
+- [ ] **Step 2: Run tests — expect fail**
+- [ ] **Step 3: Implement proactive-replace helper** (regex or negation phrases + require replace + equipment/sensor/actuator language)
+- [ ] **Step 4: Run tests — expect pass**
+- [ ] **Step 5: Commit** `fix(vibe19): ignore anti-replace wording in Eng Findings quality gate`
+
+---
+
+### Task 2: BUG-018 analysis_period from overview span
+
+**Files:**
+- Modify: `app/reporting/overview_export.py` (add `format_analysis_period`)
+- Modify: `app/reporting/pipeline.py`
+- Modify: `streamlit_app.py` (~2827)
+- Modify: `app/reporting/cli.py` if needed
+- Test: `tests/test_report_overview_export.py`, optionally CLI test
+
+**Interfaces:**
+- Produces: `format_analysis_period(ctx) -> str` like `2024-01-01 → 2024-03-31 (~2160 h)`
+- Consumes: `overview_context` keys `dataset_start`, `dataset_end`, `span_hours`
+
+- [ ] **Step 1: Failing test** for `format_analysis_period` + pipeline fill when caller passes `""`
+- [ ] **Step 2: Implement helper + pipeline fallback**
+- [ ] **Step 3: Streamlit — pass formatted period from `_ov_ctx` or omit and let pipeline fill**
+- [ ] **Step 4: Tests green**
+- [ ] **Step 5: Commit** `fix(vibe19): fill Eng Findings analysis_period from dataset window`
+
+---
+
+### Task 3: BUG-016 day-zoom skip reasons + DOCX note
+
+**Files:**
+- Modify: `app/reporting/models.py`
+- Modify: `app/reporting/day_zoom.py`
+- Modify: `app/reporting/docx.py` (`_add_finding_picture`)
+- Modify: `app/reporting/charts.py` if needed to keep skip metas
+- Test: `tests/test_report_day_zoom.py`, `tests/test_report_docx.py`
+
+**Interfaces:**
+- Produces: `day_zoom_skip_reason` on finding; metas with `skip_reason`; DOCX muted note
+
+- [ ] **Step 1: Failing tests** for `no_result` / `no_fault_day` skip metas and DOCX XML containing `Day-zoom unavailable`
+- [ ] **Step 2: Implement attach_day_zoom skip recording**
+- [ ] **Step 3: DOCX muted note when no picture**
+- [ ] **Step 4: Tests green**
+- [ ] **Step 5: Commit** `fix(vibe19): record day-zoom skip reasons in Eng Findings DOCX`
+
+---
+
+### Task 4: Eng Findings DOCX UX aligned with vibe20 client tokens
+
+**Files:**
+- Modify: `app/reporting/docx.py`
+- Test: `tests/test_report_docx.py`
+
+**Interfaces:**
+- Produces: `_cover`, `_section_h1`, `_style_table_header` (names flexible) matching design §3
+
+- [ ] **Step 1: Snapshot/assert helpers** — cover title centered; muted meta; priority table header bold; advisory italic present
+- [ ] **Step 2: Refactor `render_docx` to use helpers** without changing section inventory
+- [ ] **Step 3: Ensure day-zoom skip note + analysis period still present**
+- [ ] **Step 4: Tests green**
+- [ ] **Step 5: Commit** `feat(vibe19): align Eng Findings DOCX cover/sections with WattLab client style`
+
+---
+
+### Task 5: vibe19_agent_spec
+
+**Files:**
+- Modify: `vibe19_agent_spec/SESSION_LOG.md`
+- Modify: `vibe19_agent_spec/skills/vibe19-engineering-report/SKILL.md`
+- Modify: `vibe19_agent_spec/docs/PLOTS_DOCX_VALIDATION.md`
+
+- [ ] **Step 1: SESSION_LOG top entry** for BUG-016/017/018 + DOCX UX
+- [ ] **Step 2: Skill package map + non-negotiables** (period, gate, skip notes, style tokens)
+- [ ] **Step 3: PLOTS_DOCX_VALIDATION checklist** update
+- [ ] **Step 4: Commit** `docs(vibe19): agent_spec notes for Eng Findings hardening`
+
+---
+
+### Task 6: Verify + PR
+
+- [ ] **Step 1: Run** `pytest tests/test_report_day_zoom.py tests/test_report_docx.py tests/test_report_quality_gate.py tests/test_report_overview_export.py` (and related)
+- [ ] **Step 2: Optional** `scripts/validate_eng_findings_docx_media.py` in Docker if available
+- [ ] **Step 3: Open PR to `develop`; address CodeRabbit**
+- [ ] **Step 4: After merge — GHCR vibe19 refresh + turnkey smoke on `:8502`**
+
+---
+
+## Parallel plan
+
+vibe20 work: [`2026-07-25-occ-standby-dcv-client-docx.md`](../../../vibe_code_apps_20/docs/superpowers/plans/2026-07-25-occ-standby-dcv-client-docx.md) (may start after Task 4 helpers exist so DOCX tokens can be mirrored).

--- a/vibe_code_apps_19/streamlit_app.py
+++ b/vibe_code_apps_19/streamlit_app.py
@@ -2819,12 +2819,20 @@ def main() -> None:
             _ov_ctx = overview_context_from_session()
         except Exception:
             _ov_ctx = None
+        _analysis_period = ""
+        if _ov_ctx:
+            try:
+                from app.reporting.overview_export import format_analysis_period
+
+                _analysis_period = format_analysis_period(_ov_ctx)
+            except Exception:
+                _analysis_period = ""
         render_engineering_findings_panel(
             batch_results=st.session_state.get("batch_results") or [],
             building_name=str(
                 st.session_state.get("building_id") or st.session_state.get("site_id") or ""
             ),
-            analysis_period="",
+            analysis_period=_analysis_period,
             overview_context=_ov_ctx,
             key_prefix="run_rules_eng_findings",
         )

--- a/vibe_code_apps_19/tests/test_report_day_zoom.py
+++ b/vibe_code_apps_19/tests/test_report_day_zoom.py
@@ -127,3 +127,50 @@ def test_docx_embeds_day_zoom_media(tmp_path):
     with zipfile.ZipFile(docx_path) as zf:
         media = [n for n in zf.namelist() if n.startswith("word/media/")]
     assert media, "expected day-zoom PNG in word/media"
+
+
+def test_attach_day_zoom_records_no_result_skip(tmp_path):
+    finding = EngineeringFinding(
+        finding_id="F99",
+        title="No result",
+        classification=Classification.INCONCLUSIVE,
+        priority=1,
+        why_it_matters="x",
+        observed_behavior="y",
+        evidence_bullets=["e"],
+        contradicting_evidence=[],
+        likely_causes=["c"],
+        field_verification=["f"],
+        possible_corrective=["p"],
+        rule_ids=["VAV-5"],
+        equipment_ids=["VAV_99"],
+        systems=["VAV"],
+        candidate_keys=["VAV_99|VAV-5"],
+        include_in_report=True,
+    )
+    metas = attach_day_zoom_to_findings([finding], [], out_dir=tmp_path / "dz")
+    assert finding.day_zoom_skip_reason == "no_result"
+    assert any(m.get("skip_reason") == "no_result" for m in metas)
+    art = ReportArtifacts(
+        building="Test",
+        analysis_period="2026-01-01 → 2026-01-02 (~24 h)",
+        generated_at="2026-01-01T00:00:00Z",
+        findings=[finding],
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={"n_candidates": 1},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={"ok": True},
+    )
+    docx_path = render_docx(art, tmp_path / "skip.docx")
+    import zipfile
+
+    with zipfile.ZipFile(docx_path) as zf:
+        xml = zf.read("word/document.xml").decode("utf-8", errors="replace")
+    assert "Day-zoom unavailable" in xml
+    assert "no_result" in xml
+    assert "2026-01-01 → 2026-01-02" in xml

--- a/vibe_code_apps_19/tests/test_report_overview_export.py
+++ b/vibe_code_apps_19/tests/test_report_overview_export.py
@@ -11,6 +11,7 @@ from app.reporting.models import ReportArtifacts
 from app.reporting.overview_export import (
     build_overview_charts,
     build_overview_context,
+    format_analysis_period,
     overview_settings_from_context,
 )
 
@@ -33,6 +34,32 @@ def test_overview_settings_lean():
     assert settings["bare_min_occ_hours"] == 50
     assert settings["dataset_start"] == "2026-06-01 00:00"
     assert settings["span_hours"] == 720.0
+
+
+def test_format_analysis_period_from_span():
+    ctx = build_overview_context(
+        dataset_start=pd.Timestamp("2026-06-01"),
+        dataset_end=pd.Timestamp("2026-06-30"),
+        span_hours=720.0,
+    )
+    assert format_analysis_period(ctx) == "2026-06-01 → 2026-06-30 (~720 h)"
+
+
+def test_pipeline_fills_analysis_period_from_overview():
+    from app.reporting.pipeline import build_engineering_findings
+
+    art = build_engineering_findings(
+        building="B",
+        analysis_period="",
+        candidates=[],
+        checklist=None,
+        overview_context=build_overview_context(
+            dataset_start=pd.Timestamp("2026-01-01"),
+            dataset_end=pd.Timestamp("2026-01-31"),
+            span_hours=744.0,
+        ),
+    )
+    assert art.analysis_period == "2026-01-01 → 2026-01-31 (~744 h)"
 
 
 def test_overview_export_registers_or_skips(tmp_path):

--- a/vibe_code_apps_19/tests/test_report_quality_gate.py
+++ b/vibe_code_apps_19/tests/test_report_quality_gate.py
@@ -138,3 +138,17 @@ def test_quality_gate_rejects_proactive_replace_on_inconclusive():
     gate = run_quality_gate(_artifacts(f))
     assert gate["ok"] is False
     assert any("replace" in e.lower() for e in gate["errors"])
+
+
+def test_quality_gate_allows_soft_negation_and_flags_replacement_noun():
+    ok_f = _base_finding(
+        possible_corrective=["No need to replace the actuator until field verification"],
+    )
+    assert run_quality_gate(_artifacts(ok_f))["ok"] is True
+
+    bad_f = _base_finding(
+        possible_corrective=["Replacement of the actuator is recommended"],
+    )
+    gate = run_quality_gate(_artifacts(bad_f))
+    assert gate["ok"] is False
+    assert any("replace" in e.lower() for e in gate["errors"])

--- a/vibe_code_apps_19/tests/test_report_quality_gate.py
+++ b/vibe_code_apps_19/tests/test_report_quality_gate.py
@@ -78,3 +78,63 @@ def test_quality_gate_ok_for_supported_with_evidence():
     )
     gate = run_quality_gate(art)
     assert gate["ok"] is True
+
+
+def _base_finding(**kwargs):
+    defaults = dict(
+        finding_id="F01",
+        title="Telemetry review",
+        classification=Classification.INCONCLUSIVE,
+        priority=1,
+        why_it_matters="m",
+        observed_behavior="o",
+        evidence_bullets=["pattern present"],
+        contradicting_evidence=[],
+        likely_causes=["unknown"],
+        field_verification=["verify in field"],
+        possible_corrective=[],
+        rule_ids=["R1"],
+        equipment_ids=["AHU_1"],
+        systems=["AHU"],
+        automated_assessment={"score": 40},
+    )
+    defaults.update(kwargs)
+    return EngineeringFinding(**defaults)
+
+
+def _artifacts(finding: EngineeringFinding) -> ReportArtifacts:
+    return ReportArtifacts(
+        building="B",
+        analysis_period="p",
+        generated_at="t",
+        findings=[finding],
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={},
+    )
+
+
+def test_quality_gate_allows_do_not_replace_on_inconclusive():
+    f = _base_finding(
+        possible_corrective=[
+            "Do not replace equipment solely from this telemetry review — complete field verification first"
+        ],
+    )
+    gate = run_quality_gate(_artifacts(f))
+    assert gate["ok"] is True
+    assert not any("replace" in e.lower() for e in gate["errors"])
+
+
+def test_quality_gate_rejects_proactive_replace_on_inconclusive():
+    f = _base_finding(
+        possible_corrective=["Replace the outdoor-air damper actuator"],
+    )
+    gate = run_quality_gate(_artifacts(f))
+    assert gate["ok"] is False
+    assert any("replace" in e.lower() for e in gate["errors"])

--- a/vibe_code_apps_19/vibe19_agent_spec/SESSION_LOG.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/SESSION_LOG.md
@@ -8,6 +8,17 @@ For onboarding your own site, start with [`TEMPLATE.md`](TEMPLATE.md) and [`docs
 
 ---
 
+## 2026-07-25 — Eng Findings BUG-016/017/018 + DOCX UX
+
+- **BUG-016:** `attach_day_zoom_to_findings` records `skip_reason` (`no_result` / `no_fault_day` / `render_failed`) + `day_zoom_skip_reason`; DOCX muted note when zoom missing.
+- **BUG-017:** Quality gate ignores anti-replace honesty (“Do not replace…”); still rejects proactive replace on weak classes.
+- **BUG-018:** `format_analysis_period` from Overview dataset span; pipeline + Run Rules panel fill cover period.
+- **DOCX UX:** Cover/section/table helpers aligned with vibe20 Energy Modeling client DOCX tokens (`_cover`, `_section_h1`, `_style_table_header`, muted `#4A5568`).
+- Tests: `test_report_quality_gate`, `test_report_day_zoom`, `test_report_overview_export`, `test_report_docx`.
+- Skill / validation: `skills/vibe19-engineering-report`, `docs/PLOTS_DOCX_VALIDATION.md`.
+
+---
+
 ## 2026-07-23 — Engineering Findings Report (detection ≠ finding)
 
 - **Second reporting product** beside static Generic RCx: `app/reporting/` (evidence packets, Passes 1–7 reviewer, ≤7 prioritized findings, quality gate, Kaleido charts, DOCX+JSON).

--- a/vibe_code_apps_19/vibe19_agent_spec/docs/PLOTS_DOCX_VALIDATION.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/docs/PLOTS_DOCX_VALIDATION.md
@@ -58,10 +58,14 @@ Exactly **one** committed static template:
 **Product 2 — Engineering Findings Report (deliberate addition):**
 
 - Generated from active rule FAULTs / checklist JSON via `app/reporting/`
-- Overview: **Generate Engineering Findings Report** button only (never on section visit)
+- Overview / Run Rules: **Generate Engineering Findings Report** button only (never on section visit)
 - Optional extras: `pip install '.[engineering-report]'` (`python-docx`, `kaleido`)
 - Headless: `python -m app.reporting.cli --checklist-json … --out-dir … --docx --json`
 - Contract: detection ≠ finding; raw hits in appendix; ≤7 priority findings
+- Cover **analysis period** from Overview dataset span (`format_analysis_period`)
+- Day-zoom PNG per finding **or** muted `Day-zoom unavailable: <reason>` note
+- Quality gate must not fail on “Do not replace…” honesty language
+- Visual tokens aligned with vibe20 Energy Modeling client DOCX (centered cover, muted meta `#4A5568`, numbered H1, bold table headers)
 - Skill: [`../skills/vibe19-engineering-report/SKILL.md`](../skills/vibe19-engineering-report/SKILL.md)
 
 Do **not** commit generated Engineering Findings DOCX under `assets/reports/`.
@@ -73,4 +77,5 @@ Do **not** commit generated Engineering Findings DOCX under `assets/reports/`.
 - [ ] `app.rule_card:build_rule_card` and `app.docx_report:load_generic_rcx_report` still in `REQUIRED_UI_ENTRYPOINTS`
 - [ ] Plots source contains card catalog (`Filter cards` / rule validation cards)
 - [ ] Overview contains Generic RCx download; FDD/RCx/Export do not serve other DOCX paths
-- [ ] `python -m pytest -q tests/test_rule_card.py tests/test_docx_report.py tests/test_rcx_presets.py`
+- [ ] Eng Findings DOCX: period filled when span exists; day-zoom or skip note; anti-replace gate OK
+- [ ] `python -m pytest -q tests/test_rule_card.py tests/test_docx_report.py tests/test_rcx_presets.py tests/test_report_day_zoom.py tests/test_report_quality_gate.py tests/test_report_docx.py`

--- a/vibe_code_apps_19/vibe19_agent_spec/skills/vibe19-engineering-report/SKILL.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/skills/vibe19-engineering-report/SKILL.md
@@ -29,6 +29,10 @@ Do not invent new FDD rules here. Do not derive compressor runtime from pump sta
 3. **No new cookbook rules** in this package — review existing detections / checklist rows.
 4. **No compressor-from-pump** — respect compressor-proof analytics contract.
 5. Optional extras: `pip install '.[engineering-report]'` (`python-docx`, `kaleido`).
+6. **Analysis period** — from Overview / dataset span (`format_analysis_period`), not a hardcoded empty string.
+7. **Quality gate** — do not flag honesty language (“Do not replace…”); only proactive replace on weak classes.
+8. **Day-zoom** — every included finding gets a PNG or an observable skip reason / muted DOCX note.
+9. **DOCX visual language** — cover / muted meta / numbered H1 / bold table headers match vibe20 Energy Modeling client DOCX tokens (same family, different product).
 
 ## Package map
 
@@ -40,9 +44,11 @@ Do not invent new FDD rules here. Do not derive compressor runtime from pump sta
 | `app/reporting/candidates.py` | RuleResult / checklist JSON → candidates |
 | `app/reporting/findings.py` | Cluster, prioritize, peer/common-mode |
 | `app/reporting/narrative.py` | Finding prose |
-| `app/reporting/quality_gate.py` | Gate before ship |
+| `app/reporting/quality_gate.py` | Gate before ship (anti-replace aware) |
 | `app/reporting/charts.py` | Kaleido chart selection |
-| `app/reporting/docx.py` | Engineering Findings DOCX |
+| `app/reporting/day_zoom.py` | Peak-fault-day PNG + skip reasons |
+| `app/reporting/overview_export.py` | Overview settings/PNGs + `format_analysis_period` |
+| `app/reporting/docx.py` | Engineering Findings DOCX (client cover tokens) |
 | `app/reporting/pipeline.py` | `build_engineering_findings` / `render_engineering_report` |
 | `app/reporting/cli.py` | Headless CLI |
 | `app/report_downloads.py` | Overview panel + HITL include/note |


### PR DESCRIPTION
## Summary
- BUG-016: day-zoom skip reasons + muted DOCX notes when PNG missing
- BUG-017: quality gate ignores anti-replace honesty language
- BUG-018: analysis_period from Overview dataset span
- DOCX UX: cover/section/table tokens aligned with vibe20 Energy Modeling client style
- vibe19_agent_spec SESSION_LOG / engineering-report skill / PLOTS_DOCX_VALIDATION

## Test plan
- [x] `pytest tests/test_report_quality_gate.py tests/test_report_day_zoom.py tests/test_report_overview_export.py tests/test_report_docx.py` (16 passed, 1 skipped)
- [ ] CodeRabbit review
- [ ] After merge: GHCR vibe19 refresh + turnkey `:8502` Eng Findings smoke


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Engineering findings reports now display analysis coverage periods automatically.
  - Reports clearly identify when day-zoom visuals are unavailable and provide the reason.
  - DOCX reports have improved cover pages, section headings, table headers, and muted fallback messaging.

- **Bug Fixes**
  - Quality checks now distinguish proactive “replace” recommendations from “do not replace” guidance.
  - Day-zoom processing continues for remaining findings when one result is unavailable or fails to render.

- **Documentation**
  - Updated reporting guidance, validation requirements, and engineering-report documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->