### PR TITLE
feat(vibe20): Occupied-Standby+DCV, ranking, scenario v2, client DOCX

### DIFF
--- a/vibe_code_apps_20/CONTENTS.md
+++ b/vibe_code_apps_20/CONTENTS.md
@@ -15,7 +15,9 @@
 - `vibe19_bridge.py`
 - `ep_docker.py` / `ep_mcp_client.py` / `results_parse.py`
 - `idf_patches/` (schedules, chiller_lockout, sat_reset, gl36_proxy)
-- `ecm_library/measure_sets.json`
+- `wattlab/measures/catalog.yaml` — canonical ECM catalog
+- `wattlab/measures/measure_sets.py` — progressive measure sets
+- `ecm_library/README.md` — deprecated import shim
 
 ## Examples
 

--- a/vibe_code_apps_20/docs/ECM_CALCULATION_METHODS.md
+++ b/vibe_code_apps_20/docs/ECM_CALCULATION_METHODS.md
@@ -30,3 +30,12 @@ Magic numbers and defaults belong in versioned configuration with unit, source, 
 ## Goldens
 
 `tests/test_esco_golden.py` uses synthetic deterministic fixtures and transparent expected values. Private workbook cell addresses and client schedules are not required.
+
+## Composite ventilation proxy
+
+`ECM-OCC-STANDBY-DCV` is intentionally not a third registered ESCO calculator.
+Studio combines `oad_unoccupied_closed` (full OA closure only during verified
+unoccupied standby) and `dcv_bins` (occupied avoided OA) and records
+`calculators: ["oad_unoccupied_closed", "dcv_bins"]`. This keeps the two
+auditable methods separately golden-tested and prevents a duplicate DCV path.
+`ECM-DCV-CO2` continues to use `dcv_bins` alone.

--- a/vibe_code_apps_20/docs/ECM_EASY_BUTTONS.md
+++ b/vibe_code_apps_20/docs/ECM_EASY_BUTTONS.md
@@ -30,3 +30,15 @@ wattlab ecm audit
 Incompatibilities are checked before stacking contradictory economizer types, overlapping G36 packages, or zero-OA with occupied DCV.
 
 Coverage matrix: [`ecm_coverage_matrix.md`](ecm_coverage_matrix.md).
+
+## Presentation order and agent defaults
+
+Studio presents cards by `implementation_complexity` (`low` → `medium` →
+`high`), then category and ECM id, and labels every card with its complexity.
+This is a presentation order only: `ESCO_TOP15` remains in screening-rank
+order. `ECM-OCC-STANDBY-DCV` is a medium-complexity `esco-top15`,
+`controls-only`, and `no-capital-rcx` candidate adjacent to `ECM-DCV-CO2`.
+
+`reports/ecm_scenario.json` is schema v2. Agents may provide
+`sort_preference`, `package_hints`, `proxy_defaults`, and `roi_param_hints`;
+v1 files with only selections remain loadable.

--- a/vibe_code_apps_20/docs/ECM_INTERACTIONS.md
+++ b/vibe_code_apps_20/docs/ECM_INTERACTIONS.md
@@ -12,7 +12,9 @@ WattLab preserves progressive one-change-at-a-time EnergyPlus accounting and add
 6. G36 packages encompass many component measures — do not stack full package + every component as independent savings.
 7. Pneumatic-to-DDC packages may include scheduling and compressor removal.
 8. `ECM-OCC-STANDBY-DCV` already sums unoccupied OA closure and occupied DCV;
-   do not stack its component estimates as independent savings.
+   do not stack its component estimates as independent savings. It is mutually
+   incompatible with standalone `ECM-DCV-CO2` (Easy Buttons warns; `esco-top15`
+   includes only the composite).
 
 ## Implementation
 

--- a/vibe_code_apps_20/docs/ECM_INTERACTIONS.md
+++ b/vibe_code_apps_20/docs/ECM_INTERACTIONS.md
@@ -11,6 +11,8 @@ WattLab preserves progressive one-change-at-a-time EnergyPlus accounting and add
 5. VAV minimum reduction affects fan, cooling, heating, and ventilation.
 6. G36 packages encompass many component measures — do not stack full package + every component as independent savings.
 7. Pneumatic-to-DDC packages may include scheduling and compressor removal.
+8. `ECM-OCC-STANDBY-DCV` already sums unoccupied OA closure and occupied DCV;
+   do not stack its component estimates as independent savings.
 
 ## Implementation
 
@@ -20,3 +22,7 @@ WattLab preserves progressive one-change-at-a-time EnergyPlus accounting and add
 - Hypothesis Lab proxy crosscheck preserves both EnergyPlus and proxy originals
 
 Reports should show standalone estimates, incremental package savings, and interaction warnings — never force EnergyPlus to match the spreadsheet proxy.
+
+`ECM-OCC-STANDBY-DCV` requires `ECM-SENSOR-CRITICAL-REFRESH`, retains the
+ventilation/IAQ review required by `ECM-DCV-CO2`, and is not an authorization to
+operate with zero OA during occupied periods.

--- a/vibe_code_apps_20/docs/ESCO_SPREADSHEET_CALCS.md
+++ b/vibe_code_apps_20/docs/ESCO_SPREADSHEET_CALCS.md
@@ -95,7 +95,7 @@ Bulk-select package **`esco-top15`** on Studio → ECMs → Easy Buttons.
 | 7 | VAV minimum airflow | `ECM-VAV-MIN-RESET` | `static_pressure_reset` | — |
 | 8 | Economizer repair | `ECM-ECON-REPAIR` | `dewpoint_economizer` | — |
 | 9 | Demand-controlled ventilation | `ECM-DCV-CO2` | `dcv_bins` | — |
-| 9a | Occupied standby + DCV | `ECM-OCC-STANDBY-DCV` | `oad_unoccupied_closed` + `dcv_bins` | — |
+| 9 | Occupied standby + DCV | `ECM-OCC-STANDBY-DCV` | `oad_unoccupied_closed` + `dcv_bins` | — |
 | 10 | Hot-water reset | `ECM-BOILER-RESET` | `hydronic_reset_bins` | — |
 | 11 | CHW / CW plant optimization | `ECM-CHW-RESET`, `ECM-CW-RESET`, `ECM-CHILLER-LOCKOUT` | hydronic / economizer | lockout on chiller |
 | 12 | Boiler combustion tune | `ECM-BOILER-TUNE` | `boiler_efficiency_improvement` | — |

--- a/vibe_code_apps_20/docs/ESCO_SPREADSHEET_CALCS.md
+++ b/vibe_code_apps_20/docs/ESCO_SPREADSHEET_CALCS.md
@@ -95,6 +95,7 @@ Bulk-select package **`esco-top15`** on Studio → ECMs → Easy Buttons.
 | 7 | VAV minimum airflow | `ECM-VAV-MIN-RESET` | `static_pressure_reset` | — |
 | 8 | Economizer repair | `ECM-ECON-REPAIR` | `dewpoint_economizer` | — |
 | 9 | Demand-controlled ventilation | `ECM-DCV-CO2` | `dcv_bins` | — |
+| 9a | Occupied standby + DCV | `ECM-OCC-STANDBY-DCV` | `oad_unoccupied_closed` + `dcv_bins` | — |
 | 10 | Hot-water reset | `ECM-BOILER-RESET` | `hydronic_reset_bins` | — |
 | 11 | CHW / CW plant optimization | `ECM-CHW-RESET`, `ECM-CW-RESET`, `ECM-CHILLER-LOCKOUT` | hydronic / economizer | lockout on chiller |
 | 12 | Boiler combustion tune | `ECM-BOILER-TUNE` | `boiler_efficiency_improvement` | — |
@@ -115,6 +116,12 @@ Code: `algorithms.fan_affinity`, `algorithms.pump_vfd`, `esco.static_pressure_re
 ### Scheduling
 Removed operating hours × fan kW + OA vent cooling/heating loads.  
 Code: `esco.scheduling_fan_bins`, `scheduling_cooling_bins`, `scheduling_heating_bins`.
+
+### Occupied standby + DCV
+`ECM-OCC-STANDBY-DCV` is a Studio-composed proxy: `oad_unoccupied_closed`
+captures full OA closure during verified standby periods, while `dcv_bins`
+captures occupied airflow reduction. Its result stamps both calculator names;
+do not add either component again as independent savings.
 
 ### Boiler efficiency (ECM-12 / ECM-14)
 Delivered load MMBtu; input therms = `MMBtu × 10 / η`.  

--- a/vibe_code_apps_20/docs/README.md
+++ b/vibe_code_apps_20/docs/README.md
@@ -3,8 +3,14 @@
 | Doc | Audience |
 | --- | --- |
 | [ESCO_SPREADSHEET_CALCS.md](ESCO_SPREADSHEET_CALCS.md) | Engineers — human-readable ESCO formulas, Top-15 map, py paths, ROI $/ft² |
+| [ECM_EASY_BUTTONS.md](ECM_EASY_BUTTONS.md) | Studio users — complexity-ranked cards, packages, and agent scenario v2 |
+| [ECM_CALCULATION_METHODS.md](ECM_CALCULATION_METHODS.md) | Engineers — bin-method and composite proxy provenance |
 | [`../AGENTS.md`](../AGENTS.md) | Agents — WattLab OS |
 | [`../vibe20_agent_spec/docs/ESCO_CALCULATORS.md`](../vibe20_agent_spec/docs/ESCO_CALCULATORS.md) | Calculator contract + golden anchors |
 | [`../vibe20_agent_spec/docs/ESCO_RETROFIT_COST_ROI.md`](../vibe20_agent_spec/docs/ESCO_RETROFIT_COST_ROI.md) | Public retrofit cost bands |
 
 **Online:** [ESCO_SPREADSHEET_CALCS.md on GitHub](https://github.com/bbartling/py-bacnet-stacks-playground/blob/develop/vibe_code_apps_20/docs/ESCO_SPREADSHEET_CALCS.md)
+
+Client packages can optionally include
+`01_Report/Energy_Modeling_Report.docx`, a 14-section screening report distinct
+from the controls-checklist DOCX.

--- a/vibe_code_apps_20/docs/ecm_coverage_matrix.md
+++ b/vibe_code_apps_20/docs/ecm_coverage_matrix.md
@@ -1,6 +1,6 @@
 # ECM Coverage Matrix
 
-The canonical registry contains 37 fail-closed ECM definitions. Catalog status
+The canonical registry contains 38 fail-closed ECM definitions. Catalog status
 describes implementation maturity, not guaranteed savings. Every candidate
 still requires applicability review, evidence, and incremental interaction
 testing.
@@ -10,7 +10,7 @@ testing.
 | Category | ECMs | Current coverage |
 | --- | ---: | --- |
 | Scheduling | 3 | Schedule alignment has proxy and EnergyPlus support; optimum start and holidays have proxies. |
-| OA / ventilation | 5 | Damper and economizer proxies are usable; DCV, OA reset, and ERV need further engineering. |
+| OA / ventilation | 6 | Damper and economizer proxies are usable; DCV, OCC-STANDBY-DCV, OA reset, and ERV need further engineering. |
 | Airside / VAV | 4 | SAT, fan/VFD, and duct-pressure proxy paths are usable; VAV reset remains research. |
 | Guideline 36 | 3 | The airside entry is explicitly a partial conceptual proxy; full sequence and plant logic are not implemented. |
 | Pneumatic to DDC | 2 | Pneumatic leakage has a proxy; full conversion needs controls design and point inventory. |
@@ -42,6 +42,10 @@ Production proxy-only entries cover optimum start/stop, holidays, OA damper
 repair, economizer repair, duct static reset, pneumatic leak repair, boiler
 reset, chilled- and condenser-water reset, and pump VFD control.
 
+- `ECM-OCC-STANDBY-DCV`: medium-complexity OA measure; combines
+  `oad_unoccupied_closed` and `dcv_bins` in Studio with calculator provenance;
+  no EnergyPlus patch is registered.
+
 ## Package coverage
 
 Named packages are `pneumatic-to-ddc`, `partial-g36`,
@@ -50,3 +54,5 @@ Named packages are `pneumatic-to-ddc`, `partial-g36`,
 dependencies, preserves order, removes duplicates, and rejects unknown ECMs.
 The interaction checker reports incompatible alternatives and reminds callers
 not to sum interacting independent savings estimates.
+`ECM-OCC-STANDBY-DCV` is in `esco-top15`, `controls-only`, and
+`no-capital-rcx`; its sensor-refresh dependency is resolved automatically.

--- a/vibe_code_apps_20/docs/superpowers/plans/2026-07-25-occ-standby-dcv-client-docx.md
+++ b/vibe_code_apps_20/docs/superpowers/plans/2026-07-25-occ-standby-dcv-client-docx.md
@@ -1,0 +1,173 @@
+# Occupied-Standby+DCV, Complexity Rank, Agent Defaults, Client DOCX — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `ECM-OCC-STANDBY-DCV`, rank Studio ECMs easy→hard, enrich `ecm_scenario` defaults, surface ESCO math, ship selectable client DOCX styled like vibe19 Eng Findings, and update `ecm_library` / `docs` / `vibe20_agent_spec`.
+
+**Architecture:** Canonical measure in `catalog.yaml`; Studio proxies compose `oad_unoccupied_closed` + `dcv_bins`; Easy Buttons sort by `implementation_complexity`; `deliverables_docx` mirrors executive MD into python-docx; docs/agent_spec stay in lockstep.
+
+**Tech Stack:** Python, YAML catalog, Streamlit Studio, ESCO bin calcs, python-docx, pytest.
+
+**Design:** [`../specs/2026-07-25-occ-standby-dcv-eng-findings-hardening-design.md`](../specs/2026-07-25-occ-standby-dcv-eng-findings-hardening-design.md) §3, §5–6.
+
+**Depends on (soft):** vibe19 plan Task 4 DOCX tokens for visual parity — [`vibe_code_apps_19/.../2026-07-25-eng-findings-hardening-docx-ux.md`](../../../vibe_code_apps_19/docs/superpowers/plans/2026-07-25-eng-findings-hardening-docx-ux.md).
+
+## Global Constraints
+
+- No parallel ECM registry — `wattlab/measures/catalog.yaml` only; `ecm_library` remains a shim.
+- Do not conflate client Energy Modeling DOCX with `controls_checklist` DOCX.
+- Honesty stamps / G14 / area scale remain mandatory in packages.
+- `ESCO_TOP15` screening order semantics stay; UI presentation sorts by complexity separately.
+- Real `ECM-*` ids in all agent examples.
+- YAGNI: no EnergyPlus patch until a real IDF exists (`PRODUCTION_PROXY_ONLY`).
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `wattlab/measures/catalog.yaml` | New measure |
+| `wattlab/ecm/packages.py` | Package membership / esco-top15 slot |
+| `wattlab/studio/proxies.py` | Composite proxy dispatch |
+| `wattlab/studio/ecm_roi.py` | ROI seed |
+| `wattlab/studio/pages/ecm_easy_buttons.py` | Complexity sort + caption |
+| `wattlab/studio/ecm_scenario.py` + template | Schema v2 |
+| `wattlab/deliverables.py` | `include_docx` flag |
+| `wattlab/deliverables_docx.py` (new) | Client DOCX renderer |
+| `wattlab/studio/pages/ecms.py` / twin package UI | Checkbox |
+| `ecm_library/README.md` | Shim documentation |
+| `docs/*` | ESCO, Easy Buttons, coverage, methods, interactions, README |
+| `vibe20_agent_spec/*` | Tools, ESCO, deliverables, container, skills |
+| `tests/test_ecm_*.py`, `test_deliverables*.py`, `test_esco_golden.py` | Coverage |
+
+---
+
+### Task 1: Catalog measure `ECM-OCC-STANDBY-DCV`
+
+**Files:**
+- Modify: `wattlab/measures/catalog.yaml`
+- Modify: `wattlab/ecm/packages.py` (membership)
+- Test: `tests/test_ecm_catalog.py`
+
+**Interfaces:**
+- Produces: `get_ecm("ECM-OCC-STANDBY-DCV")` with complexity `medium`, category `oa_ventilation`, `PRODUCTION_PROXY_ONLY`
+- Package: insert in `ESCO_TOP15` adjacent to `ECM-DCV-CO2`; add to applicable packages
+
+- [ ] **Step 1: Failing test** — catalog contains id; `resolve_package("esco-top15")` includes it; deps resolve
+- [ ] **Step 2: Add YAML entry** (deps/incompat aligned with `ECM-DCV-CO2` / existing OA rules)
+- [ ] **Step 3: Update `PACKAGES` / `ESCO_TOP15`**
+- [ ] **Step 4: Tests green**
+- [ ] **Step 5: Commit** `feat(vibe20): add ECM-OCC-STANDBY-DCV to catalog and packages`
+
+---
+
+### Task 2: Proxy composite + ROI seed
+
+**Files:**
+- Modify: `wattlab/studio/proxies.py`
+- Modify: `wattlab/studio/ecm_roi.py`
+- Test: new or extend `tests/test_ecm_roi.py` + proxy unit test (create `tests/test_studio_proxies_occ_standby.py` if none)
+
+**Interfaces:**
+- Consumes: `oad_unoccupied_closed`, `dcv_bins` from `wattlab.bench.esco`
+- Produces: proxy dict with summed savings + `calculators: ["oad_unoccupied_closed", "dcv_bins"]` provenance
+- `ECM-DCV-CO2` path unchanged (dcv only)
+
+- [ ] **Step 1: Failing tests** for composite vs DCV-only
+- [ ] **Step 2: Dispatch in `estimate_proxy_savings`**
+- [ ] **Step 3: ROI default $/ft² for new id**
+- [ ] **Step 4: Tests green**
+- [ ] **Step 5: Commit** `feat(vibe20): wire OCC-STANDBY-DCV proxy to OAD-unocc + DCV bins`
+
+---
+
+### Task 3: Easy Buttons complexity sort
+
+**Files:**
+- Modify: `wattlab/studio/pages/ecm_easy_buttons.py`
+- Optional helper: `wattlab/ecm/ranking.py` with `complexity_sort_key`
+- Test: unit test for sort key / ordered ids
+
+**Interfaces:**
+- Produces: UI order low→medium→high; caption shows complexity
+- Does not mutate `ESCO_TOP15` tuple meaning
+
+- [ ] **Step 1: Failing test** for sort order across mixed complexities
+- [ ] **Step 2: Implement sort + caption**
+- [ ] **Step 3: Tests green**
+- [ ] **Step 4: Commit** `feat(vibe20): rank ECM Easy Buttons by implementation complexity`
+
+---
+
+### Task 4: Agent scenario schema v2
+
+**Files:**
+- Modify: `wattlab/studio/ecm_scenario.py`
+- Modify: `wattlab/studio/templates/ecm_scenario.template.json`
+- Test: `tests/test_live_08_status_fixes.py`, `tests/test_studio_status_deliverables.py`
+
+**Interfaces:**
+- Produces: v2 fields (`sort_preference`, `package_hints`, `proxy_defaults`, `roi_param_hints`) with backward-compatible load of v1 files
+
+- [ ] **Step 1: Failing tests** — load v1 file still works; save v2 round-trips new keys
+- [ ] **Step 2: Implement empty/load/save**
+- [ ] **Step 3: Easy Buttons honor `sort_preference` when present**
+- [ ] **Step 4: Tests green**
+- [ ] **Step 5: Commit** `feat(vibe20): enrich ecm_scenario.json agent defaults (v2)`
+
+---
+
+### Task 5: Client DOCX deliverable (vibe20 ECM / energy package)
+
+**Files:**
+- Create: `wattlab/deliverables_docx.py`
+- Modify: `wattlab/deliverables.py` (`package_deliverables(..., include_docx: bool = False)`)
+- Modify: `wattlab/studio/pages/ecms.py` (+ twin package UI if separate)
+- Test: `tests/test_studio_status_deliverables.py` / `tests/test_deliverables_campaign.py`
+
+**Interfaces:**
+- Produces: `01_Report/Energy_Modeling_Report.docx` using design §3 tokens (mirror vibe19 helpers)
+- Consumes: same inputs as `build_executive_markdown` (scorecard, report, profile, savings)
+- Separate from `controls_checklist.render_docx`
+
+- [ ] **Step 1: Failing test** — `include_docx=True` writes DOCX; zip contains it; `include_docx=False` omits
+- [ ] **Step 2: Implement `render_energy_modeling_docx`** — 14 sections, muted meta, styled tables, honesty italic
+- [ ] **Step 3: Wire `package_deliverables` + Studio checkbox “Include client DOCX”**
+- [ ] **Step 4: Soft-skip with caption if python-docx missing**
+- [ ] **Step 5: Tests green**
+- [ ] **Step 6: Commit** `feat(vibe20): selectable client Energy Modeling DOCX in deliverables`
+
+---
+
+### Task 6: Docs + ecm_library + vibe20_agent_spec
+
+**Files:**
+- Create: `ecm_library/README.md`
+- Modify: `CONTENTS.md` (stale measure_sets path) if present at app root
+- Modify: `docs/README.md`, `docs/ESCO_SPREADSHEET_CALCS.md`, `docs/ECM_EASY_BUTTONS.md`, `docs/ecm_coverage_matrix.md`, `docs/ECM_CALCULATION_METHODS.md`, `docs/ECM_INTERACTIONS.md`
+- Modify: `vibe20_agent_spec/docs/AGENT_TOOLS.md`, `ESCO_CALCULATORS.md`, `CALIBRATE_AND_DELIVERABLES.md`, `AGENT_DOCKER_WORKSPACE.md`
+- Modify: `vibe20_agent_spec/CONTAINER_AGENT.md`, `AGENTS.md` as needed
+- Modify: skills `wattlab-studio`, `wattlab-esco-bins`, `wattlab-assumptions`
+
+- [ ] **Step 1: ecm_library README** — shim only; point to catalog + `ECM-OCC-STANDBY-DCV`
+- [ ] **Step 2: ESCO + Easy Buttons + coverage + methods + interactions**
+- [ ] **Step 3: Agent spec + skills** — scenario v2, DOCX path, real ECM ids, composite calc
+- [ ] **Step 4: Commit** `docs(vibe20): OCC-STANDBY-DCV, complexity rank, client DOCX, agent defaults`
+
+---
+
+### Task 7: Verify + PR + ops
+
+- [ ] **Step 1: Run** catalog, proxy, ROI, deliverables, esco golden, scenario tests
+- [ ] **Step 2: PR to `develop`; address CodeRabbit**
+- [ ] **Step 3: Tidy merged remote branches** listed in design §6 (after confirming merged)
+- [ ] **Step 4: GHCR vibe20 refresh when path-filter fires; turnkey `:8520` smoke** — new ECM visible, complexity order, DOCX in package when checked
+
+---
+
+## Cross-cutting checklist (do not skip)
+
+- [ ] Design open item: confirm `esco-top15` slot next to DCV
+- [ ] Design open item: Studio-sum vs registered composite calculator (prefer Studio sum + provenance unless golden registry needs a name)
+- [ ] Design open item: DOCX checkbox default **on** when python-docx present
+- [ ] Visual parity spot-check: open vibe19 Eng Findings DOCX and vibe20 Energy Modeling DOCX side-by-side (cover, muted meta, H1 numbering, table headers)
+- [ ] No stale agent example ids remain in `AGENT_DOCKER_WORKSPACE.md` / `CONTAINER_AGENT.md`

--- a/vibe_code_apps_20/docs/superpowers/specs/2026-07-25-occ-standby-dcv-eng-findings-hardening-design.md
+++ b/vibe_code_apps_20/docs/superpowers/specs/2026-07-25-occ-standby-dcv-eng-findings-hardening-design.md
@@ -1,0 +1,292 @@
+# Occupied-Standby+DCV, Client DOCX UX, and Eng Findings Hardening — Design
+
+**Date:** 2026-07-25  
+**Status:** Approved — implementing  
+**Apps:** vibe19 (FDD Engineering Findings) + vibe20 (WattLab Studio ECMs)  
+**Approved product choice:** New catalog measure `ECM-OCC-STANDBY-DCV` (keep `ECM-DCV-CO2`)
+
+---
+
+## 1. Goal
+
+Ship one coherent client-facing ECM + FDD deliverable story:
+
+1. **vibe20** — Add Occupied-Standby + Demand-Controlled Ventilation as a first-class ECM; rank Easy Buttons easy→hard; richer AI scenario defaults; surface ESCO spreadsheet math in UI + package; add a **selectable client DOCX** beside MD/XLSX/ZIP.
+2. **vibe19** — Fix Eng Findings BUG-016/017/018; restyle the FDD Engineering Findings DOCX so its cover, section rhythm, tables, and muted captions feel like the vibe20 ECM client DOCX (same family, different product).
+3. **Docs / specs** — Update `ecm_library`, `docs`, `vibe20_agent_spec`, and `vibe19_agent_spec` so agents and humans share one source of truth.
+4. **Ship** — Unit tests, green GH Actions, CodeRabbit on PR, tidy stale branches, merge `develop`, refresh GHCR turnkey images.
+
+---
+
+## 2. Non-goals
+
+- No parallel ECM registry (`catalog.yaml` remains canonical; `ecm_library` stays a shim).
+- Do not invent new vibe19 FDD cookbook rules for this effort.
+- Do not merge Generic RCx static DOCX with Engineering Findings.
+- Do not conflate controls-checklist DOCX with the new WattLab **energy/ECM client DOCX**.
+- No PE-signed report claims; honesty stamps stay mandatory on vibe20 packages.
+- No force-push / destructive git ops; no committing secrets.
+
+---
+
+## 3. Shared client DOCX visual language
+
+Both products keep distinct titles and content, but share presentation tokens so a client reading an FDD findings pack and an ECM energy pack recognizes the same OpenFDD / WattLab family.
+
+| Token | Spec |
+| --- | --- |
+| Cover title | Centered Heading 0; product-specific string |
+| Subtitle / site | Centered bold ~16 pt building or project name |
+| Meta line | Muted gray (~`#4A5568`) 10 pt: period · generated timestamp |
+| Advisory callout | Italic 10 pt disclaimer paragraph under meta (not a floating badge) |
+| Section rhythm | Numbered `N. Title` Heading 1; optional Heading 2 for indexes / measure cards |
+| Tables | `Table Grid`; header row bold; compact body; no card chrome |
+| Captions | Same muted helper as meta for chart / day-zoom / skip notes |
+| Page breaks | Cover → body; optional break before appendices |
+| Brand voice | “Open-FDD advisory…” (vibe19) / “WattLab screening — not CD/TAB…” (vibe20) |
+
+**Implementation approach:** Prefer a small shared styling helper *per app* (not a cross-repo package):
+
+- vibe19: extend `app/reporting/docx.py` helpers (`_muted`, add `_cover`, `_section_h1`, `_style_table_header`).
+- vibe20: new `wattlab/deliverables_docx.py` (or `wattlab/reporting/client_docx.py`) that mirrors those helpers and maps the existing 14-section executive markdown outline into DOCX.
+
+Optional later: extract a tiny shared module only if duplication becomes painful — out of scope unless both land in the same PR and copy-paste exceeds ~80 lines of identical helpers.
+
+**UI parity (Studio / Streamlit):**
+
+- vibe19 Eng Findings panel already has generate + downloads; keep checkbox semantics for optional media.
+- vibe20 ECMs / Twin “Build client package” gains **Include client DOCX** checkbox (default on when `python-docx` available; soft-skip + caption if missing).
+- Both download rows show DOCX beside MD/XLSX/ZIP where applicable.
+
+---
+
+## 4. vibe19 — Engineering Findings hardening
+
+### 4.1 BUG-016 — Day-zoom skip reasons
+
+**Today:** `attach_day_zoom_to_findings` silently `continue`s; DOCX `_add_finding_picture` returns with no note.
+
+**Target:**
+
+- Return / record skip metas with `skip_reason ∈ {excluded, no_result, no_fault_day, render_failed}`.
+- Set `EngineeringFinding.day_zoom_skip_reason` (and optional `day_zoom_label` note) when PNG missing.
+- DOCX: if no day-zoom/chart PNG, emit muted line: `Day-zoom unavailable: <reason>`.
+- Charts JSON audit list includes skip metas (not only successes).
+
+### 4.2 BUG-017 — Quality gate anti-replace false positive
+
+**Today:** substring `"replace"` flags default corrective *“Do not replace equipment solely…”*.
+
+**Target:** Gate only proactive replace recommendations (e.g. recommend replacing equipment/sensor) on weak classifications. Phrases matching `do not replace` / `don't replace` / `never replace` are ignored. Keep rejecting weak-class *“replace the … sensor/equipment”* without STRONGLY/PROBABLE.
+
+Optionally leave `_corrective` wording unchanged (gate fix is sufficient).
+
+### 4.3 BUG-018 — Analysis period from dataset window
+
+**Today:** `streamlit_app.py` passes `analysis_period=""`; cover shows “see assumptions” while Overview settings already have start/end/span.
+
+**Target:** Derive `YYYY-MM-DD → YYYY-MM-DD (~N h)` from `overview_context` / `dataset_start`+`dataset_end`+`span_hours` inside `build_engineering_findings` (and CLI when context exists). Stop hardcoding empty string in Streamlit (pass through or omit).
+
+### 4.4 Eng Findings DOCX UX (new — user request)
+
+Restyle `app/reporting/docx.py` to match §3 tokens and vibe20 ECM client DOCX structure:
+
+| Section | Behavior |
+| --- | --- |
+| Cover | Shared cover helper; real analysis period; advisory italic |
+| 1. Executive summary | Metrics paragraph + **Priority index** table with styled header |
+| 2. Building at a glance | Overview settings + Kaleido overview PNGs + summary charts |
+| 3. Prioritized findings | Finding cards as H2; status badge line; evidence bullets; day-zoom or skip note |
+| 4–7 + Appendices | Keep content; apply same table header + muted caption helpers |
+
+Do **not** change detection≠finding semantics, clustering ≤7, or Passes 1–7.
+
+### 4.5 vibe19_agent_spec updates
+
+| File | Update |
+| --- | --- |
+| `SESSION_LOG.md` | Top entry: BUG-016/017/018 + DOCX UX alignment with vibe20 client package |
+| `skills/vibe19-engineering-report/SKILL.md` | Package map (`day_zoom`, `overview_export`); gate anti-replace rule; period from span; shared DOCX visual language |
+| `docs/PLOTS_DOCX_VALIDATION.md` | Day-zoom + skip note; cover period; style checklist vs vibe20 ECM DOCX |
+| Optional | `docs/DASHBOARD_CONTRACT.md` one-liner if Overview→report period contract needs it |
+
+### 4.6 vibe19 tests
+
+- `test_report_day_zoom.py` — skip reasons
+- `test_report_docx.py` — skip muted note; styled cover period; priority table present
+- `test_report_quality_gate.py` — anti-replace OK; proactive replace fails on INCONCLUSIVE
+- `test_report_overview_export.py` / CLI overview tests — period derivation
+- Keep `validate_eng_findings_docx_media.py` green (media ≥2 when Kaleido/matplotlib available)
+
+---
+
+## 5. vibe20 — Occupied-Standby + DCV and client package
+
+### 5.1 New measure `ECM-OCC-STANDBY-DCV`
+
+**Catalog** (`wattlab/measures/catalog.yaml`):
+
+| Field | Value |
+| --- | --- |
+| `ecm_id` | `ECM-OCC-STANDBY-DCV` |
+| `display_name` | Occupied-standby + demand-controlled ventilation |
+| `category` | `oa_ventilation` |
+| `implementation_complexity` | `medium` (standby scheduling low; DCV medium → composite medium) |
+| `proxy_calculator` | Prefer a named composite or document dual dispatch in Studio proxies |
+| `dependencies` | Include sensor / schedule prerequisites as appropriate (align with `ECM-DCV-CO2`) |
+| `iaq_risk` | `high` |
+| `status` | `PRODUCTION_PROXY_ONLY` initially |
+| `energyplus_patch` | `null` until a real IDF patch exists |
+
+**Proxy wiring** (`wattlab/studio/proxies.py`):
+
+- Match `OCC-STANDBY` / `OCC_STANDBY` / id contains both standby+DCV intent.
+- Combine existing ESCO calculators: `oad_unoccupied_closed` + `dcv_bins` (sum electric/thermal with clear provenance in result dict).
+- Keep `ECM-DCV-CO2` → `dcv_bins` only.
+- Wire ROI seed in `ecm_roi.py` (`DEFAULT_ECM_ROI_MODELS`) with a documented $/ft² band.
+
+**Packages:**
+
+- Add to `esco-top15` near other OA/ventilation measures (after DCV or as adjacent rank — document exact slot in coverage matrix).
+- Consider `low-cost` / `controls-only` / `no-capital-rcx` membership where engineering-appropriate.
+- Incompatibilities: respect existing zero-OA vs occupied DCV rules; document in `ECM_INTERACTIONS.md`.
+
+### 5.2 Rank Easy Buttons easy → hard
+
+- Sort catalog cards by `implementation_complexity` rank (`low`→`medium`→`high`), then category, then `ecm_id`.
+- Show complexity caption on each card (e.g. “Complexity: medium”).
+- Do **not** reorder `ESCO_TOP15` screening rank semantics; that tuple remains ESCO screening order. UI default presentation uses complexity; package order still follows `resolve_package`.
+
+### 5.3 Richer AI agent defaults (`ecm_scenario.json`)
+
+Extend schema **compatibly** (version bump to `2` if needed; v1 loaders still accept missing keys):
+
+```json
+{
+  "version": 2,
+  "selected_ecm_ids": ["ECM-AHU-SCHED-ALIGN", "ECM-OCC-STANDBY-DCV", "..."],
+  "measure_set": null,
+  "sort_preference": "implementation_complexity",
+  "package_hints": ["esco-top15"],
+  "proxy_defaults": {},
+  "roi_param_hints": {},
+  "notes": "",
+  "recommendations": [],
+  "status": "..."
+}
+```
+
+- Agent tools / `CONTAINER_AGENT.md` / `AGENT_DOCKER_WORKSPACE.md` examples use **real** `ECM-*` ids (fix stale `fan_schedule_optimization` examples).
+- Studio `_ensure_checkbox_defaults` still seeds checkboxes from `selected_ecm_ids`; optionally honor `sort_preference`.
+
+### 5.4 ESCO spreadsheet calcs in UI + report
+
+- Keep human doc `docs/ESCO_SPREADSHEET_CALCS.md` as formula map; add Occupied-Standby+DCV row (OAD unocc closed + DCV bins).
+- Studio ECMs page: ensure crosscheck / proxy columns expose calculator names for the new measure.
+- Client MD **and** DOCX section 9 (ECMs) list measure id, proxy calculator provenance, kWh/therms when present.
+- Agent spec `ESCO_CALCULATORS.md` + skill `wattlab-esco-bins` mention composite measure.
+
+### 5.5 Selectable client DOCX deliverable
+
+- New renderer maps `build_executive_markdown` 14-section outline → DOCX using §3 visual language.
+- `package_deliverables(..., include_docx: bool = False)` writes `01_Report/Energy_Modeling_Report.docx` when requested.
+- Studio checkbox on ECMs + Twin calibrate package builders.
+- CLI flag if a package CLI exists; otherwise document Studio-only first.
+- **Separate** from `controls_checklist.render_docx`.
+
+### 5.6 `ecm_library`
+
+- Keep shim to `wattlab.measures`.
+- Add `ecm_library/README.md` stating deprecation + pointer to `catalog.yaml` and Occupied-Standby+DCV id.
+- Fix stale `CONTENTS.md` references to `ecm_library/measure_sets.json`.
+
+### 5.7 vibe20 `docs/` updates
+
+| Doc | Update |
+| --- | --- |
+| `README.md` | Link new measure + client DOCX |
+| `ESCO_SPREADSHEET_CALCS.md` | OCC-STANDBY-DCV formulas + paths |
+| `ECM_EASY_BUTTONS.md` | Complexity sort; full package list incl. `esco-top15`; new measure |
+| `ecm_coverage_matrix.md` | New row + package membership |
+| `ECM_CALCULATION_METHODS.md` | Composite proxy |
+| `ECM_INTERACTIONS.md` | Incompat / stacking notes |
+| This design + plan under `docs/superpowers/` | As written |
+
+### 5.8 `vibe20_agent_spec` updates
+
+| File | Update |
+| --- | --- |
+| `docs/AGENT_TOOLS.md` | Scenario v2 fields; package DOCX |
+| `docs/ESCO_CALCULATORS.md` | Composite calculators |
+| `docs/CALIBRATE_AND_DELIVERABLES.md` | Client DOCX checkbox + path |
+| `docs/AGENT_DOCKER_WORKSPACE.md` | Real ECM ids in examples |
+| `CONTAINER_AGENT.md` | Scenario write + DOCX deliverable |
+| `AGENTS.md` | Pointers if needed |
+| Skills: `wattlab-studio`, `wattlab-esco-bins`, `wattlab-assumptions` | Ranking, defaults, DOCX, new ECM |
+| Add / append SESSION-style note if the tree has a session log; else CONTAINER_AGENT changelog section |
+
+### 5.9 vibe20 tests
+
+- Catalog: new id loads; package resolve; incompat
+- Proxies: OCC-STANDBY-DCV combines oad + dcv; DCV alone unchanged
+- Easy Buttons sort helper unit test
+- `ecm_scenario` v2 load/save backward compatible
+- Deliverables: `include_docx=True` produces DOCX bytes; checkbox path doesn’t break ZIP
+- Golden ESCO: existing `oad_unoccupied_closed` / `dcv_bins` remain; optional composite golden
+
+---
+
+## 6. Ship / ops (both apps)
+
+| Step | Detail |
+| --- | --- |
+| Branches | Feature branches from `develop`; prefer two PRs (vibe19 then vibe20) or one stacked PR if tightly coupled on DOCX tokens |
+| Tests | App-local pytest suites for touched modules; keep turnkey/Docker smokes green |
+| CI | Green GitHub Actions required before merge |
+| CodeRabbit | Address review comments before merge |
+| Branch tidy | Close/delete merged remotes: `feat/vibe19-fdd-overview-day-zoom`, `fix/vibe19-eng-findings-bugs-011-015`, kaleido/dockerfile branches if already merged |
+| GHCR | Path-filter publish; vibe19 refresh after merge; vibe20 when paths fire; `workflow_dispatch` `no_cache=true` if `:latest` sticky |
+| Turnkey verify | Pull recreate; vibe19 `:8502` Eng Findings DOCX media + period; vibe20 `:8520` ECM card + client DOCX |
+
+---
+
+## 7. Phased delivery (recommended)
+
+| Phase | Scope | Independently shippable? |
+| --- | --- | --- |
+| **P1** | vibe19 BUG-016/017/018 + Eng Findings DOCX UX + vibe19_agent_spec | Yes |
+| **P2** | vibe20 `ECM-OCC-STANDBY-DCV` + proxy + packages + complexity sort + scenario v2 | Yes |
+| **P3** | vibe20 client DOCX + Studio checkbox + deliverables tests | Yes (after P2 preferred so ECM section has content) |
+| **P4** | Docs/`ecm_library`/vibe20_agent_spec sweep + ESCO doc rows | Can land with P2/P3 |
+| **P5** | PR review, merge, GH tidy, GHCR, turnkey QA | After green CI |
+
+Shared DOCX visual language: implement helpers in P1 (vibe19), mirror in P3 (vibe20) so styles converge.
+
+---
+
+## 8. Success criteria
+
+- Eng Findings DOCX: non-empty analysis period when Overview span exists; day-zoom or explicit skip note per included finding; quality gate accepts “Do not replace…”; cover/sections match §3.
+- Studio ECMs: new measure visible, complexity-sorted, proxy savings non-zero on synthetic bins; agent scenario can pre-select it with real ids.
+- Client package ZIP optionally contains Energy Modeling DOCX with numbered sections and honesty disclaimer.
+- Spec/docs folders listed in §4.5 / §5.6–5.8 updated; `ecm_library` README clarifies shim.
+- CI green; CodeRabbit resolved; turnkey containers refreshed and smoke-checked.
+
+---
+
+## 9. Open items (resolve during implementation, not blockers)
+
+1. Exact `esco-top15` rank slot for `ECM-OCC-STANDBY-DCV` (adjacent to `ECM-DCV-CO2` recommended).
+2. Whether composite proxy is a new `@register` calculator vs Studio-only sum of two registered calcs (prefer Studio sum + documented provenance to avoid double-counting in golden registry — or a thin registered wrapper that calls both).
+3. Default for “Include client DOCX” checkbox (recommend **on** when dependency present).
+
+---
+
+## 10. Spec self-review
+
+- [x] No TBD placeholders for core behavior
+- [x] vibe19 + vibe20 + all four requested doc surfaces included
+- [x] User DOCX UX alignment request included
+- [x] Non-goals prevent registry / product conflation
+- [x] Phases keep shippable slices
+- [x] Tests and ops called out

--- a/vibe_code_apps_20/ecm_library/README.md
+++ b/vibe_code_apps_20/ecm_library/README.md
@@ -1,0 +1,8 @@
+# Deprecated ECM library shim
+
+`ecm_library` is retained only for import compatibility. It is not an ECM
+registry and must not receive new measure metadata.
+
+The canonical registry is [`../wattlab/measures/catalog.yaml`](../wattlab/measures/catalog.yaml).
+For example, `ECM-OCC-STANDBY-DCV` is defined there and is available through
+`wattlab.ecm.get_ecm`, packages, Studio Easy Buttons, and agent scenarios.

--- a/vibe_code_apps_20/tests/test_ecm_catalog.py
+++ b/vibe_code_apps_20/tests/test_ecm_catalog.py
@@ -79,7 +79,7 @@ def test_package_resolution_expands_dependencies_without_duplicates() -> None:
     assert "ECM-ADVANCED-RTU" in esco
     assert "ECM-AHU-SCHED-ALIGN" in esco
     assert "ECM-OCC-STANDBY-DCV" in esco
-    assert esco.index("ECM-OCC-STANDBY-DCV") == esco.index("ECM-DCV-CO2") + 1
+    assert "ECM-DCV-CO2" not in esco  # standalone DCV superseded to avoid double-count
     assert "ECM-SENSOR-CRITICAL-REFRESH" in esco
     assert len(esco) == len(set(esco))
 
@@ -103,6 +103,11 @@ def test_occ_standby_dcv_is_a_production_proxy_oa_measure() -> None:
     assert measure.status == "PRODUCTION_PROXY_ONLY"
     assert measure.energyplus_patch is None
     assert measure.dependencies == ["ECM-SENSOR-CRITICAL-REFRESH"]
+    assert "ECM-DCV-CO2" in measure.incompatibilities
+
+    issues = detect_incompatibilities(["ECM-OCC-STANDBY-DCV", "ECM-DCV-CO2"])
+    assert len(issues) == 1
+    assert set(issues[0].ecm_ids) == {"ECM-OCC-STANDBY-DCV", "ECM-DCV-CO2"}
 
 
 def test_incompatibility_detection_is_symmetric_and_fail_closed() -> None:

--- a/vibe_code_apps_20/tests/test_ecm_catalog.py
+++ b/vibe_code_apps_20/tests/test_ecm_catalog.py
@@ -78,6 +78,9 @@ def test_package_resolution_expands_dependencies_without_duplicates() -> None:
     assert "ECM-CONDENSING-BOILER" in esco
     assert "ECM-ADVANCED-RTU" in esco
     assert "ECM-AHU-SCHED-ALIGN" in esco
+    assert "ECM-OCC-STANDBY-DCV" in esco
+    assert esco.index("ECM-OCC-STANDBY-DCV") == esco.index("ECM-DCV-CO2") + 1
+    assert "ECM-SENSOR-CRITICAL-REFRESH" in esco
     assert len(esco) == len(set(esco))
 
     erv = resolve_package("energy-recovery")
@@ -90,6 +93,16 @@ def test_package_resolution_expands_dependencies_without_duplicates() -> None:
 
     with pytest.raises(KeyError, match="Unknown ECM package"):
         resolve_package("not-a-package")
+
+
+def test_occ_standby_dcv_is_a_production_proxy_oa_measure() -> None:
+    measure = get_ecm("ECM-OCC-STANDBY-DCV")
+
+    assert measure.category == "oa_ventilation"
+    assert measure.implementation_complexity == "medium"
+    assert measure.status == "PRODUCTION_PROXY_ONLY"
+    assert measure.energyplus_patch is None
+    assert measure.dependencies == ["ECM-SENSOR-CRITICAL-REFRESH"]
 
 
 def test_incompatibility_detection_is_symmetric_and_fail_closed() -> None:

--- a/vibe_code_apps_20/tests/test_ecm_ranking.py
+++ b/vibe_code_apps_20/tests/test_ecm_ranking.py
@@ -1,0 +1,21 @@
+"""Ordering behavior shared by the ECM Easy Buttons UI."""
+
+from __future__ import annotations
+
+from wattlab.ecm.ranking import complexity_sort_key
+
+
+def test_complexity_sort_key_orders_low_medium_high_then_category_and_id() -> None:
+    entries = [
+        {"implementation_complexity": "high", "category": "oa", "ecm_id": "ECM-C"},
+        {"implementation_complexity": "medium", "category": "z", "ecm_id": "ECM-B"},
+        {"implementation_complexity": "low", "category": "z", "ecm_id": "ECM-Z"},
+        {"implementation_complexity": "low", "category": "a", "ecm_id": "ECM-A"},
+    ]
+
+    assert [entry["ecm_id"] for entry in sorted(entries, key=complexity_sort_key)] == [
+        "ECM-A",
+        "ECM-Z",
+        "ECM-B",
+        "ECM-C",
+    ]

--- a/vibe_code_apps_20/tests/test_ecm_roi.py
+++ b/vibe_code_apps_20/tests/test_ecm_roi.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from wattlab.studio.ecm_roi import (
+    default_model_for,
     implementation_cost_usd,
     seed_roi_cost_rows,
 )
@@ -45,3 +46,10 @@ def test_seed_roi_preserves_engineer_edits() -> None:
     assert by_id["ECM-GL36-AIRSIDE"]["coverage_fraction"] == 0.4
     assert by_id["ECM-GL36-AIRSIDE"]["implementation_cost_usd"] == 300_000.0
     assert by_id["ECM-AHU-SCHED-ALIGN"]["coverage_fraction"] == 1.0
+
+
+def test_occ_standby_dcv_has_a_documented_roi_seed() -> None:
+    model = default_model_for("ECM-OCC-STANDBY-DCV")
+
+    assert model["usd_per_ft2"] == 0.65
+    assert "standby" in model["note"].lower()

--- a/vibe_code_apps_20/tests/test_studio_proxies_occ_standby.py
+++ b/vibe_code_apps_20/tests/test_studio_proxies_occ_standby.py
@@ -1,0 +1,20 @@
+"""Regression tests for the occupied-standby plus DCV Studio proxy."""
+
+from __future__ import annotations
+
+from wattlab.studio.proxies import estimate_proxy_savings
+
+
+def test_occ_standby_dcv_sums_unoccupied_oad_and_dcv_with_provenance() -> None:
+    savings = estimate_proxy_savings(
+        {"floor_area_ft2": 50_000},
+        ["ECM-OCC-STANDBY-DCV", "ECM-DCV-CO2"],
+    )
+
+    composite = savings["ECM-OCC-STANDBY-DCV"]
+    dcv_only = savings["ECM-DCV-CO2"]
+
+    assert composite["calculators"] == ["oad_unoccupied_closed", "dcv_bins"]
+    assert dcv_only["calculators"] == ["dcv_bins"]
+    assert composite["savings_kwh"] > dcv_only["savings_kwh"]
+    assert composite["savings_therms"] > dcv_only["savings_therms"]

--- a/vibe_code_apps_20/tests/test_studio_status_deliverables.py
+++ b/vibe_code_apps_20/tests/test_studio_status_deliverables.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,7 @@ from wattlab.studio.status import (
     required_gaps_still_missing,
     soften_required_gaps,
 )
+from wattlab.deliverables import build_executive_markdown
 
 
 def test_soften_required_gaps_when_answers_filled():
@@ -40,6 +42,54 @@ def test_ecm_scenario_roundtrip(tmp_path: Path):
     loaded = load_ecm_scenario(path)
     assert loaded["selected_ecm_ids"] == ["a", "b"]
     assert "2 ECMs" in loaded["status"]
+
+
+def test_ecm_scenario_v1_loads_and_v2_fields_roundtrip(tmp_path: Path):
+    path = tmp_path / "ecm_scenario.json"
+    path.write_text(
+        json.dumps({"version": 1, "selected_ecm_ids": ["ECM-A"]}),
+        encoding="utf-8",
+    )
+    migrated = load_ecm_scenario(path)
+    assert migrated["version"] == 2
+    assert migrated["sort_preference"] == "implementation_complexity"
+    assert migrated["package_hints"] == []
+    assert migrated["proxy_defaults"] == {}
+    assert migrated["roi_param_hints"] == {}
+
+    save_ecm_scenario(
+        {
+            "selected_ecm_ids": ["ECM-OCC-STANDBY-DCV"],
+            "sort_preference": "implementation_complexity",
+            "package_hints": ["esco-top15"],
+            "proxy_defaults": {"oa_fraction": 0.2},
+            "roi_param_hints": {"usd_per_ft2": 0.65},
+        },
+        path=path,
+    )
+    loaded = load_ecm_scenario(path)
+    assert loaded["version"] == 2
+    assert loaded["package_hints"] == ["esco-top15"]
+    assert loaded["proxy_defaults"] == {"oa_fraction": 0.2}
+    assert loaded["roi_param_hints"] == {"usd_per_ft2": 0.65}
+
+
+def test_executive_markdown_lists_proxy_calculator_provenance() -> None:
+    markdown = build_executive_markdown(
+        report={
+            "proxy_savings": {
+                "ECM-OCC-STANDBY-DCV": {
+                    "calculators": ["oad_unoccupied_closed", "dcv_bins"],
+                    "savings_kwh": 120.0,
+                    "savings_therms": 9.0,
+                }
+            }
+        }
+    )
+
+    assert "oad_unoccupied_closed + dcv_bins" in markdown
+    assert "120.0" in markdown
+    assert "9.0" in markdown
 
 
 def test_build_session_status_answers_answered(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -106,3 +156,27 @@ def test_package_deliverables_has_source_and_iteration(tmp_path: Path, monkeypat
     assert "Executive summary" in Path(meta["report_md"]).read_text(encoding="utf-8")
     wb = load_workbook(io.BytesIO(Path(meta["workbook_xlsx"]).read_bytes()))
     assert "Iteration_Runs" in wb.sheetnames
+
+
+def test_package_deliverables_optionally_writes_client_docx(tmp_path: Path) -> None:
+    from wattlab.deliverables import package_deliverables
+
+    with_docx = package_deliverables(
+        out_dir=tmp_path / "with_docx",
+        scorecard={"run_id": "docx", "status": "screening"},
+        profile={"display_name": "Example Building"},
+        include_docx=True,
+    )
+    docx_path = Path(with_docx["report_docx"])
+    assert docx_path.is_file()
+    assert docx_path.read_bytes()[:2] == b"PK"
+    with zipfile.ZipFile(with_docx["zip_path"]) as packaged:
+        assert "with_docx/01_Report/Energy_Modeling_Report.docx" in packaged.namelist()
+
+    without_docx = package_deliverables(
+        out_dir=tmp_path / "without_docx",
+        scorecard={"run_id": "no-docx", "status": "screening"},
+        include_docx=False,
+    )
+    assert "report_docx" not in without_docx
+    assert not (tmp_path / "without_docx" / "01_Report" / "Energy_Modeling_Report.docx").exists()

--- a/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/AGENTS.md
@@ -41,7 +41,7 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 9. **EUI units are kBtu/ft²-year (site)** — conversions: 1 kWh = 3,412 Btu; 1 Mcf gas = 1.037 MMBtu; 1 therm = 100 kBtu. Peer bands from `benchmarks_public.json` (EPA PM medians, CBECS 70.6 fallback).
 10. **Docker-only EnergyPlus** — pinned image via `wattlab.energyplus.docker`; run manifests (`run_manifest.json`) record model/weather SHA + image on every run. Docker tests skip when the image is missing — that's fine. Studio image includes a **Docker CLI client**; mount `/var/run/docker.sock` + set `WATTLAB_HOST_WORKSPACE` + prefer `ENERGYPLUS_DOCKER_USER=1000:1000`. Prefer **`docker exec vibe20 wattlab …`** over host `pip install -e` (host drift bug).
 10b. **G14 calibrate campaign** — `wattlab calibrate-campaign --bundle … --bills … [--answers …] --lat --lon` merges human answers into null dump seed, derives AMY window from bill months, stashes off-window dump weather, scores G14 (`months_compared` multi-year aware), publishes Twin + optional client zip. **lat/lon beat city label.** Schedule:File must use `/work/in/<csv>` (DinD). Details: [`docs/CALIBRATE_AND_DELIVERABLES.md`](docs/CALIBRATE_AND_DELIVERABLES.md) + [`docs/AGENT_DOCKER_WORKSPACE.md`](docs/AGENT_DOCKER_WORKSPACE.md). Honest G14 fail = screening twin — no calibrated ROI without pass + stamps.
-10c. **Client deliverables** — Twin **Build client package** (also ECM) → markdown report + xlsx workbook + model zip (`01_Report`…`06_Documentation`). Humans must not need raw E+ trees to read conclusions.
+10c. **Client deliverables** — Twin **Build client package** (also ECM) → markdown report + optional 14-section client DOCX + xlsx workbook + model zip (`01_Report`…`06_Documentation`). Humans must not need raw E+ trees to read conclusions.
 11. **Dry-run first** — `run_easy_button(profile, dry_run=True)` and the Studio "Dry-run plan" path must always work without Docker. Never make a feature Docker-mandatory when a plan/preview is possible.
 12. **Weather** — AMY EPW from `weather_observed.csv` / Open-Meteo (`wattlab.weather.epw`); Weather-Man OAT bin tables (5°F × 3 shifts + MCWB) in `wattlab.weather.bins` (built-in NOAA Washington DC table + `from_hourly`). Calibration weather and degree-day benchmarking are separate use cases — don't conflate.
 13. **The vibe19 dump is the seed** — start with `wattlab twin <dump.zip>` (or `wattlab.seed.load_bundle` + `gap_report`). Read `MANIFEST.json` first. Required human fields: `building_type`, `city`, `floor_area_ft2` (plus `lat`/`lon` for AMY calibrate). **Never invent office/Madison/Chicago** for a real dump. Prefer `fdd_findings.csv` over `fdd_summary.csv`. See [`DATA_CONTRACT.md`](DATA_CONTRACT.md) and the **Tomorrow demo** section in [`../AGENTS.md`](../AGENTS.md).
@@ -141,7 +141,7 @@ Plain Markdown on disk is the source of truth for **any AI agent** (Cursor, Code
 | `wattlab/easy_button.py` | Baseline + progressive measures (`--dry-run`) |
 | `wattlab/calibrate.py` | Overlap-window calibration + Studio publish |
 | `wattlab/calibrate_campaign.py` | Bills → AMY window → G14 → Twin + deliverable |
-| `wattlab/deliverables.py` | Client report.md / xlsx / model zip |
+| `wattlab/deliverables.py` + `deliverables_docx.py` | Client report.md / optional DOCX / xlsx / model zip |
 | `wattlab/bridge.py` | vibe19 faults → measures |
 | `wattlab/energyplus/` | Docker (CLI in image), results (`peak_demand_kw`), timeseries, IDF patches |
 | `wattlab/measures/` + `wattlab/ecm/` | Catalog / packages |

--- a/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/CONTAINER_AGENT.md
@@ -101,9 +101,19 @@ Useful commands:
   (merges existing keys — does not drop `ecm_scenario_path`)
 - `wattlab geo-idf` / `wattlab dial-loads` / `wattlab score-monthly` — site-scale twin ladder
 - `wattlab calibrate-campaign …` / `wattlab twin …` / `wattlab benchmark …`
-- Write `reports/ecm_scenario.json` → Studio ECMs Easy Buttons after Re-apply
+- Write schema-v2 `reports/ecm_scenario.json` with real `ECM-*` ids (for
+  example `ECM-OCC-STANDBY-DCV`) → Studio ECMs Easy Buttons after Re-apply
 
 Human: open Studio → **refresh** or sidebar **Re-apply bootstrap**. Twin DinD shows live progress + IDF massing when `model.idf` is published.
+
+## ECM and client-DOCX handoff
+
+`ECM-OCC-STANDBY-DCV` combines verified unoccupied OA closure and occupied DCV;
+its Studio proxy reports `oad_unoccupied_closed` and `dcv_bins` provenance.
+Easy Buttons presents catalog cards low→medium→high complexity. The human can
+select **Include client DOCX** when building a Twin or ECM package; that writes
+`01_Report/Energy_Modeling_Report.docx` when `python-docx` is installed. It is
+not the controls-checklist DOCX.
 
 ## Do not
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -185,11 +185,15 @@ Write `/data/reports/ecm_scenario.json`:
 
 ```json
 {
-  "version": 1,
-  "selected_ecm_ids": ["fan_schedule_optimization"],
+  "version": 2,
+  "selected_ecm_ids": ["ECM-AHU-SCHED-ALIGN", "ECM-OCC-STANDBY-DCV"],
   "measure_set": "best",
+  "sort_preference": "implementation_complexity",
+  "package_hints": ["esco-top15"],
+  "proxy_defaults": {},
+  "roi_param_hints": {},
   "notes": "from chat",
-  "recommendations": ["chiller_lockout_reset"]
+  "recommendations": ["ECM-CHILLER-LOCKOUT"]
 }
 ```
 
@@ -199,8 +203,10 @@ writes back. Optional bootstrap key: `ecm_scenario_path`.
 ## Twin iteration dashboard + client package
 
 Twin **Iteration history** shows run_id, hypothesis, weather, status, eplusout,
-elapsed (from `run_manifest.json`). **Build client package** downloads report.md,
-workbook.xlsx, and full zip (`05_Source_Data` included when answers/bills present).
+elapsed (from `run_manifest.json`). **Build client package** can include the
+14-section `01_Report/Energy_Modeling_Report.docx` alongside report.md,
+workbook.xlsx, and the full zip (`05_Source_Data` included when answers/bills
+are present). The Studio checkbox defaults on when `python-docx` is installed.
 
 Fuel **Portfolio** peer metrics have `?` help text + “How buildings are benchmarked”.
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
@@ -143,3 +143,16 @@ Details: [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md).
 
 See also: [`AGENT_DOCKER_WORKSPACE.md`](AGENT_DOCKER_WORKSPACE.md),
 [`TWIN_LOOP.md`](TWIN_LOOP.md), [`ESCO_RETROFIT_COST_ROI.md`](ESCO_RETROFIT_COST_ROI.md).
+
+## ECM scenario and client package handoff
+
+Agents may write `reports/ecm_scenario.json` schema v2 with real catalog IDs
+only. In addition to `selected_ecm_ids`, use `sort_preference`,
+`package_hints`, `proxy_defaults`, and `roi_param_hints` when useful; Studio
+still accepts v1 selection-only files. For `ECM-OCC-STANDBY-DCV`, retain the
+proxy provenance from `oad_unoccupied_closed` + `dcv_bins`.
+
+The human selects **Include client DOCX** on Twin or ECM package builders.
+When available, the package writes
+`01_Report/Energy_Modeling_Report.docx`; this is separate from the controls
+FDD checklist DOCX.

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/CALIBRATE_AND_DELIVERABLES.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/CALIBRATE_AND_DELIVERABLES.md
@@ -66,11 +66,13 @@ Also: `wattlab calibrate --bundle …` for an already-seeded dump with
 1. **Modeled vs actual fuel** — monthly table + chart; NMBE / CV(RMSE) / pass-fail metrics when a scorecard is present (path or autoload from active run).
 2. **Client deliverables** — **Build client package**:
    - Report preview (markdown)
-   - Downloads: `.md` · `.xlsx` · full `.zip`
+   - Optional client DOCX (checkbox defaults on when `python-docx` is available)
+   - Downloads: `.md` · `.xlsx` · `.docx` · full `.zip`
 3. Zip layout:
 
 ```text
 01_Report/Energy_Modeling_Report.md
+01_Report/Energy_Modeling_Report.docx  # selected client-rendered report
 02_Results/Energy_Model_Results.xlsx + calibration_scorecard.json
 03_Models/Baseline/Building_Baseline.idf + Weather.epw + README.md
 04_Outputs/Baseline/eplustbl.* eplusout.err …
@@ -78,6 +80,8 @@ Also: `wattlab calibrate --bundle …` for an already-seeded dump with
 ```
 
 ECM page can build the same zip from `studio_report` (screening package).
+The DOCX is an energy-modeling deliverable, not the separate
+`wattlab controls-checklist --docx` output.
 
 ## Ladder reminder (sparse sites)
 

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/ESCO_CALCULATORS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/ESCO_CALCULATORS.md
@@ -53,6 +53,15 @@ Common inputs: `bins` (anything `parse_bins_input` accepts),
 Common outputs: `savings_kwh` and/or `savings_therms`, plus per-bin breakdown
 lists for auditability.
 
+## Studio composite: occupied standby + DCV
+
+`ECM-OCC-STANDBY-DCV` is a catalog measure, not a new registered calculator.
+`wattlab.studio.proxies.estimate_proxy_savings` composes
+`oad_unoccupied_closed` for verified unoccupied OA closure and `dcv_bins` for
+occupied ventilation reduction. The result carries
+`calculators: ["oad_unoccupied_closed", "dcv_bins"]`; preserve that provenance
+in reports. `ECM-DCV-CO2` remains `dcv_bins` only.
+
 ## Golden anchors (never drift)
 
 | Test | Anchor |

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-assumptions/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-assumptions/SKILL.md
@@ -68,6 +68,10 @@ thermostat / fan hours, WWR, HVAC family, weather mode
 (`TYPICAL_YEAR_SCREENING` / `ACTUAL_YEAR_CALIBRATION` /
 `SUBSTITUTE_CLIMATE_CONCEPTUAL_ONLY`), `prototype_area_scale`.
 
+For `ECM-OCC-STANDBY-DCV`, record the verified occupied and standby schedules,
+minimum-ventilation constraint, sensor calibration evidence, and the source of
+the DCV airflow reduction. Never infer zero occupied OA from a screening proxy.
+
 ## Short / long fuel playbook (Twin G14 dial)
 
 Autosized plant is fine for sparse twins — dial **envelope + loads + as-operated

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-esco-bins/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-esco-bins/SKILL.md
@@ -62,6 +62,11 @@ from vibe19 `weather_observed.csv` (timestamp + OAT columns).
 Engineering conventions everywhere: 4.5·CFM·Δh (total), 1.08·CFM·ΔT (sensible),
 12,000 Btu/ton-h, therms = kBtu/100.
 
+`ECM-OCC-STANDBY-DCV` is a Studio composite, not a new registration: combine
+`oad_unoccupied_closed` for verified standby hours with `dcv_bins` for
+occupied DCV and return both calculator names as provenance. Keep
+`ECM-DCV-CO2` on `dcv_bins` alone; do not double-count the component savings.
+
 ## Hard rules
 
 1. **Golden tests pin public engineering behavior** — changing math means

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-studio/SKILL.md
@@ -67,9 +67,17 @@ Prefer agent work via `docker exec vibe20 wattlab …`
 
 Artifacts: `/data/.artifacts`. Sims default to ReadVars (`-r`) for `eplusout.csv`.
 
-**Client deliverables (Twin):** Build client package → report preview + download
-`.md` / `.xlsx` / `.zip` (`wattlab.deliverables`). See
+**Client deliverables (Twin and ECMs):** Build client package → report preview
+optional `.docx` / `.md` / `.xlsx` / `.zip` (`wattlab.deliverables`). The
+**Include client DOCX** checkbox defaults on when `python-docx` is available;
+it writes `01_Report/Energy_Modeling_Report.docx` and is distinct from the
+controls-checklist DOCX. See
 [`docs/CALIBRATE_AND_DELIVERABLES.md`](../../docs/CALIBRATE_AND_DELIVERABLES.md).
+
+**ECM scenario:** `reports/ecm_scenario.json` v2 accepts
+`sort_preference=implementation_complexity`, package/proxy/ROI hints, and
+real `ECM-*` ids. Cards sort low→medium→high complexity without changing
+`ESCO_TOP15` screening order.
 
 **G14:** scorecard NMBE/CV(RMSE) on Twin when `calibration_scorecard.json` is
 present; campaign CLI `wattlab calibrate-campaign`.

--- a/vibe_code_apps_20/wattlab/deliverables.py
+++ b/vibe_code_apps_20/wattlab/deliverables.py
@@ -153,6 +153,27 @@ def build_executive_markdown(
             "_No progressive ECM table in this package (baseline-only or calibrate run). "
             "See `reports/ecm_scenario.json` / Easy Buttons for screening selections._"
         )
+    proxy_savings = rp.get("proxy_savings") or rp.get("proxies") or {}
+    if isinstance(proxy_savings, dict) and proxy_savings:
+        lines.extend(
+            [
+                "",
+                "### Screening proxy provenance",
+                "",
+                "| measure | calculator provenance | kWh/yr | therms/yr |",
+                "| --- | --- | ---: | ---: |",
+            ]
+        )
+        for measure_id, proxy in proxy_savings.items():
+            if not isinstance(proxy, dict):
+                continue
+            calculators = proxy.get("calculators") or proxy.get("calculator") or "—"
+            if isinstance(calculators, list):
+                calculators = " + ".join(str(name) for name in calculators)
+            lines.append(
+                f"| {measure_id} | {calculators} | {proxy.get('savings_kwh', '—')} | "
+                f"{proxy.get('savings_therms', '—')} |"
+            )
     lines.extend(
         [
             "",
@@ -410,6 +431,7 @@ def package_deliverables(
     zip_name: str | None = None,
     source_files: list[Path] | None = None,
     iteration_runs: list[dict[str, Any]] | None = None,
+    include_docx: bool = False,
 ) -> dict[str, Any]:
     """Write curated deliverable tree + zip; return paths/meta."""
     out = Path(out_dir)
@@ -448,6 +470,20 @@ def package_deliverables(
     md = build_executive_markdown(scorecard=sc, report=rp, profile=profile)
     report_path = out / "01_Report" / "Energy_Modeling_Report.md"
     report_path.write_text(md, encoding="utf-8")
+    report_docx: Path | None = None
+    docx_note: str | None = None
+    if include_docx:
+        try:
+            from wattlab.deliverables_docx import render_energy_modeling_docx
+
+            report_docx = render_energy_modeling_docx(
+                out_path=out / "01_Report" / "Energy_Modeling_Report.docx",
+                scorecard=sc,
+                report=rp,
+                profile=profile,
+            )
+        except ImportError:
+            docx_note = "Client DOCX skipped: install the optional python-docx dependency."
 
     xlsx_bytes = build_results_workbook_bytes(
         scorecard=sc, report=rp, iteration_runs=iters
@@ -602,7 +638,7 @@ def package_deliverables(
             if p.is_file():
                 zf.write(p, arcname=str(p.relative_to(out.parent)))
 
-    return {
+    result = {
         "ok": True,
         "out_dir": str(out),
         "zip_path": str(zip_path),
@@ -610,3 +646,8 @@ def package_deliverables(
         "workbook_xlsx": str(xlsx_path),
         "stamp": stamp,
     }
+    if report_docx is not None:
+        result["report_docx"] = str(report_docx)
+    if docx_note:
+        result["docx_note"] = docx_note
+    return result

--- a/vibe_code_apps_20/wattlab/deliverables_docx.py
+++ b/vibe_code_apps_20/wattlab/deliverables_docx.py
@@ -1,0 +1,128 @@
+"""Client-facing Energy Modeling DOCX renderer for WattLab packages."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _set_color(run: Any, hex_color: str = "4A5568") -> None:
+    from docx.shared import RGBColor
+
+    run.font.color.rgb = RGBColor.from_string(hex_color)
+
+
+def _add_cover(document: Any, *, project_name: str) -> None:
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.shared import Pt
+
+    title = document.add_heading("Energy Modeling Report", level=0)
+    title.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    subtitle = document.add_paragraph()
+    subtitle.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = subtitle.add_run(project_name)
+    run.bold = True
+    run.font.size = Pt(16)
+    meta = document.add_paragraph()
+    meta.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = meta.add_run(
+        f"Generated {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}"
+    )
+    run.font.size = Pt(10)
+    _set_color(run)
+    advisory = document.add_paragraph()
+    advisory.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = advisory.add_run(
+        "WattLab screening — not CD/TAB, final equipment selection, or construction documents."
+    )
+    run.italic = True
+    run.font.size = Pt(10)
+    _set_color(run)
+
+
+def _style_table_header(table: Any) -> None:
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    for cell in table.rows[0].cells:
+        for run in cell.paragraphs[0].runs:
+            run.bold = True
+            _set_color(run, "FFFFFF")
+        shading = cell._tc.get_or_add_tcPr()
+        shading.append(parse_xml(r'<w:shd {} w:fill="2D3748"/>'.format(nsdecls("w"))))
+
+
+def _add_markdown_body(document: Any, markdown: str) -> None:
+    """Render the executive markdown's stable 14-section outline."""
+    lines = markdown.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index].strip()
+        if line.startswith("## "):
+            document.add_heading(line[3:], level=1)
+        elif line.startswith("### "):
+            document.add_heading(line[4:], level=2)
+        elif line.startswith("> "):
+            p = document.add_paragraph()
+            run = p.add_run(line[2:])
+            run.italic = True
+            _set_color(run)
+        elif line.startswith("- "):
+            document.add_paragraph(line[2:], style="List Bullet")
+        elif line.startswith("| ") and index + 1 < len(lines) and lines[index + 1].strip().startswith("| ---"):
+            headers = [cell.strip() for cell in line.strip("|").split("|")]
+            table = document.add_table(rows=1, cols=len(headers), style="Table Grid")
+            for cell, value in zip(table.rows[0].cells, headers):
+                cell.text = value
+            index += 2
+            while index < len(lines) and lines[index].strip().startswith("|"):
+                values = [cell.strip() for cell in lines[index].strip().strip("|").split("|")]
+                cells = table.add_row().cells
+                for cell, value in zip(cells, values):
+                    cell.text = value
+                index += 1
+            _style_table_header(table)
+            continue
+        elif line and not line.startswith("# ") and not line.startswith("_Generated"):
+            document.add_paragraph(line.replace("**", "").replace("`", ""))
+        index += 1
+
+
+def render_energy_modeling_docx(
+    *,
+    out_path: Path,
+    scorecard: dict[str, Any] | None = None,
+    report: dict[str, Any] | None = None,
+    profile: dict[str, Any] | None = None,
+) -> Path:
+    """Write a 14-section client DOCX mirroring the executive markdown."""
+    from docx import Document
+    from docx.enum.text import WD_BREAK
+
+    from wattlab.deliverables import build_executive_markdown
+
+    sc = scorecard or {}
+    rp = report or {}
+    pr = profile or {}
+    document = Document()
+    _add_cover(
+        document,
+        project_name=str(
+            pr.get("display_name")
+            or rp.get("display_name")
+            or sc.get("profile_project_id")
+            or "WattLab Energy Screen"
+        ),
+    )
+    document.add_paragraph().add_run().add_break(WD_BREAK.PAGE)
+    _add_markdown_body(
+        document,
+        build_executive_markdown(scorecard=sc, report=rp, profile=pr),
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    document.save(out_path)
+    return out_path
+
+
+__all__ = ["render_energy_modeling_docx"]

--- a/vibe_code_apps_20/wattlab/ecm/packages.py
+++ b/vibe_code_apps_20/wattlab/ecm/packages.py
@@ -15,8 +15,7 @@ ESCO_TOP15: tuple[str, ...] = (
     "ECM-SAT-RESET",             # 6 Supply-air-temperature reset
     "ECM-VAV-MIN-RESET",         # 7 VAV minimum-airflow reduction
     "ECM-ECON-REPAIR",           # 8 Economizer repair / optimization
-    "ECM-DCV-CO2",               # 9 Demand-controlled ventilation
-    "ECM-OCC-STANDBY-DCV",       # 9a Occupied standby + DCV composite
+    "ECM-OCC-STANDBY-DCV",       # 9 Occupied standby + DCV (supersedes standalone DCV in Top-15)
     "ECM-BOILER-RESET",          # 10 Hot-water reset / boiler optimization
     "ECM-CHW-RESET",             # 11a Chilled-water plant optimization
     "ECM-CW-RESET",              # 11b

--- a/vibe_code_apps_20/wattlab/ecm/packages.py
+++ b/vibe_code_apps_20/wattlab/ecm/packages.py
@@ -16,6 +16,7 @@ ESCO_TOP15: tuple[str, ...] = (
     "ECM-VAV-MIN-RESET",         # 7 VAV minimum-airflow reduction
     "ECM-ECON-REPAIR",           # 8 Economizer repair / optimization
     "ECM-DCV-CO2",               # 9 Demand-controlled ventilation
+    "ECM-OCC-STANDBY-DCV",       # 9a Occupied standby + DCV composite
     "ECM-BOILER-RESET",          # 10 Hot-water reset / boiler optimization
     "ECM-CHW-RESET",             # 11a Chilled-water plant optimization
     "ECM-CW-RESET",              # 11b
@@ -60,6 +61,7 @@ PACKAGES: dict[str, tuple[str, ...]] = {
     ),
     "controls-only": (
         "ECM-AHU-SCHED-ALIGN",
+        "ECM-OCC-STANDBY-DCV",
         "ECM-CHILLER-LOCKOUT",
         "ECM-SAT-RESET",
         "ECM-DSP-RESET",
@@ -80,6 +82,7 @@ PACKAGES: dict[str, tuple[str, ...]] = {
     "no-capital-rcx": (
         "ECM-AHU-SCHED-ALIGN",
         "ECM-OA-DAMPER-REPAIR",
+        "ECM-OCC-STANDBY-DCV",
         "ECM-CHILLER-LOCKOUT",
         "ECM-SENSOR-CALIBRATION",
         "ECM-RCX-SETPOINT-REVIEW",

--- a/vibe_code_apps_20/wattlab/ecm/ranking.py
+++ b/vibe_code_apps_20/wattlab/ecm/ranking.py
@@ -1,0 +1,27 @@
+"""Presentation-only catalog ordering helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_COMPLEXITY_RANK = {"low": 0, "medium": 1, "high": 2}
+
+
+def _field(entry: Any, name: str, default: str = "") -> str:
+    if isinstance(entry, Mapping):
+        return str(entry.get(name, default))
+    return str(getattr(entry, name, default))
+
+
+def complexity_sort_key(entry: Any) -> tuple[int, str, str]:
+    """Sort catalog entries easy-to-hard without changing package order."""
+    complexity = _field(entry, "implementation_complexity").lower()
+    return (
+        _COMPLEXITY_RANK.get(complexity, len(_COMPLEXITY_RANK)),
+        _field(entry, "category").lower(),
+        _field(entry, "ecm_id").upper(),
+    )
+
+
+__all__ = ["complexity_sort_key"]

--- a/vibe_code_apps_20/wattlab/measures/catalog.yaml
+++ b/vibe_code_apps_20/wattlab/measures/catalog.yaml
@@ -100,6 +100,31 @@ ecms:
     status: PRODUCTION_PROXY_ONLY
 
   - <<: *defaults
+    ecm_id: ECM-OCC-STANDBY-DCV
+    display_name: Occupied-standby + demand-controlled ventilation
+    short_name: Occupancy standby + DCV
+    category: oa_ventilation
+    equipment_types: [air_handling_unit, outside_air_damper, co2_sensor]
+    system_families: [vav, single_zone]
+    retrofit_classes: [controls, sensors, rcx]
+    description: >
+      Close outdoor air during verified unoccupied standby periods and reset
+      occupied airflow from calibrated carbon-dioxide or population demand.
+    engineering_rationale: >
+      Combines schedule-aligned ventilation shutdown with occupied demand control
+      while retaining minimum ventilation and indoor-air-quality safeguards.
+    required_inputs: [baseline_oa_cfm, proposed_oa_cfm, occupied_hours, unoccupied_hours]
+    optional_inputs: [co2_trends, population_schedule, oa_damper_command]
+    proxy_calculator: occ_standby_dcv_composite
+    energyplus_patch: null
+    unit_contract: {airflow: CFM, temperature_difference: deltaF, savings: kWh/year}
+    applicability_checks: [Verify unoccupied ventilation requirements, Confirm calibrated CO2 sensors]
+    dependencies: [ECM-SENSOR-CRITICAL-REFRESH]
+    iaq_risk: high
+    implementation_complexity: medium
+    status: PRODUCTION_PROXY_ONLY
+
+  - <<: *defaults
     ecm_id: ECM-OA-RESET
     display_name: Reset minimum outdoor airflow
     short_name: OA reset

--- a/vibe_code_apps_20/wattlab/measures/catalog.yaml
+++ b/vibe_code_apps_20/wattlab/measures/catalog.yaml
@@ -95,6 +95,7 @@ ecms:
     unit_contract: {airflow: CFM, temperature_difference: deltaF, savings: kWh/year}
     applicability_checks: [Confirm code permits DCV, Confirm calibrated CO2 sensors]
     dependencies: [ECM-SENSOR-CRITICAL-REFRESH]
+    incompatibilities: [ECM-OCC-STANDBY-DCV]
     iaq_risk: high
     implementation_complexity: medium
     status: PRODUCTION_PROXY_ONLY
@@ -120,6 +121,7 @@ ecms:
     unit_contract: {airflow: CFM, temperature_difference: deltaF, savings: kWh/year}
     applicability_checks: [Verify unoccupied ventilation requirements, Confirm calibrated CO2 sensors]
     dependencies: [ECM-SENSOR-CRITICAL-REFRESH]
+    incompatibilities: [ECM-DCV-CO2]
     iaq_risk: high
     implementation_complexity: medium
     status: PRODUCTION_PROXY_ONLY

--- a/vibe_code_apps_20/wattlab/studio/ecm_roi.py
+++ b/vibe_code_apps_20/wattlab/studio/ecm_roi.py
@@ -59,6 +59,11 @@ DEFAULT_ECM_ROI_MODELS: dict[str, dict[str, Any]] = {
         "coverage_fraction": 1.0,
         "note": "CO₂ sensors + OA reset programming",
     },
+    "ECM-OCC-STANDBY-DCV": {
+        "usd_per_ft2": 0.65,
+        "coverage_fraction": 1.0,
+        "note": "Occupied standby scheduling + CO₂/DCV programming",
+    },
     "ECM-BOILER-RESET": {
         "usd_per_ft2": 0.20,
         "coverage_fraction": 1.0,

--- a/vibe_code_apps_20/wattlab/studio/ecm_scenario.py
+++ b/vibe_code_apps_20/wattlab/studio/ecm_scenario.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_ECM_SCENARIO_NAME = "ecm_scenario.json"
-ECM_SCENARIO_VERSION = 1
+ECM_SCENARIO_VERSION = 2
 
 
 def default_ecm_scenario_path(workspace: Path | None = None) -> Path:
@@ -23,6 +23,10 @@ def empty_ecm_scenario() -> dict[str, Any]:
         "version": ECM_SCENARIO_VERSION,
         "selected_ecm_ids": [],
         "measure_set": None,
+        "sort_preference": "implementation_complexity",
+        "package_hints": [],
+        "proxy_defaults": {},
+        "roi_param_hints": {},
         "notes": "",
         "recommendations": [],
         "status": "empty — waiting agent or Easy Buttons",
@@ -46,6 +50,12 @@ def load_ecm_scenario(path: Path | str | None = None) -> dict[str, Any]:
     if not isinstance(ids, list):
         ids = []
     out["selected_ecm_ids"] = [str(x) for x in ids]
+    out["sort_preference"] = str(out.get("sort_preference") or "implementation_complexity")
+    for key in ("package_hints",):
+        value = out.get(key)
+        out[key] = [str(item) for item in value] if isinstance(value, list) else []
+    for key in ("proxy_defaults", "roi_param_hints"):
+        out[key] = dict(out.get(key) or {}) if isinstance(out.get(key), dict) else {}
     if out["selected_ecm_ids"]:
         out["status"] = f"{len(out['selected_ecm_ids'])} ECMs selected"
     else:
@@ -65,6 +75,12 @@ def save_ecm_scenario(
     body["version"] = ECM_SCENARIO_VERSION
     ids = body.get("selected_ecm_ids") or []
     body["selected_ecm_ids"] = [str(x) for x in ids] if isinstance(ids, list) else []
+    body["sort_preference"] = str(body.get("sort_preference") or "implementation_complexity")
+    body["package_hints"] = [
+        str(item) for item in (body.get("package_hints") or [])
+    ] if isinstance(body.get("package_hints"), list) else []
+    for key in ("proxy_defaults", "roi_param_hints"):
+        body[key] = dict(body.get(key) or {}) if isinstance(body.get(key), dict) else {}
     if body["selected_ecm_ids"]:
         body["status"] = f"{len(body['selected_ecm_ids'])} ECMs selected"
     else:

--- a/vibe_code_apps_20/wattlab/studio/pages/ecm_easy_buttons.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecm_easy_buttons.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -13,6 +12,7 @@ import streamlit as st
 from wattlab.ecm.catalog import ECMEntry, load_catalog
 from wattlab.ecm.interactions import detect_incompatibilities
 from wattlab.ecm.packages import PACKAGES, resolve_package
+from wattlab.ecm.ranking import complexity_sort_key
 from wattlab.studio.ecm_scenario import load_ecm_scenario, save_ecm_scenario
 from wattlab.studio.state import namespaced_key
 
@@ -78,6 +78,8 @@ def render(
         return
 
     scenario = load_ecm_scenario(_scenario_path())
+    if scenario.get("sort_preference") == "implementation_complexity":
+        entries = sorted(entries, key=complexity_sort_key)
     _ensure_checkbox_defaults(entries, list(scenario.get("selected_ecm_ids") or []))
     recs = scenario.get("recommendations") or []
     if recs:
@@ -97,12 +99,17 @@ def render(
         ),
     )
 
-    grouped: dict[str, list[ECMEntry]] = defaultdict(list)
+    grouped: dict[str, list[ECMEntry]] = {}
     for entry in entries:
-        grouped[entry.category].append(entry)
-    for category in sorted(grouped):
-        with st.expander(category, expanded=False):
-            for entry in grouped[category]:
+        group = (
+            f"{entry.implementation_complexity.title()} complexity"
+            if scenario.get("sort_preference") == "implementation_complexity"
+            else entry.category
+        )
+        grouped.setdefault(group, []).append(entry)
+    for group, group_entries in grouped.items():
+        with st.expander(group, expanded=False):
+            for entry in group_entries:
                 with st.container(border=True):
                     left, right = st.columns([4, 1])
                     left.markdown(f"**{entry.display_name}**  \n{entry.description}")
@@ -112,6 +119,7 @@ def render(
                     )
                     st.caption(
                         f"`{entry.ecm_id}` · status **{entry.status}** · "
+                        f"category **{entry.category}** · complexity **{entry.implementation_complexity}** · "
                         f"confidence **{entry.confidence}** · "
                         f"proxy {'✓' if entry.proxy_calculator else '—'} · "
                         f"EnergyPlus {'✓' if entry.energyplus_patch else '—'}"

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -638,10 +638,16 @@ def render() -> None:
                     "sizing_scenario": report.get("sizing_scenario"),
                     "utility_bills": {},
                 }
+                active_ids = {str(m) for m in (measures or [])}
+                proxy_for_pkg = {
+                    k: v
+                    for k, v in (proxies or {}).items()
+                    if str(k) in active_ids
+                }
                 meta = package_deliverables(
                     out_dir=dest,
                     scorecard=sc,
-                    report={**report, "proxy_savings": proxies},
+                    report={**report, "proxy_savings": proxy_for_pkg},
                     profile=profile,
                     include_docx=include_docx,
                 )

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
@@ -610,6 +611,15 @@ def render() -> None:
 
     st.subheader("Client energy-model package")
     st.caption("Same Twin deliverable builder — report + workbook + model zip from the latest Studio report.")
+    docx_available = find_spec("docx") is not None
+    include_docx = st.checkbox(
+        "Include client DOCX",
+        value=docx_available,
+        disabled=not docx_available,
+        key="ecm_include_client_docx",
+    )
+    if not docx_available:
+        st.caption("Client DOCX is unavailable until the optional `python-docx` dependency is installed.")
     if st.button("Build client package from ECM report", key="ecm_build_deliverable"):
         from wattlab.deliverables import package_deliverables
 
@@ -631,11 +641,14 @@ def render() -> None:
                 meta = package_deliverables(
                     out_dir=dest,
                     scorecard=sc,
-                    report=report,
+                    report={**report, "proxy_savings": proxies},
                     profile=profile,
+                    include_docx=include_docx,
                 )
                 st.session_state["studio_deliverable"] = meta
                 st.success(f"Package → {meta.get('out_dir')}")
+                if meta.get("docx_note"):
+                    st.caption(str(meta["docx_note"]))
             except Exception as exc:
                 st.error(str(exc))
     deliv = st.session_state.get("studio_deliverable") or {}

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
@@ -974,8 +975,15 @@ def render() -> None:
     )
     studio_report = st.session_state.get("studio_report") or {}
     profile = _profile() or {}
+    docx_available = find_spec("docx") is not None
     build_col, hint_col = st.columns([1, 2])
     with build_col:
+        include_docx = st.checkbox(
+            "Include client DOCX",
+            value=docx_available,
+            disabled=not docx_available,
+            key="twin_include_client_docx",
+        )
         build_clicked = st.button(
             "Build client package",
             key="twin_build_deliverable",
@@ -987,6 +995,8 @@ def render() -> None:
             "Uses the active Twin run + calibration scorecard when present. "
             "Agents can also run `wattlab calibrate-campaign` then refresh."
         )
+        if not docx_available:
+            st.caption("Client DOCX is unavailable until the optional `python-docx` dependency is installed.")
     if build_clicked:
         from wattlab.deliverables import package_deliverables
 
@@ -1016,11 +1026,18 @@ def render() -> None:
                     out_dir=dest,
                     run_dir=Path(run_src) if run_src else None,
                     scorecard=sc or {},
-                    report=studio_report or None,
+                    report={
+                        **studio_report,
+                        "proxy_savings": st.session_state.get("studio_proxies") or {},
+                    }
+                    or None,
                     profile=profile,
+                    include_docx=include_docx,
                 )
                 st.session_state["studio_deliverable"] = meta
                 st.success(f"Package ready → `{meta.get('out_dir')}`")
+                if meta.get("docx_note"):
+                    st.caption(str(meta["docx_note"]))
             except Exception as exc:
                 st.error(f"Deliverable build failed: {exc}")
 
@@ -1034,7 +1051,7 @@ def render() -> None:
             stamp = (deliv.get("stamp") or {})
             if stamp:
                 st.json(stamp, expanded=False)
-            d1, d2, d3 = st.columns(3)
+            d1, d2, d3, d4 = st.columns(4)
             d1.download_button(
                 "Report (.md)",
                 data=md_text.encode("utf-8"),
@@ -1051,9 +1068,18 @@ def render() -> None:
                     mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                     key="dl_workbook_xlsx",
                 )
+            docx_p = deliv.get("report_docx")
+            if docx_p and Path(str(docx_p)).is_file():
+                d3.download_button(
+                    "Client report (.docx)",
+                    data=Path(str(docx_p)).read_bytes(),
+                    file_name="Energy_Modeling_Report.docx",
+                    mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    key="dl_report_docx",
+                )
             zip_p = deliv.get("zip_path")
             if zip_p and Path(str(zip_p)).is_file():
-                d3.download_button(
+                d4.download_button(
                     "Full package (.zip)",
                     data=Path(str(zip_p)).read_bytes(),
                     file_name=Path(str(zip_p)).name,

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -1022,13 +1022,24 @@ def render() -> None:
             rid = (sc or {}).get("run_id") or (Path(run_src).name if run_src else "latest")
             dest = reports_dir() / f"deliverable_{rid}"
             try:
+                all_proxies = st.session_state.get("studio_proxies") or {}
+                plan_rows = (st.session_state.get("studio_capital_plan") or {}).get("measures") or []
+                active_ids = {str(r.get("measure_id")) for r in plan_rows if isinstance(r, dict)}
+                if not active_ids:
+                    scenario = st.session_state.get("ecm_easy__scenario_ids") or []
+                    active_ids = {str(x) for x in scenario}
+                proxy_for_pkg = (
+                    {k: v for k, v in all_proxies.items() if str(k) in active_ids}
+                    if active_ids
+                    else all_proxies
+                )
                 meta = package_deliverables(
                     out_dir=dest,
                     run_dir=Path(run_src) if run_src else None,
                     scorecard=sc or {},
                     report={
                         **studio_report,
-                        "proxy_savings": st.session_state.get("studio_proxies") or {},
+                        "proxy_savings": proxy_for_pkg,
                     }
                     or None,
                     profile=profile,

--- a/vibe_code_apps_20/wattlab/studio/proxies.py
+++ b/vibe_code_apps_20/wattlab/studio/proxies.py
@@ -35,6 +35,7 @@ DEFAULT_MEASURE_COSTS = {
     "ECM-BOILER-TUNE": 12000.0,
     "ECM-BOILER-RESET": 10000.0,
     "ECM-DCV-CO2": 18000.0,
+    "ECM-OCC-STANDBY-DCV": 24000.0,
     "ECM-ECON-REPAIR": 15000.0,
     "ECM-VAV-MIN-RESET": 20000.0,
 }
@@ -120,7 +121,35 @@ def _schedule_proxy(get, *, fan_kw: float, oa_cfm: float, kw_per_ton: float, bin
     }
 
 
-def estimate_proxy_savings(profile: dict[str, Any], measure_ids: list[str]) -> dict[str, dict[str, float]]:
+def _occ_standby_dcv_proxy(get, *, oa_cfm: float, kw_per_ton: float, bins, occupied) -> dict[str, Any]:
+    """Combine unoccupied damper closure with occupied DCV bin-method savings."""
+    unoccupied = {"shifts": [7, 0, 5], "days_per_week": 5}
+    common = {
+        "oa_cfm_total": oa_cfm,
+        "kw_per_ton": kw_per_ton,
+        "boiler_efficiency": PROXY_ASSUMPTIONS["boiler_efficiency"],
+        "bins": bins,
+    }
+    oad_cooling = get("oad_unoccupied_closed")({**common, "mode": "cooling", "vent_hours_schedule": unoccupied})
+    oad_heating = get("oad_unoccupied_closed")({**common, "mode": "heating", "vent_hours_schedule": unoccupied})
+    dcv = get("dcv_bins")(
+        {
+            "baseline_oa_cfm": oa_cfm,
+            "proposed_oa_cfm": oa_cfm * 0.65,
+            "kw_per_ton": kw_per_ton,
+            "boiler_efficiency": PROXY_ASSUMPTIONS["boiler_efficiency"],
+            "schedule": occupied,
+            "bins": bins,
+        }
+    )
+    return {
+        "savings_kwh": round(float(oad_cooling["savings_kwh"]) + float(dcv["savings_kwh"]), 1),
+        "savings_therms": round(float(oad_heating["savings_therms"]) + float(dcv["savings_therms"]), 1),
+        "calculators": ["oad_unoccupied_closed", "dcv_bins"],
+    }
+
+
+def estimate_proxy_savings(profile: dict[str, Any], measure_ids: list[str]) -> dict[str, dict[str, Any]]:
     """Screening proxy savings per measure from the ESCO bin calculators."""
     from wattlab.bench import runner  # noqa: F401  (registers calculators)
     from wattlab.bench.registry import get
@@ -144,7 +173,7 @@ def estimate_proxy_savings(profile: dict[str, Any], measure_ids: list[str]) -> d
     proposed = PROXY_ASSUMPTIONS["proposed_schedule"]
     capacity_mbh = max(area * 0.03, 500.0)  # screening plant capacity
 
-    out: dict[str, dict[str, float]] = {}
+    out: dict[str, dict[str, Any]] = {}
     for mid in measure_ids:
         try:
             if mid == "ECM-ERV" or (mid.endswith("-ERV") and "TOILET" not in mid):
@@ -255,6 +284,10 @@ def estimate_proxy_savings(profile: dict[str, Any], measure_ids: list[str]) -> d
                     }
                 )
                 out[mid] = {"savings_kwh": round(float(res["savings_kwh"]), 1), "savings_therms": 0.0}
+            elif mid == "ECM-OCC-STANDBY-DCV" or ("OCC-STANDBY" in mid and "DCV" in mid):
+                out[mid] = _occ_standby_dcv_proxy(
+                    get, oa_cfm=oa_cfm, kw_per_ton=kw_per_ton, bins=bins, occupied=proposed
+                )
             elif "DCV" in mid or mid in ("ECM-OA-RESET",) or "OA-RESET" in mid:
                 res = get("dcv_bins")(
                     {
@@ -269,6 +302,7 @@ def estimate_proxy_savings(profile: dict[str, Any], measure_ids: list[str]) -> d
                 out[mid] = {
                     "savings_kwh": round(float(res.get("savings_kwh") or 0.0), 1),
                     "savings_therms": round(float(res.get("savings_therms") or 0.0), 1),
+                    "calculators": ["dcv_bins"],
                 }
             elif "BOILER-RESET" in mid or mid == "ECM-BOILER-RESET":
                 res = get("hydronic_reset_bins")(

--- a/vibe_code_apps_20/wattlab/studio/templates/ecm_scenario.template.json
+++ b/vibe_code_apps_20/wattlab/studio/templates/ecm_scenario.template.json
@@ -1,7 +1,11 @@
 {
-  "version": 1,
+  "version": 2,
   "selected_ecm_ids": [],
   "measure_set": null,
+  "sort_preference": "implementation_complexity",
+  "package_hints": [],
+  "proxy_defaults": {},
+  "roi_param_hints": {},
   "notes": "",
   "recommendations": [],
   "status": "empty — waiting agent or Easy Buttons"


### PR DESCRIPTION
## Summary
- New catalog measure `ECM-OCC-STANDBY-DCV` (composite `oad_unoccupied_closed` + `dcv_bins`) in esco-top15 / controls packages
- Easy Buttons ranked by `implementation_complexity` (low→high) with complexity captions
- `ecm_scenario.json` v2 fields (`sort_preference`, package/proxy/ROI hints) with v1 backward compatibility
- Selectable client Energy Modeling DOCX in `package_deliverables` (ECMs + Twin UI checkboxes)
- Docs: ESCO calcs, Easy Buttons, coverage matrix, methods, interactions, `ecm_library` README
- `vibe20_agent_spec` tools/ESCO/deliverables/container/skills updated with real `ECM-*` ids

Design: `docs/superpowers/specs/2026-07-25-occ-standby-dcv-eng-findings-hardening-design.md`

Companion: vibe19 Eng Findings hardening in PR #45

## Test plan
- [x] `pytest tests/test_ecm_catalog.py tests/test_ecm_roi.py tests/test_ecm_ranking.py tests/test_studio_proxies_occ_standby.py tests/test_studio_status_deliverables.py` (21 passed)
- [ ] CodeRabbit review
- [ ] After merge: GHCR vibe20 refresh when path-filter fires; turnkey `:8520` — new ECM, complexity groups, DOCX in package when checked


Made with [Cursor](https://cursor.com)