### PR TITLE
feat(vibe19): Eng Findings VAV/FD agent knobs (BUG-019–024)

### DIFF
--- a/vibe_code_apps_19/app/report_downloads.py
+++ b/vibe_code_apps_19/app/report_downloads.py
@@ -76,6 +76,17 @@ def overview_context_from_session() -> dict[str, Any]:
     )
 
 
+def _resolve_batch_results(batch_results: list | None) -> list:
+    """Prefer explicit arg, else common session keys (BUG-024 cold-session path)."""
+    if batch_results:
+        return list(batch_results)
+    for key in ("batch_results", "rule_results", "last_rule_results"):
+        val = st.session_state.get(key)
+        if isinstance(val, list) and val:
+            return list(val)
+    return []
+
+
 def render_engineering_findings_panel(
     *,
     batch_results: list | None = None,
@@ -90,16 +101,84 @@ def render_engineering_findings_panel(
     st.caption(
         "Performs an automated evidence review of FDD/RCx rule results before presenting "
         "prioritized findings. Findings remain advisory and should be field-verified. "
-        "Detection ≠ finding — raw rule hits and likely false positives stay in the appendices."
+        "Detection ≠ finding — raw rule hits and likely false positives stay in the appendices. "
+        "Agent knobs: VAV scope, explicit raise past top-7, FAULT inventory."
     )
-    if not batch_results:
-        st.info("Run rules above first so FAULT rows are available for evidence review.")
-        return
+
+    results = _resolve_batch_results(batch_results)
+    if not results:
+        st.info(
+            "Run rules above first (or bootstrap with auto_run_rules) so FAULT rows are "
+            "available for evidence review. Filters below apply on Generate."
+        )
+
+    with st.expander("Agent / scope options (BUG-019–023)", expanded=bool(results)):
+        c1, c2 = st.columns(2)
+        with c1:
+            systems = st.text_input(
+                "Systems scope (CSV)",
+                value="",
+                placeholder="VAV",
+                key=f"{key_prefix}_systems",
+                help="Rank only these systems (e.g. VAV). Empty = default all.",
+            )
+            equip_prefix = st.text_input(
+                "Equipment prefix (CSV)",
+                value="",
+                placeholder="VAV",
+                key=f"{key_prefix}_prefix",
+            )
+            rule_ids = st.text_input(
+                "Rule IDs (CSV)",
+                value="",
+                placeholder="VAV-4,VAV-5,SV-FLATLINE",
+                key=f"{key_prefix}_rule_ids",
+            )
+            boost_terminal = st.checkbox(
+                "Boost terminal / VAV over plant",
+                value=False,
+                key=f"{key_prefix}_boost_terminal",
+            )
+        with c2:
+            max_findings = st.number_input(
+                "Max priority findings",
+                min_value=1,
+                max_value=50,
+                value=7,
+                key=f"{key_prefix}_max_findings",
+            )
+            allow_more = st.checkbox(
+                "Allow more than 7 priority findings (explicit raise)",
+                value=False,
+                key=f"{key_prefix}_allow_raise",
+                help="Required when max > 7 so the quality gate passes.",
+            )
+            allow_priority = None
+            if allow_more:
+                allow_priority = int(
+                    st.number_input(
+                        "Allow priority up to N",
+                        min_value=int(max_findings),
+                        max_value=50,
+                        value=int(max_findings),
+                        key=f"{key_prefix}_allow_priority",
+                    )
+                )
+            write_inventory = st.checkbox(
+                "Write FAULT inventory JSON",
+                value=True,
+                key=f"{key_prefix}_inventory",
+            )
+
+    gen_label = "Generate FDD Engineering Findings Report"
+    if systems.strip() or equip_prefix.strip() or rule_ids.strip():
+        gen_label = "Generate scoped FDD Engineering Findings Report"
 
     if st.button(
-        "Generate FDD Engineering Findings Report",
+        gen_label,
         key=f"{key_prefix}_generate",
         type="primary",
+        disabled=not results,
     ):
         try:
             import docx  # noqa: F401
@@ -115,6 +194,7 @@ def render_engineering_findings_panel(
                     build_engineering_findings,
                     render_engineering_report,
                 )
+                from app.reporting.scope import FindingScope
 
                 ctx = overview_context
                 if ctx is None:
@@ -122,11 +202,21 @@ def render_engineering_findings_panel(
                         ctx = overview_context_from_session()
                     except Exception:
                         ctx = None
+                scope = FindingScope.from_cli(
+                    systems=systems or None,
+                    equipment_prefix=equip_prefix or None,
+                    rule_ids=rule_ids or None,
+                    boost_terminal=bool(boost_terminal),
+                )
                 art = build_engineering_findings(
                     building=building_name or "Building",
                     analysis_period=analysis_period,
-                    rule_results=list(batch_results),
+                    rule_results=list(results),
                     overview_context=ctx,
+                    max_findings=int(max_findings),
+                    allow_priority=allow_priority,
+                    scope=scope,
+                    write_inventory=bool(write_inventory),
                 )
                 buf_dir = Path(
                     st.session_state.get("_eng_findings_tmpdir")
@@ -141,7 +231,8 @@ def render_engineering_findings_panel(
                     json_out=True,
                     charts=True,
                     overview_context=ctx,
-                    rule_results=list(batch_results),
+                    rule_results=list(results),
+                    write_inventory=bool(write_inventory),
                 )
                 st.session_state[f"{key_prefix}_artifacts"] = art
                 st.session_state[f"{key_prefix}_written"] = {
@@ -165,6 +256,25 @@ def render_engineering_findings_panel(
         st.warning("Quality gate errors: " + "; ".join(art.quality_gate["errors"]))
     if art.quality_gate.get("warnings"):
         st.caption("Warnings: " + "; ".join(art.quality_gate["warnings"]))
+
+    # Day-zoom visibility (BUG-022)
+    missing_zoom = [
+        f
+        for f in art.findings
+        if f.include_in_report and not f.day_zoom_path and f.day_zoom_skip_reason
+    ]
+    if missing_zoom:
+        with st.expander(f"Day-zoom unavailable ({len(missing_zoom)})", expanded=False):
+            for f in missing_zoom:
+                st.caption(f"{f.finding_id}: {f.day_zoom_label or f.day_zoom_skip_reason}")
+
+    inv = getattr(art, "fault_inventory", None) or {}
+    if inv.get("n_orphans"):
+        st.caption(
+            f"FAULT inventory: {inv.get('n_faults')} FAULTs · "
+            f"{inv.get('n_in_priority')} in priority · "
+            f"{inv.get('n_orphans')} orphans (not in DOCX body)"
+        )
 
     st.markdown("##### Engineer review (optional)")
     for f in art.findings:
@@ -192,6 +302,7 @@ def render_engineering_findings_panel(
 
     jp = written.get("json")
     dp = written.get("docx")
+    ip = written.get("fault_inventory")
     if jp and Path(jp).is_file():
         Path(jp).write_text(json.dumps(art.to_dict(), indent=2) + "\n", encoding="utf-8")
         st.download_button(
@@ -200,6 +311,14 @@ def render_engineering_findings_panel(
             file_name=Path(jp).name,
             mime="application/json",
             key=f"{key_prefix}_dl_json",
+        )
+    if ip and Path(ip).is_file():
+        st.download_button(
+            "Download FAULT inventory JSON",
+            data=Path(ip).read_bytes(),
+            file_name=Path(ip).name,
+            mime="application/json",
+            key=f"{key_prefix}_dl_inv",
         )
     if dp and Path(dp).is_file():
         st.download_button(

--- a/vibe_code_apps_19/app/reporting/cli.py
+++ b/vibe_code_apps_19/app/reporting/cli.py
@@ -54,32 +54,118 @@ def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(
         description=(
             "Generate an FDD Engineering Findings Report (evidence-reviewed). "
-            "Detection ≠ finding; likely false positives stay in Appendix C."
+            "Detection ≠ finding; likely false positives stay in Appendix C. "
+            "Agent knobs: --systems / --equipment-prefix / --rule-ids / "
+            "--allow-priority / --pin-finding / --drop-finding / --write-inventory."
         )
     )
     p.add_argument("--checklist-json", type=Path, help="controls_service_checklist JSON")
     p.add_argument("--dump", type=Path, help="WattLab dump / vibe19 package zip or folder")
+    p.add_argument("--package", type=Path, help="Alias for --dump (agent-friendly)")
     p.add_argument("--building", default="", help="Override building name")
-    p.add_argument("--out-dir", type=Path, required=True)
+    p.add_argument("--out-dir", type=Path, help="Output directory")
+    p.add_argument("--out", type=Path, help="Alias for --out-dir")
     p.add_argument("--docx", action="store_true")
     p.add_argument("--json", action="store_true", dest="json_out")
     p.add_argument("--no-charts", action="store_true")
-    p.add_argument("--max-findings", type=int, default=7)
+    p.add_argument("--max-findings", type=int, default=7, help="Priority pack size (default 7)")
+    p.add_argument(
+        "--allow-priority",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Explicit raise: authorize up to N priority findings (quality gate). "
+        "Required when --max-findings > 7.",
+    )
+    p.add_argument(
+        "--raise-max-findings",
+        action="store_true",
+        help="Shorthand: set --allow-priority to the same value as --max-findings",
+    )
+    p.add_argument("--systems", default="", help="Scope systems CSV e.g. VAV or VAV,AHU (BUG-019)")
+    p.add_argument(
+        "--equipment-prefix",
+        default="",
+        help="Scope equipment id prefixes CSV e.g. VAV (BUG-019)",
+    )
+    p.add_argument(
+        "--rule-ids",
+        default="",
+        help="Scope exact cookbook rule ids CSV e.g. VAV-4,VAV-5,SV-FLATLINE (BUG-019)",
+    )
+    p.add_argument(
+        "--boost-terminal",
+        action="store_true",
+        help="Prefer VAV/terminal FAULTs over plant when ranking (BUG-019)",
+    )
+    p.add_argument(
+        "--pin-finding",
+        action="append",
+        default=[],
+        metavar="REF",
+        help="Force-include finding (equipment:rule or equipment|rule). Repeatable (BUG-021)",
+    )
+    p.add_argument(
+        "--drop-finding",
+        action="append",
+        default=[],
+        metavar="REF",
+        help="Exclude finding from priority even if ranked high. Repeatable (BUG-021)",
+    )
+    p.add_argument(
+        "--note",
+        action="append",
+        default=[],
+        metavar="REF=TEXT",
+        help="Attach field note (BUG-021). Repeatable.",
+    )
+    p.add_argument("--notes-file", type=Path, help="JSON object of ref → note (BUG-021)")
+    p.add_argument(
+        "--write-inventory",
+        action="store_true",
+        default=True,
+        help="Write FAULT inventory JSON alongside report (default on) (BUG-023)",
+    )
+    p.add_argument("--no-inventory", action="store_true", help="Skip FAULT inventory export")
     p.add_argument("--run-rules", action="store_true", help="With --dump, also run cookbook FAULTs")
     args = p.parse_args(argv)
 
-    if not args.checklist_json and not args.dump:
-        p.error("Provide --checklist-json and/or --dump")
+    dump = args.dump or args.package
+    out_dir = args.out_dir or args.out
+    if out_dir is None:
+        p.error("Provide --out-dir / --out")
+    if not args.checklist_json and not dump:
+        p.error("Provide --checklist-json and/or --dump/--package")
 
+    allow_priority = args.allow_priority
+    if args.raise_max_findings:
+        allow_priority = args.max_findings
+
+    from app.reporting.hitl import load_notes_file, parse_note_arg
     from app.reporting.pipeline import build_engineering_findings, render_engineering_report
+    from app.reporting.scope import FindingScope
+
+    notes: dict[str, str] = {}
+    if args.notes_file:
+        notes.update(load_notes_file(args.notes_file))
+    for raw in args.note or []:
+        ref, text = parse_note_arg(raw)
+        notes[ref] = text
+
+    scope = FindingScope.from_cli(
+        systems=args.systems or None,
+        equipment_prefix=args.equipment_prefix or None,
+        rule_ids=args.rule_ids or None,
+        boost_terminal=bool(args.boost_terminal),
+    )
 
     rule_results = None
     overview_context = None
     building = args.building
-    if args.dump:
+    if dump:
         from app.agent_api import load_package_path, run_rules
 
-        ds = load_package_path(args.dump)
+        ds = load_package_path(dump)
         building = building or getattr(ds, "building_id", "") or ""
         try:
             overview_context = _overview_context_from_dataset(ds)
@@ -90,21 +176,29 @@ def main(argv: list[str] | None = None) -> int:
             run = run_rules(ds)
             rule_results = run.results
 
+    write_inv = bool(args.write_inventory) and not args.no_inventory
     artifacts = build_engineering_findings(
         building=building,
         checklist=args.checklist_json,
         rule_results=rule_results,
         overview_context=overview_context,
         max_findings=args.max_findings,
+        allow_priority=allow_priority,
+        scope=scope,
+        pin_findings=list(args.pin_finding or []),
+        drop_findings=list(args.drop_finding or []),
+        notes=notes,
+        write_inventory=write_inv,
     )
     written = render_engineering_report(
         artifacts,
-        args.out_dir,
+        out_dir,
         docx=args.docx,
         json_out=args.json_out or not args.docx,
         charts=not args.no_charts,
         overview_context=overview_context,
         rule_results=rule_results,
+        write_inventory=write_inv,
     )
     print(json.dumps({k: str(v) for k, v in written.items()}, indent=2))
     print("metrics", json.dumps(artifacts.metrics))

--- a/vibe_code_apps_19/app/reporting/fault_inventory.py
+++ b/vibe_code_apps_19/app/reporting/fault_inventory.py
@@ -1,0 +1,122 @@
+"""FAULT inventory export — orphans / suppressed terminal faults (BUG-023)."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from app.reporting.scope import equipment_system
+from app.reporting.models import CandidateDetection, EngineeringFinding
+
+
+def build_fault_inventory(
+    candidates: list[CandidateDetection] | list[dict[str, Any]],
+    findings: list[EngineeringFinding],
+    *,
+    suppressed: list[dict[str, Any]] | None = None,
+    statuses: set[str] | None = None,
+) -> dict[str, Any]:
+    """List FAULT (or configured) detections with in_priority + suppressed_reason."""
+    want = {s.upper() for s in (statuses or {"FAULT"})}
+    priority_keys: set[str] = set()
+    for f in findings:
+        if not f.include_in_report:
+            continue
+        for k in f.candidate_keys or []:
+            priority_keys.add(k)
+        for eid in f.equipment_ids or []:
+            for rid in f.rule_ids or []:
+                priority_keys.add(f"{eid}|{rid}")
+
+    suppress_by_key: dict[str, str] = {}
+    for row in suppressed or []:
+        key = str(row.get("candidate_key") or "")
+        reasons = row.get("reasons") or []
+        reason = "; ".join(str(r) for r in reasons) if reasons else str(row.get("classification") or "suppressed")
+        if key:
+            for part in key.split(","):
+                part = part.strip()
+                if part:
+                    suppress_by_key[part] = reason
+
+    rows: list[dict[str, Any]] = []
+    for raw in candidates:
+        if isinstance(raw, CandidateDetection):
+            c = raw
+            status = (c.status or "").upper()
+            eid = c.equipment_id
+            rid = c.rule_id
+            et = c.equipment_type
+            hours = c.fault_hours
+            samples = c.sample_count
+            key = c.key
+        else:
+            status = str(raw.get("status") or "").upper()
+            eid = str(raw.get("equipment_id") or "")
+            rid = str(raw.get("rule_id") or "")
+            et = str(raw.get("equipment_type") or "")
+            hours = raw.get("fault_hours")
+            samples = int(raw.get("sample_count") or 0)
+            key = str(raw.get("key") or f"{eid}|{rid}")
+        if status and status not in want:
+            continue
+        in_priority = key in priority_keys
+        suppressed_reason = None
+        if not in_priority:
+            suppressed_reason = suppress_by_key.get(key) or "not_in_priority_pack"
+        sys = equipment_system(et, rid)
+        prefix = _equip_prefix(eid)
+        rows.append(
+            {
+                "equipment": eid,
+                "equipment_prefix": prefix,
+                "system": sys,
+                "rule_id": rid,
+                "status": status or "FAULT",
+                "fault_samples": samples,
+                "fault_hours": hours,
+                "in_priority": in_priority,
+                "suppressed_reason": suppressed_reason,
+                "candidate_key": key,
+            }
+        )
+
+    by_rule: dict[str, dict[str, Any]] = defaultdict(lambda: {"count": 0, "fault_hours": 0.0, "in_priority": 0})
+    by_prefix: dict[str, dict[str, Any]] = defaultdict(lambda: {"count": 0, "fault_hours": 0.0, "in_priority": 0})
+    for r in rows:
+        br = by_rule[r["rule_id"]]
+        br["count"] += 1
+        br["fault_hours"] += float(r["fault_hours"] or 0)
+        br["in_priority"] += 1 if r["in_priority"] else 0
+        bp = by_prefix[r["equipment_prefix"]]
+        bp["count"] += 1
+        bp["fault_hours"] += float(r["fault_hours"] or 0)
+        bp["in_priority"] += 1 if r["in_priority"] else 0
+
+    orphans = [r for r in rows if not r["in_priority"]]
+    orphans_sorted = sorted(orphans, key=lambda x: -float(x["fault_hours"] or 0))
+
+    return {
+        "rows": rows,
+        "orphans": orphans_sorted,
+        "rollup_by_rule_id": dict(by_rule),
+        "rollup_by_equipment_prefix": dict(by_prefix),
+        "n_faults": len(rows),
+        "n_in_priority": sum(1 for r in rows if r["in_priority"]),
+        "n_orphans": len(orphans),
+    }
+
+
+def _equip_prefix(eid: str) -> str:
+    s = (eid or "").upper()
+    if not s:
+        return "OTHER"
+    # VAV_22 → VAV; AHU-1 → AHU; CHW_PLANT → CHW
+    for sep in ("_", "-", " "):
+        if sep in s:
+            return s.split(sep, 1)[0]
+    # strip trailing digits
+    i = len(s)
+    while i > 0 and s[i - 1].isdigit():
+        i -= 1
+    return s[:i] if i else s

--- a/vibe_code_apps_19/app/reporting/fault_inventory.py
+++ b/vibe_code_apps_19/app/reporting/fault_inventory.py
@@ -22,11 +22,14 @@ def build_fault_inventory(
     for f in findings:
         if not f.include_in_report:
             continue
-        for k in f.candidate_keys or []:
-            priority_keys.add(k)
-        for eid in f.equipment_ids or []:
-            for rid in f.rule_ids or []:
-                priority_keys.add(f"{eid}|{rid}")
+        keys = list(f.candidate_keys or [])
+        if keys:
+            priority_keys.update(keys)
+        else:
+            # Legacy / pin edge case: only then fall back to equipment×rule pairs
+            for eid in f.equipment_ids or []:
+                for rid in f.rule_ids or []:
+                    priority_keys.add(f"{eid}|{rid}")
 
     suppress_by_key: dict[str, str] = {}
     for row in suppressed or []:

--- a/vibe_code_apps_19/app/reporting/findings.py
+++ b/vibe_code_apps_19/app/reporting/findings.py
@@ -18,6 +18,12 @@ from app.reporting.narrative import (
     why_it_matters,
 )
 from app.reporting.rule_meta import is_duct_static_rule
+from app.reporting.scope import (
+    FindingScope,
+    filter_candidates,
+    sort_key_for_finding,
+    equipment_system,
+)
 
 CLIENT_CLASSIFICATIONS = {
     Classification.STRONGLY_SUPPORTED,
@@ -34,11 +40,30 @@ def cluster_and_prioritize(
     assessments: dict[str, FindingAssessment],
     *,
     max_findings: int = MAX_PRIORITY_FINDINGS,
+    scope: FindingScope | None = None,
 ) -> tuple[list[EngineeringFinding], list[dict[str, Any]], list[dict[str, Any]]]:
     """Return (priority findings, suppressed rows, data_quality rows)."""
-    by_key = {c.key: c for c in candidates}
+    # Scope filter affects ranking inputs (BUG-019) — not a post-DOCX filter.
+    scoped = filter_candidates(candidates, scope)
+    scoped_keys = {c.key for c in scoped}
+    by_key = {c.key: c for c in scoped}
     suppressed: list[dict[str, Any]] = []
     data_quality: list[dict[str, Any]] = []
+
+    for c in candidates:
+        if c.key in scoped_keys:
+            continue
+        a = assessments.get(c.key)
+        suppressed.append(
+            {
+                "candidate_key": c.key,
+                "classification": (a.classification.value if a else "OUT_OF_SCOPE"),
+                "score": a.score if a else None,
+                "reasons": [f"Out of report scope ({_scope_label(scope)})"],
+                "equipment_id": c.equipment_id,
+                "rule_id": c.rule_id,
+            }
+        )
 
     # Group keys for clustering
     clusters: dict[str, list[str]] = defaultdict(list)
@@ -100,7 +125,7 @@ def cluster_and_prioritize(
         fid += 1
         equip_ids = sorted({m.equipment_id for m in members})
         rule_ids = sorted({m.rule_id for m in members})
-        systems = sorted({_system(m.equipment_type, m.rule_id) for m in members})
+        systems = sorted({equipment_system(m.equipment_type, m.rule_id) for m in members})
 
         # Common-mode VAV: one finding
         title = finding_title(members, best)
@@ -145,8 +170,8 @@ def cluster_and_prioritize(
             )
         )
 
-    # Keep top max_findings for client body; rest → suppressed as lower priority
-    findings.sort(key=lambda f: (-_cls_rank(f.classification), -float(f.automated_assessment.get("score") or 0)))
+    boost = bool(scope and scope.boost_terminal)
+    findings.sort(key=lambda f: sort_key_for_finding(f, boost_terminal=boost))
     for i, f in enumerate(findings, 1):
         f.priority = i
         f.finding_id = f"F{i:02d}"
@@ -164,6 +189,19 @@ def cluster_and_prioritize(
             }
         )
     return primary, suppressed, data_quality
+
+
+def _scope_label(scope: FindingScope | None) -> str:
+    if scope is None:
+        return "none"
+    parts = []
+    if scope.systems:
+        parts.append("systems=" + ",".join(scope.systems))
+    if scope.equipment_prefixes:
+        parts.append("prefix=" + ",".join(scope.equipment_prefixes))
+    if scope.rule_ids:
+        parts.append("rules=" + ",".join(scope.rule_ids))
+    return "; ".join(parts) or "none"
 
 
 def _cluster_id(c: CandidateDetection, a: FindingAssessment) -> str:
@@ -199,16 +237,8 @@ def _cls_rank(c: Classification) -> int:
 
 
 def _system(equipment_type: str, rule_id: str) -> str:
-    et = (equipment_type or "").upper()
-    if "AHU" in et or rule_id.startswith("SCHED") or rule_id == "FAN-OFF-STATIC":
-        return "AHU"
-    if "CHILL" in et or rule_id.startswith("CHW"):
-        return "CHW"
-    if "BOIL" in et or rule_id.startswith("HW"):
-        return "HW"
-    if "VAV" in et or rule_id.startswith("VAV"):
-        return "VAV"
-    return et or "Other"
+    """Back-compat alias — prefer ``equipment_system``."""
+    return equipment_system(equipment_type, rule_id)
 
 
 def _chart_spec_for(c: CandidateDetection, packet: EvidencePacket | None) -> dict[str, Any] | None:

--- a/vibe_code_apps_19/app/reporting/hitl.py
+++ b/vibe_code_apps_19/app/reporting/hitl.py
@@ -1,0 +1,176 @@
+"""HITL pin / drop / note overrides for Engineering Findings (BUG-021)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.reporting.models import (
+    CandidateDetection,
+    Classification,
+    EngineeringFinding,
+    FindingAssessment,
+)
+
+
+def normalize_finding_ref(raw: str) -> str:
+    """Accept ``equipment|rule``, ``equipment:rule``, or bare finding_id / equipment."""
+    s = (raw or "").strip()
+    if not s:
+        return ""
+    if ":" in s and "|" not in s:
+        left, right = s.split(":", 1)
+        return f"{left.strip()}|{right.strip()}"
+    return s
+
+
+def parse_note_arg(raw: str) -> tuple[str, str]:
+    """``id=text`` → (ref, note)."""
+    s = (raw or "").strip()
+    if "=" not in s:
+        raise ValueError(f"Note must be id=text, got: {raw!r}")
+    left, right = s.split("=", 1)
+    return normalize_finding_ref(left), right.strip()
+
+
+def load_notes_file(path: Path | str | None) -> dict[str, str]:
+    if not path:
+        return {}
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(str(p))
+    data = json.loads(p.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Notes file must be a JSON object of ref → note")
+    return {normalize_finding_ref(str(k)): str(v) for k, v in data.items()}
+
+
+def _refs_match_finding(ref: str, f: EngineeringFinding) -> bool:
+    if not ref:
+        return False
+    if ref == f.finding_id:
+        return True
+    if ref in (f.candidate_keys or []):
+        return True
+    if "|" in ref:
+        eid, rid = ref.split("|", 1)
+        if eid in (f.equipment_ids or []) and rid in (f.rule_ids or []):
+            return True
+        return False
+    # bare equipment id
+    return ref in (f.equipment_ids or [])
+
+
+def _refs_match_candidate(ref: str, c: CandidateDetection) -> bool:
+    if not ref:
+        return False
+    if ref == c.key or ref == c.equipment_id:
+        return True
+    if "|" in ref:
+        eid, rid = ref.split("|", 1)
+        return c.equipment_id == eid and c.rule_id == rid
+    return False
+
+
+def apply_hitl_overrides(
+    findings: list[EngineeringFinding],
+    *,
+    pin_refs: list[str] | None = None,
+    drop_refs: list[str] | None = None,
+    notes: dict[str, str] | None = None,
+    candidates: list[CandidateDetection] | None = None,
+    assessments: dict[str, FindingAssessment] | None = None,
+    suppressed: list[dict[str, Any]] | None = None,
+) -> list[EngineeringFinding]:
+    """Apply pin / drop / notes. Pins force ``include_in_report`` and may promote orphans."""
+    pins = [normalize_finding_ref(x) for x in (pin_refs or []) if x]
+    drops = [normalize_finding_ref(x) for x in (drop_refs or []) if x]
+    note_map = {normalize_finding_ref(k): v for k, v in (notes or {}).items()}
+    out = list(findings)
+    by_key = {c.key: c for c in (candidates or [])}
+    assessments = assessments or {}
+
+    # Promote pinned candidates missing from priority pack
+    existing_keys = {k for f in out for k in (f.candidate_keys or [])}
+    for ref in pins:
+        if any(_refs_match_finding(ref, f) for f in out):
+            continue
+        cand = None
+        if ref in by_key:
+            cand = by_key[ref]
+        else:
+            for c in by_key.values():
+                if _refs_match_candidate(ref, c):
+                    cand = c
+                    break
+        if cand is None:
+            continue
+        if cand.key in existing_keys:
+            continue
+        a = assessments.get(cand.key)
+        score = float(a.score) if a else float(cand.fault_hours or 0)
+        cls = a.classification if a else Classification.PROBABLE
+        fid = f"PIN{len(out)+1:02d}"
+        title = f"{cand.equipment_id} · {cand.rule_id} (pinned)"
+        promoted = EngineeringFinding(
+            finding_id=fid,
+            title=title,
+            classification=cls,
+            priority=len(out) + 1,
+            why_it_matters="Pinned by engineer / agent for field follow-up.",
+            observed_behavior=cand.notes or f"FAULT hours≈{cand.fault_hours}",
+            evidence_bullets=(a.supporting[:4] if a and a.supporting else [f"Pinned candidate {cand.key}"]),
+            contradicting_evidence=(a.contradicting[:2] if a else []) or ["None material in automated review"],
+            likely_causes=(a.likely_causes[:3] if a else []) or ["Verify in field"],
+            field_verification=(a.field_verification[:3] if a else []) or [f"Inspect {cand.equipment_id}"],
+            possible_corrective=["Do not replace equipment solely from this telemetry review — complete field verification first"],
+            rule_ids=[cand.rule_id],
+            equipment_ids=[cand.equipment_id],
+            systems=[_guess_system(cand)],
+            candidate_keys=[cand.key],
+            automated_assessment=(a.to_dict() if a else {"score": score, "pinned": True}),
+            include_in_report=True,
+            data_confidence_notes=["Pinned via --pin-finding / HITL"],
+            engineer_override={"pinned": True, "automated_classification": cls.value},
+        )
+        out.append(promoted)
+        existing_keys.add(cand.key)
+        if suppressed is not None:
+            suppressed[:] = [
+                row
+                for row in suppressed
+                if cand.key not in str(row.get("candidate_key") or "")
+            ]
+
+    for f in out:
+        if any(_refs_match_finding(ref, f) for ref in pins):
+            f.include_in_report = True
+            ov = dict(f.engineer_override or {})
+            ov["pinned"] = True
+            f.engineer_override = ov
+        if any(_refs_match_finding(ref, f) for ref in drops):
+            f.include_in_report = False
+            ov = dict(f.engineer_override or {})
+            ov["dropped"] = True
+            f.engineer_override = ov
+        for ref, text in note_map.items():
+            if _refs_match_finding(ref, f) and text:
+                ov = dict(f.engineer_override or {})
+                ov["note"] = text
+                ov.setdefault("automated_classification", f.classification.value)
+                f.engineer_override = ov
+
+    # Re-number included priority slots for stable F01…
+    included = [f for f in out if f.include_in_report]
+    for i, f in enumerate(included, 1):
+        f.priority = i
+        if not str(f.finding_id).startswith("PIN"):
+            f.finding_id = f"F{i:02d}"
+    return out
+
+
+def _guess_system(c: CandidateDetection) -> str:
+    from app.reporting.scope import equipment_system
+
+    return equipment_system(c.equipment_type, c.rule_id)

--- a/vibe_code_apps_19/app/reporting/hitl.py
+++ b/vibe_code_apps_19/app/reporting/hitl.py
@@ -51,13 +51,12 @@ def _refs_match_finding(ref: str, f: EngineeringFinding) -> bool:
         return False
     if ref == f.finding_id:
         return True
-    if ref in (f.candidate_keys or []):
+    keys = list(f.candidate_keys or [])
+    if ref in keys:
         return True
     if "|" in ref:
-        eid, rid = ref.split("|", 1)
-        if eid in (f.equipment_ids or []) and rid in (f.rule_ids or []):
-            return True
-        return False
+        # Exact equipment|rule membership only (avoid cluster cross-product false hits)
+        return ref in keys
     # bare equipment id
     return ref in (f.equipment_ids or [])
 

--- a/vibe_code_apps_19/app/reporting/models.py
+++ b/vibe_code_apps_19/app/reporting/models.py
@@ -170,6 +170,8 @@ class EngineeringFinding:
         d = asdict(self)
         d["classification"] = self.classification.value
         d["effective_classification"] = self.effective_classification.value
+        # BUG-022 alias for agents expecting day_zoom_error
+        d["day_zoom_error"] = self.day_zoom_skip_reason
         return d
 
 
@@ -191,6 +193,7 @@ class ReportArtifacts:
     charts: list[dict[str, Any]] = field(default_factory=list)
     overview_settings: dict[str, Any] = field(default_factory=dict)
     overview_charts: list[dict[str, Any]] = field(default_factory=list)
+    fault_inventory: dict[str, Any] = field(default_factory=dict)
     disclaimer: str = (
         "Open-FDD / Vibe 19 educational analysis. Findings are telemetry-based "
         "and advisory; physical verification remains a human/field activity."
@@ -214,5 +217,6 @@ class ReportArtifacts:
             "charts": self.charts,
             "overview_settings": self.overview_settings,
             "overview_charts": self.overview_charts,
+            "fault_inventory": self.fault_inventory,
             "disclaimer": self.disclaimer,
         }

--- a/vibe_code_apps_19/app/reporting/pipeline.py
+++ b/vibe_code_apps_19/app/reporting/pipeline.py
@@ -151,11 +151,12 @@ def build_engineering_findings(
                         "rule_id": ",".join(f.rule_ids),
                     }
                 )
-    # Stable F-ids for included
+    # Stable F-ids for included (preserve PIN* promotions from HITL)
     included_final = [f for f in findings if f.include_in_report]
     for i, f in enumerate(included_final, 1):
         f.priority = i
-        f.finding_id = f"F{i:02d}"
+        if not str(f.finding_id).startswith("PIN"):
+            f.finding_id = f"F{i:02d}"
 
     field_checklist: list[str] = []
     for f in included_final:

--- a/vibe_code_apps_19/app/reporting/pipeline.py
+++ b/vibe_code_apps_19/app/reporting/pipeline.py
@@ -17,13 +17,16 @@ from app.reporting.candidates import (
 )
 from app.reporting.charts import build_report_charts
 from app.reporting.evidence import build_evidence_packet
+from app.reporting.fault_inventory import build_fault_inventory
 from app.reporting.findings import cluster_and_prioritize
+from app.reporting.hitl import apply_hitl_overrides, load_notes_file, parse_note_arg
 from app.reporting.models import (
     Classification,
     ReportArtifacts,
 )
 from app.reporting.quality_gate import run_quality_gate
 from app.reporting.reviewer import review_evidence_packet
+from app.reporting.scope import FindingScope, scope_to_dict
 from app.rules.base import RuleResult
 
 
@@ -37,6 +40,12 @@ def build_engineering_findings(
     context: dict[str, Any] | None = None,
     overview_context: dict[str, Any] | None = None,
     max_findings: int = 7,
+    allow_priority: int | None = None,
+    scope: FindingScope | None = None,
+    pin_findings: list[str] | None = None,
+    drop_findings: list[str] | None = None,
+    notes: dict[str, str] | None = None,
+    write_inventory: bool = True,
 ) -> ReportArtifacts:
     """Calculate assessments and prioritized findings (no DOCX yet)."""
     ctx = dict(context or {})
@@ -99,16 +108,64 @@ def build_engineering_findings(
         packets[c.key] = pkt
         assessments[c.key] = review_evidence_packet(pkt)
 
+    # When pinning orphans, temporarily allow a wider cluster cut so HITL can promote
+    cluster_cap = max_findings
+    if pin_findings:
+        cluster_cap = max(max_findings, min(len(cands), max_findings + len(pin_findings) + 5))
+
     findings, suppressed, data_quality = cluster_and_prioritize(
-        cands, packets, assessments, max_findings=max_findings
+        cands,
+        packets,
+        assessments,
+        max_findings=cluster_cap,
+        scope=scope,
     )
 
+    findings = apply_hitl_overrides(
+        findings,
+        pin_refs=pin_findings,
+        drop_refs=drop_findings,
+        notes=notes,
+        candidates=cands,
+        assessments=assessments,
+        suppressed=suppressed,
+    )
+
+    # Enforce max_findings on included set while always keeping pins
+    included = [f for f in findings if f.include_in_report]
+    pinned = [f for f in included if (f.engineer_override or {}).get("pinned")]
+    others = [f for f in included if f not in pinned]
+    keep = pinned + others
+    if len(keep) > max_findings:
+        keep_set = set(id(x) for x in (pinned + others[: max(0, max_findings - len(pinned))]))
+        for f in findings:
+            if f.include_in_report and id(f) not in keep_set:
+                f.include_in_report = False
+                suppressed.append(
+                    {
+                        "candidate_key": ",".join(f.candidate_keys),
+                        "classification": f.classification.value,
+                        "score": f.automated_assessment.get("score"),
+                        "reasons": [f"Deprioritized beyond top {max_findings}: {f.title}"],
+                        "equipment_id": ",".join(f.equipment_ids),
+                        "rule_id": ",".join(f.rule_ids),
+                    }
+                )
+    # Stable F-ids for included
+    included_final = [f for f in findings if f.include_in_report]
+    for i, f in enumerate(included_final, 1):
+        f.priority = i
+        f.finding_id = f"F{i:02d}"
+
     field_checklist: list[str] = []
-    for f in findings:
+    for f in included_final:
         field_checklist.extend(f.field_verification)
-    # unique preserve order
     seen: set[str] = set()
     field_checklist = [x for x in field_checklist if not (x in seen or seen.add(x))][:12]
+
+    inv: dict[str, Any] = {}
+    if write_inventory:
+        inv = build_fault_inventory(cands, findings, suppressed=suppressed)
 
     metrics = {
         "n_candidates": len(cands),
@@ -121,7 +178,10 @@ def build_engineering_findings(
         ),
         "n_suppressed": len(suppressed),
         "n_data_quality": len(data_quality),
-        "n_priority_findings": len(findings),
+        "n_priority_findings": len(included_final),
+        "max_findings": max_findings,
+        "allow_priority": allow_priority,
+        "scope": scope_to_dict(scope),
     }
 
     artifacts = ReportArtifacts(
@@ -142,11 +202,14 @@ def build_engineering_findings(
             "near_continuous_pct": 95.0,
             "evidence_score": "Explainable engineering score — not probability",
             "detection_vs_finding": "Rule hits are candidates until evidence review",
+            "allow_priority": allow_priority,
+            "scope": scope_to_dict(scope),
         },
         quality_gate={},
         overview_settings=overview_settings,
+        fault_inventory=inv,
     )
-    artifacts.quality_gate = run_quality_gate(artifacts)
+    artifacts.quality_gate = run_quality_gate(artifacts, allow_priority=allow_priority)
     return artifacts
 
 
@@ -160,6 +223,7 @@ def render_engineering_report(
     basename: str | None = None,
     overview_context: dict[str, Any] | None = None,
     rule_results: list[RuleResult] | None = None,
+    write_inventory: bool = True,
 ) -> dict[str, Path]:
     """Write JSON / DOCX / chart assets. Raises if quality gate fails critically."""
     out_dir = Path(out_dir)
@@ -176,8 +240,9 @@ def render_engineering_report(
             overview_context=overview_context,
             rule_results=rule_results,
         )
-        # re-run gate after charts attached
-        artifacts.quality_gate = run_quality_gate(artifacts)
+        # re-run gate after charts / day-zoom attached
+        allow = (artifacts.metrics or {}).get("allow_priority")
+        artifacts.quality_gate = run_quality_gate(artifacts, allow_priority=allow)
 
     if not artifacts.quality_gate.get("ok"):
         # Allow DOCX with warnings only; hard-fail on errors
@@ -187,6 +252,11 @@ def render_engineering_report(
         jp = out_dir / f"{base}.json"
         jp.write_text(json.dumps(artifacts.to_dict(), indent=2) + "\n", encoding="utf-8")
         written["json"] = jp
+
+    if write_inventory and artifacts.fault_inventory:
+        ip = out_dir / f"{base}_fault_inventory.json"
+        ip.write_text(json.dumps(artifacts.fault_inventory, indent=2) + "\n", encoding="utf-8")
+        written["fault_inventory"] = ip
 
     if docx:
         from app.reporting.docx import render_docx
@@ -203,3 +273,12 @@ def render_engineering_report(
 
 def _safe_name(s: str) -> str:
     return "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in s)[:80] or "Building"
+
+
+# Re-export helpers used by CLI
+__all__ = [
+    "build_engineering_findings",
+    "render_engineering_report",
+    "load_notes_file",
+    "parse_note_arg",
+]

--- a/vibe_code_apps_19/app/reporting/quality_gate.py
+++ b/vibe_code_apps_19/app/reporting/quality_gate.py
@@ -47,14 +47,34 @@ def _has_proactive_replace(corrective: list[str] | None) -> bool:
     return False
 
 
-def run_quality_gate(artifacts: ReportArtifacts) -> dict[str, Any]:
-    """Return {ok, errors, warnings}. Reject if critical errors."""
+def run_quality_gate(
+    artifacts: ReportArtifacts,
+    *,
+    allow_priority: int | None = None,
+) -> dict[str, Any]:
+    """Return {ok, errors, warnings}. Reject if critical errors.
+
+    ``allow_priority`` (BUG-020): when set, authorizes up to that many included
+    priority findings. Default remains 7 without an explicit raise.
+    """
     errors: list[str] = []
     warnings: list[str] = []
 
+    # Prefer explicit arg; else artifacts.metrics / assumptions flag from pipeline
+    authorized = allow_priority
+    if authorized is None:
+        authorized = (artifacts.metrics or {}).get("allow_priority")
+    try:
+        authorized_n = int(authorized) if authorized is not None else None
+    except (TypeError, ValueError):
+        authorized_n = None
+
     findings = [f for f in artifacts.findings if f.include_in_report]
     if len(findings) > 7:
-        errors.append(f"More than 7 priority findings ({len(findings)}) without explicit raise")
+        if authorized_n is None or len(findings) > authorized_n:
+            errors.append(
+                f"More than 7 priority findings ({len(findings)}) without explicit raise"
+            )
 
     for f in findings:
         cls = f.effective_classification
@@ -65,6 +85,16 @@ def run_quality_gate(artifacts: ReportArtifacts) -> dict[str, Any]:
         if cls in {Classification.STRONGLY_SUPPORTED, Classification.PROBABLE}:
             if f.chart_spec is None and f.chart_path is None:
                 warnings.append(f"{f.finding_id}: chartable finding has no chart_spec")
+        # BUG-022: never silent-skip day zoom after charts attach
+        has_zoom = bool(getattr(f, "day_zoom_path", None))
+        has_zoom_err = bool(getattr(f, "day_zoom_skip_reason", None) or getattr(f, "day_zoom_error", None))
+        # Only enforce when chart pass has run (charts list non-empty or any finding has zoom fields set)
+        zoom_pass_done = bool(artifacts.charts) or any(
+            getattr(x, "day_zoom_path", None) or getattr(x, "day_zoom_skip_reason", None)
+            for x in artifacts.findings
+        )
+        if zoom_pass_done and f.include_in_report and not has_zoom and not has_zoom_err:
+            errors.append(f"{f.finding_id}: day-zoom missing path and error (silent skip)")
         title_l = f.title.lower()
         if "comfort" in title_l and cls != Classification.DATA_QUALITY:
             # dead sensor comfort

--- a/vibe_code_apps_19/app/reporting/scope.py
+++ b/vibe_code_apps_19/app/reporting/scope.py
@@ -1,0 +1,147 @@
+"""Scope filters for Engineering Findings prioritization (BUG-019)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from app.reporting.models import CandidateDetection, EngineeringFinding
+
+# Prefer terminal/zone FAULTs over plant when ``boost_terminal`` is set (BUG-019).
+# Added to the evidence score for sort only — does not change stored assessment scores.
+TERMINAL_SCORE_BOOST = 8.0
+
+
+def equipment_system(equipment_type: str, rule_id: str) -> str:
+    """AHU / CHW / HW / VAV / Other — shared with findings clustering."""
+    et = (equipment_type or "").upper()
+    if "AHU" in et or rule_id.startswith("SCHED") or rule_id == "FAN-OFF-STATIC":
+        return "AHU"
+    if "CHILL" in et or rule_id.startswith("CHW"):
+        return "CHW"
+    if "BOIL" in et or rule_id.startswith("HW"):
+        return "HW"
+    if "VAV" in et or rule_id.startswith("VAV") or rule_id.startswith("SV-"):
+        return "VAV"
+    return et or "Other"
+
+
+@dataclass
+class FindingScope:
+    """Optional filters applied before ranking (empty = no constraint on that axis)."""
+
+    systems: list[str] = field(default_factory=list)
+    equipment_prefixes: list[str] = field(default_factory=list)
+    rule_ids: list[str] = field(default_factory=list)
+    boost_terminal: bool = False
+
+    @property
+    def active(self) -> bool:
+        return bool(self.systems or self.equipment_prefixes or self.rule_ids or self.boost_terminal)
+
+    @classmethod
+    def from_cli(
+        cls,
+        *,
+        systems: str | None = None,
+        equipment_prefix: str | None = None,
+        rule_ids: str | None = None,
+        boost_terminal: bool = False,
+    ) -> FindingScope:
+        return cls(
+            systems=[s.upper() for s in _split_csv(systems)],
+            equipment_prefixes=_split_csv(equipment_prefix),
+            rule_ids=_split_csv(rule_ids),
+            boost_terminal=bool(boost_terminal),
+        )
+
+
+def _split_csv(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    return [p.strip() for p in str(raw).split(",") if p.strip()]
+
+
+def parse_systems(raw: str | Iterable[str] | None) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [s.upper() for s in _split_csv(raw)]
+    return [str(s).strip().upper() for s in raw if str(s).strip()]
+
+
+def candidate_matches_scope(c: CandidateDetection, scope: FindingScope | None) -> bool:
+    """True when candidate passes all non-empty scope dimensions (AND)."""
+    if scope is None:
+        return True
+    systems = [s.upper() for s in scope.systems]
+    prefixes = list(scope.equipment_prefixes)
+    rule_ids = set(scope.rule_ids)
+    if not systems and not prefixes and not rule_ids:
+        return True
+    if systems:
+        sys = equipment_system(c.equipment_type, c.rule_id).upper()
+        if sys not in systems:
+            return False
+    if prefixes:
+        eid = (c.equipment_id or "").upper()
+        if not any(eid.startswith(p.upper()) for p in prefixes):
+            return False
+    if rule_ids and c.rule_id not in rule_ids:
+        return False
+    return True
+
+
+def filter_candidates(
+    candidates: list[CandidateDetection],
+    scope: FindingScope | None,
+) -> list[CandidateDetection]:
+    if scope is None or not (scope.systems or scope.equipment_prefixes or scope.rule_ids):
+        return list(candidates)
+    return [c for c in candidates if candidate_matches_scope(c, scope)]
+
+
+def is_terminal_finding(f: EngineeringFinding) -> bool:
+    systems = {s.upper() for s in (f.systems or [])}
+    if "VAV" in systems:
+        return True
+    if any((eid or "").upper().startswith("VAV") for eid in (f.equipment_ids or [])):
+        return True
+    if any((rid or "").upper().startswith("VAV") or (rid or "").upper().startswith("SV-") for rid in (f.rule_ids or [])):
+        return True
+    return False
+
+
+def sort_key_for_finding(
+    f: EngineeringFinding,
+    *,
+    boost_terminal: bool = False,
+    cls_rank_fn=None,
+) -> tuple:
+    from app.reporting.models import Classification
+
+    order = {
+        Classification.STRONGLY_SUPPORTED: 5,
+        Classification.PROBABLE: 4,
+        Classification.DATA_QUALITY: 3,
+        Classification.INCONCLUSIVE: 2,
+        Classification.LIKELY_FALSE_POSITIVE: 1,
+        Classification.NOT_ACTIONABLE: 0,
+    }
+    rank_fn = cls_rank_fn or (lambda c: order.get(c, 0))
+    score = float((f.automated_assessment or {}).get("score") or 0)
+    if boost_terminal and is_terminal_finding(f):
+        score += TERMINAL_SCORE_BOOST
+    return (-rank_fn(f.classification), -score)
+
+
+def scope_to_dict(scope: FindingScope | None) -> dict[str, Any]:
+    if scope is None:
+        return {}
+    return {
+        "systems": list(scope.systems),
+        "equipment_prefixes": list(scope.equipment_prefixes),
+        "rule_ids": list(scope.rule_ids),
+        "boost_terminal": bool(scope.boost_terminal),
+        "terminal_score_boost": TERMINAL_SCORE_BOOST if scope.boost_terminal else 0.0,
+    }

--- a/vibe_code_apps_19/app/reporting/scope.py
+++ b/vibe_code_apps_19/app/reporting/scope.py
@@ -13,10 +13,15 @@ TERMINAL_SCORE_BOOST = 8.0
 
 
 def equipment_system(equipment_type: str, rule_id: str) -> str:
-    """AHU / CHW / HW / VAV / Other — shared with findings clustering."""
-    et = (equipment_type or "").upper()
-    if "AHU" in et or rule_id.startswith("SCHED") or rule_id == "FAN-OFF-STATIC":
+    """AHU / CHW / HW / VAV / HP / Other — shared with findings clustering.
+
+    RTU maps to AHU; heatPump / HP map to HP (dashboard contract).
+    """
+    et = (equipment_type or "").upper().replace(" ", "")
+    if "AHU" in et or "RTU" in et or rule_id.startswith("SCHED") or rule_id == "FAN-OFF-STATIC":
         return "AHU"
+    if "HEATPUMP" in et or et == "HP" or et.endswith("HP"):
+        return "HP"
     if "CHILL" in et or rule_id.startswith("CHW"):
         return "CHW"
     if "BOIL" in et or rule_id.startswith("HW"):

--- a/vibe_code_apps_19/tests/test_eng_findings_agent_knobs.py
+++ b/vibe_code_apps_19/tests/test_eng_findings_agent_knobs.py
@@ -15,7 +15,13 @@ from app.reporting.models import (
 )
 from app.reporting.pipeline import build_engineering_findings
 from app.reporting.quality_gate import run_quality_gate
-from app.reporting.scope import FindingScope, TERMINAL_SCORE_BOOST
+from app.reporting.scope import FindingScope, TERMINAL_SCORE_BOOST, equipment_system
+
+
+def test_equipment_system_maps_rtu_and_heatpump():
+    assert equipment_system("RTU", "SCHED-1") == "AHU"
+    assert equipment_system("heatPump", "HP-1") == "HP"
+    assert equipment_system("VAV", "VAV-5") == "VAV"
 
 
 def _pkt(key: str) -> EvidencePacket:

--- a/vibe_code_apps_19/tests/test_eng_findings_agent_knobs.py
+++ b/vibe_code_apps_19/tests/test_eng_findings_agent_knobs.py
@@ -1,0 +1,332 @@
+"""BUG-019–023: Eng Findings VAV scope, raise, HITL, inventory."""
+
+from __future__ import annotations
+
+from app.reporting.fault_inventory import build_fault_inventory
+from app.reporting.findings import cluster_and_prioritize
+from app.reporting.hitl import apply_hitl_overrides, parse_note_arg
+from app.reporting.models import (
+    CandidateDetection,
+    Classification,
+    EngineeringFinding,
+    EvidencePacket,
+    FindingAssessment,
+    ReportArtifacts,
+)
+from app.reporting.pipeline import build_engineering_findings
+from app.reporting.quality_gate import run_quality_gate
+from app.reporting.scope import FindingScope, TERMINAL_SCORE_BOOST
+
+
+def _pkt(key: str) -> EvidencePacket:
+    return EvidencePacket(
+        candidate_key=key,
+        identity={},
+        rule_evidence={},
+        mapping_evidence={},
+        telemetry_evidence={},
+        context={},
+        sensor_quality={},
+    )
+
+
+def _cand(
+    eid: str,
+    rid: str,
+    *,
+    et: str,
+    hours: float,
+    score: float,
+) -> tuple[CandidateDetection, FindingAssessment]:
+    c = CandidateDetection(
+        building="B100",
+        equipment_id=eid,
+        equipment_type=et,
+        rule_id=rid,
+        status="FAULT",
+        fault_hours=hours,
+        sample_count=int(hours * 12),
+    )
+    a = FindingAssessment(
+        candidate_key=c.key,
+        classification=Classification.PROBABLE,
+        score=score,
+        score_breakdown={},
+        supporting=[f"{eid} {rid} evidence"],
+    )
+    return c, a
+
+
+def _b100_like() -> tuple[list, dict, dict]:
+    """Plant AHU/CHW high scores + high-volume VAV_22 VAV-5 (burial case)."""
+    rows = [
+        _cand("AHU_1", "AHU-DUCTHI", et="AHU", hours=200, score=92),
+        _cand("AHU_2", "FAN-OFF-STATIC", et="AHU", hours=180, score=90),
+        _cand("CH_1", "CHW-1", et="CHILLER", hours=150, score=88),
+        _cand("CH_2", "CHW-2", et="CHILLER", hours=140, score=86),
+        _cand("AHU_3", "SCHED-1", et="AHU", hours=120, score=84),
+        _cand("AHU_4", "AHU-DUCTHI", et="AHU", hours=110, score=83),
+        _cand("AHU_5", "FAN-OFF-STATIC", et="AHU", hours=100, score=82),
+        # Buried terminal — high volume, slightly lower score
+        _cand("VAV_22", "VAV-5", et="VAV", hours=35000, score=78),
+        _cand("VAV_10", "VAV-4", et="VAV", hours=8000, score=76),
+        _cand("VAV_11", "SV-FLATLINE", et="VAV", hours=5000, score=74),
+    ]
+    cands = [r[0] for r in rows]
+    packets = {c.key: _pkt(c.key) for c in cands}
+    assessments = {r[0].key: r[1] for r in rows}
+    return cands, packets, assessments
+
+
+def test_bug019_default_unscoped_buries_vav22():
+    cands, packets, assessments = _b100_like()
+    findings, _, _ = cluster_and_prioritize(cands, packets, assessments, max_findings=7)
+    assert len(findings) == 7
+    keys = {k for f in findings for k in f.candidate_keys}
+    assert "VAV_22|VAV-5" not in keys  # buried under plant
+
+
+def test_bug019_systems_vav_surfaces_vav22():
+    cands, packets, assessments = _b100_like()
+    scope = FindingScope(systems=["VAV"])
+    findings, suppressed, _ = cluster_and_prioritize(
+        cands, packets, assessments, max_findings=7, scope=scope
+    )
+    keys = {k for f in findings for k in f.candidate_keys}
+    assert "VAV_22|VAV-5" in keys
+    assert all("AHU" not in (f.systems or []) for f in findings)
+    assert any("Out of report scope" in ";".join(r.get("reasons") or []) for r in suppressed)
+
+
+def test_bug019_equipment_prefix_and_rule_ids():
+    cands, packets, assessments = _b100_like()
+    scope = FindingScope(equipment_prefixes=["VAV"], rule_ids=["VAV-5", "VAV-4"])
+    findings, _, _ = cluster_and_prioritize(
+        cands, packets, assessments, max_findings=7, scope=scope
+    )
+    rule_ids = {rid for f in findings for rid in f.rule_ids}
+    assert "VAV-5" in rule_ids
+    assert "SV-FLATLINE" not in rule_ids
+
+
+def test_bug019_boost_terminal_helps_near_ties():
+    cands, packets, assessments = _b100_like()
+    # Unscoped with boost: VAV_22 (78+8=86) should enter top-7 vs AHU_5 (82)
+    scope = FindingScope(boost_terminal=True)
+    findings, _, _ = cluster_and_prioritize(
+        cands, packets, assessments, max_findings=7, scope=scope
+    )
+    keys = {k for f in findings for k in f.candidate_keys}
+    assert "VAV_22|VAV-5" in keys
+    assert TERMINAL_SCORE_BOOST == 8.0
+
+
+def test_bug020_gate_fails_without_raise():
+    findings = []
+    for i in range(12):
+        findings.append(
+            EngineeringFinding(
+                finding_id=f"F{i+1:02d}",
+                title=f"f{i}",
+                classification=Classification.PROBABLE,
+                priority=i + 1,
+                why_it_matters="m",
+                observed_behavior="o",
+                evidence_bullets=["e"],
+                contradicting_evidence=[],
+                likely_causes=[],
+                field_verification=[],
+                possible_corrective=[],
+                rule_ids=["R"],
+                equipment_ids=[f"E{i}"],
+                systems=["VAV"],
+                automated_assessment={"score": 70},
+                include_in_report=True,
+            )
+        )
+    art = ReportArtifacts(
+        building="B",
+        analysis_period="p",
+        generated_at="t",
+        findings=findings,
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={},
+    )
+    gate = run_quality_gate(art)
+    assert gate["ok"] is False
+    assert any("without explicit raise" in e for e in gate["errors"])
+
+
+def test_bug020_gate_passes_with_allow_priority():
+    findings = []
+    for i in range(12):
+        findings.append(
+            EngineeringFinding(
+                finding_id=f"F{i+1:02d}",
+                title=f"f{i}",
+                classification=Classification.PROBABLE,
+                priority=i + 1,
+                why_it_matters="m",
+                observed_behavior="o",
+                evidence_bullets=["e"],
+                contradicting_evidence=[],
+                likely_causes=[],
+                field_verification=[],
+                possible_corrective=[],
+                rule_ids=["R"],
+                equipment_ids=[f"E{i}"],
+                systems=["VAV"],
+                automated_assessment={"score": 70},
+                include_in_report=True,
+            )
+        )
+    art = ReportArtifacts(
+        building="B",
+        analysis_period="p",
+        generated_at="t",
+        findings=findings,
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={"allow_priority": 12},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={},
+    )
+    gate = run_quality_gate(art, allow_priority=12)
+    assert gate["ok"] is True
+
+
+def test_bug020_pipeline_max12_with_raise():
+    cands, packets, assessments = _b100_like()
+    # Use pipeline with candidates directly
+    art = build_engineering_findings(
+        building="B100",
+        candidates=cands,
+        max_findings=12,
+        allow_priority=12,
+        scope=FindingScope(systems=["VAV"]),
+        write_inventory=True,
+    )
+    included = [f for f in art.findings if f.include_in_report]
+    assert len(included) <= 12
+    assert art.quality_gate.get("ok") is True
+    assert art.metrics.get("allow_priority") == 12
+
+
+def test_bug021_pin_and_note_and_drop():
+    cands, packets, assessments = _b100_like()
+    findings, suppressed, _ = cluster_and_prioritize(
+        cands, packets, assessments, max_findings=7
+    )
+    # VAV_22 buried — pin it; drop an AHU finding
+    ahu_ref = "AHU_1|AHU-DUCTHI"
+    out = apply_hitl_overrides(
+        findings,
+        pin_refs=["VAV_22:VAV-5"],
+        drop_refs=[ahu_ref],
+        notes={"VAV_22|VAV-5": "FD flag intermittent; verify airflow sensor"},
+        candidates=cands,
+        assessments=assessments,
+        suppressed=suppressed,
+    )
+    pinned = [f for f in out if f.include_in_report and "VAV_22" in f.equipment_ids]
+    assert pinned
+    assert (pinned[0].engineer_override or {}).get("note", "").startswith("FD flag")
+    dropped = [f for f in out if ahu_ref in (f.candidate_keys or [])]
+    assert dropped and dropped[0].include_in_report is False
+    ref, text = parse_note_arg("VAV_22:VAV-5=hello")
+    assert ref == "VAV_22|VAV-5" and text == "hello"
+
+
+def test_bug022_day_zoom_error_alias_and_gate():
+    f = EngineeringFinding(
+        finding_id="F01",
+        title="x",
+        classification=Classification.PROBABLE,
+        priority=1,
+        why_it_matters="m",
+        observed_behavior="o",
+        evidence_bullets=["e"],
+        contradicting_evidence=[],
+        likely_causes=[],
+        field_verification=[],
+        possible_corrective=[],
+        rule_ids=["VAV-5"],
+        equipment_ids=["VAV_1"],
+        systems=["VAV"],
+        automated_assessment={"score": 70},
+        include_in_report=True,
+        day_zoom_skip_reason="no_fault_day",
+        day_zoom_label="Day-zoom unavailable: no_fault_day",
+    )
+    d = f.to_dict()
+    assert d["day_zoom_error"] == "no_fault_day"
+    # Silent skip after zoom pass → gate error
+    silent = EngineeringFinding(
+        finding_id="F02",
+        title="y",
+        classification=Classification.PROBABLE,
+        priority=2,
+        why_it_matters="m",
+        observed_behavior="o",
+        evidence_bullets=["e"],
+        contradicting_evidence=[],
+        likely_causes=[],
+        field_verification=[],
+        possible_corrective=[],
+        rule_ids=["VAV-4"],
+        equipment_ids=["VAV_2"],
+        systems=["VAV"],
+        automated_assessment={"score": 70},
+        include_in_report=True,
+    )
+    art = ReportArtifacts(
+        building="B",
+        analysis_period="p",
+        generated_at="t",
+        findings=[f, silent],
+        suppressed=[],
+        candidates=[],
+        assessments=[],
+        data_quality=[],
+        comfort_summary={},
+        metrics={},
+        field_checklist=[],
+        assumptions={},
+        quality_gate={},
+        charts=[{"name": "day_zoom_F01", "skip_reason": "no_fault_day"}],
+    )
+    gate = run_quality_gate(art)
+    assert gate["ok"] is False
+    assert any("silent skip" in e for e in gate["errors"])
+
+
+def test_bug023_inventory_orphans_and_in_priority():
+    cands, packets, assessments = _b100_like()
+    findings, suppressed, _ = cluster_and_prioritize(
+        cands, packets, assessments, max_findings=7
+    )
+    inv = build_fault_inventory(cands, findings, suppressed=suppressed)
+    assert inv["n_faults"] == len(cands)
+    assert inv["n_orphans"] >= 1
+    vav22 = next(r for r in inv["rows"] if r["candidate_key"] == "VAV_22|VAV-5")
+    assert vav22["in_priority"] is False
+    assert vav22["suppressed_reason"]
+    assert "VAV" in inv["rollup_by_equipment_prefix"]
+    # After scoped run, VAV_22 in priority
+    scoped, _, _ = cluster_and_prioritize(
+        cands, packets, assessments, max_findings=7, scope=FindingScope(systems=["VAV"])
+    )
+    inv2 = build_fault_inventory(cands, scoped, suppressed=[])
+    vav22b = next(r for r in inv2["rows"] if r["candidate_key"] == "VAV_22|VAV-5")
+    assert vav22b["in_priority"] is True

--- a/vibe_code_apps_19/vibe19_agent_spec/SESSION_LOG.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/SESSION_LOG.md
@@ -8,6 +8,18 @@ For onboarding your own site, start with [`TEMPLATE.md`](TEMPLATE.md) and [`docs
 
 ---
 
+## 2026-07-25 — Eng Findings BUG-019–024 (VAV/FD agent packs)
+
+- **BUG-019:** `--systems` / `--equipment-prefix` / `--rule-ids` / `--boost-terminal` scope ranking (`app/reporting/scope.py`).
+- **BUG-020:** `--allow-priority N` / `--raise-max-findings` + UI checkbox; quality gate honors explicit raise.
+- **BUG-021:** `--pin-finding` / `--drop-finding` / `--note` HITL (`app/reporting/hitl.py`).
+- **BUG-022:** `day_zoom_error` JSON alias; gate fails on silent zoom skip after chart pass.
+- **BUG-023:** FAULT inventory JSON (`*_fault_inventory.json`) with orphans + rollups.
+- **BUG-024:** Run Rules panel agent/scope expander + session `batch_results` fallback.
+- Tests: `tests/test_eng_findings_agent_knobs.py`.
+
+---
+
 ## 2026-07-25 — Eng Findings BUG-016/017/018 + DOCX UX
 
 - **BUG-016:** `attach_day_zoom_to_findings` records `skip_reason` (`no_result` / `no_fault_day` / `render_failed`) + `day_zoom_skip_reason`; DOCX muted note when zoom missing.

--- a/vibe_code_apps_19/vibe19_agent_spec/skills/vibe19-engineering-report/SKILL.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/skills/vibe19-engineering-report/SKILL.md
@@ -86,7 +86,23 @@ cd vibe_code_apps_19
   --docx --json
 ```
 
-Also: `--dump` WattLab zip/folder + optional `--run-rules`.
+Also: `--dump` / `--package` WattLab zip/folder + optional `--run-rules`.
+
+**Agent VAV/FD pack (BUG-019–023):**
+
+```bash
+python -m app.reporting.cli \
+  --package /path/to/BUILDING_100 \
+  --systems VAV \
+  --rule-ids VAV-4,VAV-5,SV-FLATLINE \
+  --max-findings 12 --allow-priority 12 \
+  --pin-finding VAV_22:VAV-5 \
+  --note 'VAV_22:VAV-5=FD flag intermittent; verify airflow sensor' \
+  --write-inventory \
+  --out /tmp/b100_vav_fd/ --docx --json --run-rules
+```
+
+Modules: `scope.py`, `hitl.py`, `fault_inventory.py`. UI mirrors filters under Run Rules → Agent / scope options.
 
 Liberty / WattLab workspace bridge: checklist under `reports/controls_checklist/`; findings under `reports/engineering_findings/` (see wattlab `tools/README.md`).
 
@@ -96,6 +112,7 @@ Liberty / WattLab workspace bridge: checklist under `reports/controls_checklist/
 .venv/bin/python -m pytest -q \
   tests/test_report_*.py \
   tests/test_finding_*.py \
+  tests/test_eng_findings_agent_knobs.py \
   tests/test_false_positive_review.py \
   tests/test_near_continuous_fault_review.py \
   tests/test_peer_common_mode_detection.py


### PR DESCRIPTION
## Summary
- **BUG-019:** Scope ranking via `--systems` / `--equipment-prefix` / `--rule-ids` / `--boost-terminal` (and Run Rules UI mirrors)
- **BUG-020:** Explicit raise `--allow-priority N` / `--raise-max-findings`; quality gate still fails without raise when >7
- **BUG-021:** CLI HITL `--pin-finding` / `--drop-finding` / `--note` (+ notes file)
- **BUG-022:** `day_zoom_error` JSON alias; gate errors on silent zoom skip after chart pass
- **BUG-023:** `*_fault_inventory.json` with orphans + rule/prefix rollups
- **BUG-024:** Agent/scope expander on Eng Findings panel; session `batch_results` fallback

## BUG → files → tests
| BUG | Files | Tests |
| --- | --- | --- |
| 019 | `scope.py`, `findings.py`, `cli.py`, `report_downloads.py` | `test_bug019_*` |
| 020 | `quality_gate.py`, `pipeline.py`, `cli.py` | `test_bug020_*` |
| 021 | `hitl.py`, `pipeline.py`, `cli.py` | `test_bug021_*` |
| 022 | `models.py`, `quality_gate.py`, `day_zoom.py` (existing) | `test_bug022_*` |
| 023 | `fault_inventory.py`, `pipeline.py` | `test_bug023_*` |
| 024 | `report_downloads.py` | AppTest + manual checklist |

## Example CLI (Liberty 100 VAV/FD pack)
```bash
python -m app.reporting.cli \
  --package /path/to/BUILDING_100 \
  --systems VAV \
  --rule-ids VAV-4,VAV-5,SV-FLATLINE \
  --max-findings 12 --allow-priority 12 \
  --pin-finding VAV_22:VAV-5 \
  --note 'VAV_22:VAV-5=FD flag intermittent; verify airflow sensor' \
  --write-inventory \
  --out /tmp/b100_vav_fd/ --docx --json --run-rules
```

## Test plan
- [x] `pytest tests/test_eng_findings_agent_knobs.py tests/test_finding_clustering.py tests/test_report_quality_gate.py tests/test_report_day_zoom.py tests/test_report_docx.py tests/test_eng_findings_apptest.py`
- [ ] CI green + CodeRabbit addressed
- [ ] After merge: GHCR vibe19 refresh + `:8502` smoke; vibe20 already on develop → refresh `:8520`

## UI smoke (local / tip)
1. App loads Run Rules with no exception banner
2. Defaults Generate completes
3. VAV scope Generate → terminal-heavy priority
4. Explicit raise to 12 → gate OK
5. Day-zoom image or visible unavailable reason per finding
6. FAULT inventory download present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added report filtering by system, equipment prefix, and rule, with optional terminal-equipment prioritization.
  * Added pin, drop, and note controls for manually managing findings.
  * Added FAULT inventory summaries, orphan tracking, and downloadable inventory JSON.
  * Added day-zoom availability details and expanded report-generation options in the UI.
  * Added CLI options for scoping, finding limits, notes, priority handling, and inventory output.

* **Bug Fixes**
  * Improved batch-result detection and report-generation state handling.
  * Quality checks now support authorized priority limits and detect silent day-zoom failures.
  * Added clearer serialized error information for skipped day-zoom processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->