### PR TITLE
fix: BUG-030–040 notebook prefill, ROI formulas, xlsx agent friction

### DIFF
--- a/vibe_code_apps_19/app/report_downloads.py
+++ b/vibe_code_apps_19/app/report_downloads.py
@@ -273,8 +273,9 @@ def render_engineering_findings_panel(
     if inv.get("n_orphans"):
         st.caption(
             f"FAULT inventory: {inv.get('n_faults')} FAULTs · "
-            f"{inv.get('n_in_priority')} in priority · "
-            f"{inv.get('n_orphans')} orphans (not in DOCX body)"
+            f"{inv.get('n_priority_findings', inv.get('n_in_priority'))} findings in report · "
+            f"{inv.get('n_candidates_in_priority', '—')} candidate rows covered · "
+            f"{inv.get('n_orphans')} orphans (not in body)"
         )
 
     st.markdown("##### Engineer review (optional)")

--- a/vibe_code_apps_19/app/reporting/fault_inventory.py
+++ b/vibe_code_apps_19/app/reporting/fault_inventory.py
@@ -98,6 +98,8 @@ def build_fault_inventory(
 
     orphans = [r for r in rows if not r["in_priority"]]
     orphans_sorted = sorted(orphans, key=lambda x: -float(x["fault_hours"] or 0))
+    n_priority_findings = sum(1 for f in findings if f.include_in_report)
+    n_candidates_in_priority = sum(1 for r in rows if r["in_priority"])
 
     return {
         "rows": rows,
@@ -105,7 +107,12 @@ def build_fault_inventory(
         "rollup_by_rule_id": dict(by_rule),
         "rollup_by_equipment_prefix": dict(by_prefix),
         "n_faults": len(rows),
-        "n_in_priority": sum(1 for r in rows if r["in_priority"]),
+        # Candidate FAULT rows covered by a priority finding (may be >> findings count)
+        "n_candidates_in_priority": n_candidates_in_priority,
+        # Body findings count — what agents usually mean by "in priority" (BUG-040)
+        "n_priority_findings": n_priority_findings,
+        # Back-compat: prefer findings count for n_in_priority (was candidate-row count)
+        "n_in_priority": n_priority_findings,
         "n_orphans": len(orphans),
     }
 

--- a/vibe_code_apps_19/app/reporting/xlsx.py
+++ b/vibe_code_apps_19/app/reporting/xlsx.py
@@ -95,6 +95,13 @@ def render_findings_xlsx(
     _hdr(find_ws)
     for i, f in enumerate(included, start=2):
         note = (f.engineer_override or {}).get("note", "")
+        # Relative basename for agent-friendly cells; PNG still embeds from absolute (BUG-039)
+        zoom_cell = ""
+        if f.day_zoom_path:
+            try:
+                zoom_cell = Path(str(f.day_zoom_path)).name
+            except Exception:
+                zoom_cell = str(f.day_zoom_path)
         find_ws.append(
             [
                 f.finding_id,
@@ -106,7 +113,7 @@ def render_findings_xlsx(
                 ", ".join(f.rule_ids or []),
                 f.why_it_matters,
                 f.observed_behavior,
-                f.day_zoom_path,
+                zoom_cell,
                 f.day_zoom_skip_reason,
                 note,
             ]
@@ -156,12 +163,21 @@ def render_findings_xlsx(
             ]
         )
     inv_ws.append([])
-    inv_ws.append(["rollup", "n_faults", "n_in_priority", "n_orphans"])
+    inv_ws.append(
+        [
+            "rollup",
+            "n_faults",
+            "n_in_priority_findings",
+            "n_candidates_in_priority",
+            "n_orphans",
+        ]
+    )
     inv_ws.append(
         [
             "summary",
             inv.get("n_faults"),
-            inv.get("n_in_priority"),
+            inv.get("n_priority_findings", inv.get("n_in_priority")),
+            inv.get("n_candidates_in_priority"),
             inv.get("n_orphans"),
         ]
     )
@@ -174,14 +190,30 @@ def render_findings_xlsx(
     _hdr(ov, row=2)
     r = 3
     img_row = 3
+    # Prefer overview_charts; fall back to charts — dedupe by name (BUG-038)
+    seen_names: set[str] = set()
+    chart_metas: list[dict[str, Any]] = []
     for meta in list(artifacts.overview_charts or []) + list(artifacts.charts or []):
         if not isinstance(meta, dict):
             continue
+        name = str(meta.get("name") or meta.get("title") or "").strip()
+        if not name or name in seen_names:
+            continue
+        seen_names.add(name)
+        chart_metas.append(meta)
+    for meta in chart_metas:
         name = meta.get("name") or meta.get("title") or ""
         path = meta.get("path")
+        # Prefer relative path for agent-friendly cells (BUG-039)
+        path_cell = path
+        if path:
+            try:
+                path_cell = str(Path(str(path)).name)
+            except Exception:
+                path_cell = path
         embedded = False
         ov[f"A{r}"] = name
-        ov[f"B{r}"] = path
+        ov[f"B{r}"] = path_cell
         if (
             embed_images
             and path

--- a/vibe_code_apps_19/tests/test_report_xlsx.py
+++ b/vibe_code_apps_19/tests/test_report_xlsx.py
@@ -62,8 +62,31 @@ def test_render_findings_xlsx_sheets(tmp_path: Path):
                 "title": "Economizer free-cooling delta scatter",
             }
         ],
-        fault_inventory={"rows": [], "n_faults": 0, "n_in_priority": 0, "n_orphans": 0},
+        # Duplicate name in charts must not double-embed (BUG-038)
+        charts=[
+            {
+                "name": "overview_economizer_delta_scatter",
+                "path": str(png),
+                "title": "dup",
+            },
+            {
+                "name": "other_chart",
+                "path": str(png),
+            },
+        ],
+        fault_inventory={
+            "rows": [],
+            "n_faults": 0,
+            "n_in_priority": 1,
+            "n_priority_findings": 1,
+            "n_candidates_in_priority": 3,
+            "n_orphans": 0,
+        },
     )
+    # Absolute day_zoom path → relative cell
+    art.findings[0].day_zoom_path = str(tmp_path / "day_zoom_F01.png")
+    (tmp_path / "day_zoom_F01.png").write_bytes(png.read_bytes())
+
     out = tmp_path / "findings.xlsx"
     render_findings_xlsx(art, out, embed_images=True)
     assert out.is_file()
@@ -72,5 +95,14 @@ def test_render_findings_xlsx_sheets(tmp_path: Path):
     punch = wb["Punchlist"]
     assert punch["B2"].value == "Verify OA damper travel"
     ov = wb["Overview_Charts"]
-    assert ov["A3"].value == "overview_economizer_delta_scatter"
-    assert ov["C3"].value is True
+    names = [ov[f"A{r}"].value for r in range(3, 10) if ov[f"A{r}"].value]
+    assert names.count("overview_economizer_delta_scatter") == 1
+    assert "other_chart" in names
+    assert ov["B3"].value == "overview_economizer_delta_scatter.png"  # relative
+    find = wb["Findings"]
+    assert find["J2"].value == "day_zoom_F01.png"
+    inv = wb["FAULT_Inventory"]
+    # summary row uses findings count
+    assert inv["C12"].value == 1 or any(
+        inv.cell(r, 3).value == 1 for r in range(1, 20)
+    )

--- a/vibe_code_apps_19/vibe19_agent_spec/SESSION_LOG.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/SESSION_LOG.md
@@ -8,6 +8,13 @@ For onboarding your own site, start with [`TEMPLATE.md`](TEMPLATE.md) and [`docs
 
 ---
 
+## 2026-07-25 — BUG-030–040 notebook / xlsx agent fixes
+
+- vibe20: in-place `prefill` (no wipe); ROI B=H + live NPV formula + `npv_usd_at_build`; preview `data_only=False`; validate warns empty E+; ECMs Advanced expander; tests `test_notebook_builder.py`.
+- vibe19: Overview chart dedupe; relative day_zoom/Overview paths; inventory `n_priority_findings` (+ candidates covered).
+
+---
+
 ## 2026-07-25 — Economizer free-cooling diagnostic plots + Eng Findings xlsx
 
 - Overview: fan-on AHU/RTU delta scatter (MAT−RAT vs OAT−RAT), MAT residual, temps+damper overlay; |OAT−RAT|<10°F suppressed (G36).

--- a/vibe_code_apps_20/tests/test_notebook_builder.py
+++ b/vibe_code_apps_20/tests/test_notebook_builder.py
@@ -1,0 +1,155 @@
+"""Engineering notebook builder / prefill / validate / preview (BUG-030–037)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+openpyxl = pytest.importorskip("openpyxl")
+
+from wattlab.notebooks.builder import (
+    build_and_save_notebook,
+    build_notebook_workbook,
+    prefill_notebook_inputs,
+    preview_sheet_rows,
+    read_notebook_inputs,
+    summarize_notebook,
+    validate_notebook,
+)
+from wattlab.notebooks.packages import INPUT_NAMED_RANGES, REQUIRED_SHEETS, list_notebook_packages
+
+
+def test_list_notebook_packages_ladder():
+    pkgs = list_notebook_packages()
+    ids = [p.id for p in pkgs]
+    assert ids == [
+        "controls_first",
+        "schedules_economizer",
+        "plant_optimization",
+        "esco_top15",
+        "deep_retrofit",
+    ]
+    assert [p.rank for p in pkgs] == [1, 2, 3, 4, 5]
+
+
+def test_build_validate_named_ranges_and_roi_formulas(tmp_path: Path):
+    written = build_and_save_notebook(
+        "controls_first",
+        tmp_path,
+        profile={"conditioned_floor_area_ft2": 140_000, "utility": {"elec_usd_per_kwh": 0.14}},
+        report={},
+    )
+    xlsx = written["xlsx"]
+    v = validate_notebook(xlsx)
+    assert v["ok"] is True
+    assert set(REQUIRED_SHEETS) <= set(v["sheets"])
+    assert any("EPlus_Results empty" in w for w in v["warnings"])
+
+    wb = openpyxl.load_workbook(xlsx, data_only=False)
+    defined = set(wb.defined_names.keys())
+    for n in INPUT_NAMED_RANGES:
+        assert n in defined
+    # BUG-035: B mirrors H formula
+    assert str(wb["ROI_Capital"]["B2"].value).startswith("=H")
+    assert "inp_usd_per_ft2" in str(wb["ROI_Capital"]["H2"].value)
+    # BUG-032: NPV is live formula, cache in I
+    assert str(wb["ROI_Capital"]["G2"].value).startswith("=IF")
+    assert isinstance(wb["ROI_Capital"]["I2"].value, (int, float))
+    # Cover honesty mentions scaffold / proxies
+    cover_note = str(wb["Cover"]["B13"].value or wb["Cover"]["B14"].value or "")
+    # find Note row
+    notes = [str(wb["Cover"][f"B{r}"].value or "") for r in range(4, 20)]
+    assert any("scaffold" in n.lower() or "proxies" in n.lower() for n in notes)
+
+
+def test_prefill_merges_in_place_keeps_eplus(tmp_path: Path):
+    written = build_and_save_notebook(
+        "controls_first",
+        tmp_path,
+        profile={"conditioned_floor_area_ft2": 140_000, "utility": {"elec_usd_per_kwh": 0.14, "gas_usd_per_therm": 0.9}},
+        report={
+            "savings_by_measure": [
+                {
+                    "measure_id": "ECM-AHU-SCHED-ALIGN",
+                    "vs_baseline": {"kwh_saved": 12345.0, "therms_saved": 100.0},
+                }
+            ]
+        },
+    )
+    xlsx = written["xlsx"]
+    before = read_notebook_inputs(xlsx)
+    assert before["area_ft2"] == 140_000
+    assert before["elec_rate"] == 0.14
+
+    wb0 = openpyxl.load_workbook(xlsx, data_only=False)
+    ep_kwh = wb0["EPlus_Results"]["B2"].value
+    assert ep_kwh == 12345.0
+
+    result = prefill_notebook_inputs(xlsx, overrides={"elec_rate": 0.22})
+    assert "elec_rate" in result["updated"]
+    after = read_notebook_inputs(xlsx)
+    assert after["elec_rate"] == 0.22
+    assert after["area_ft2"] == 140_000  # not wiped to 50000
+    assert after["gas_rate"] == before["gas_rate"]
+
+    wb1 = openpyxl.load_workbook(xlsx, data_only=False)
+    assert wb1["EPlus_Results"]["B2"].value == 12345.0
+
+
+def test_preview_shows_formulas_not_none(tmp_path: Path):
+    written = build_and_save_notebook("controls_first", tmp_path, profile={"floor_area_ft2": 50_000})
+    rows = preview_sheet_rows(written["xlsx"], "ROI_Capital", data_only=False)
+    assert rows
+    # header + data: cost / npv cells should be formula strings, not None
+    header = rows[0]
+    assert "npv_usd_at_build" in header
+    data = rows[1]
+    # B implementation_cost
+    assert data[1] is not None and str(data[1]).startswith("=")
+    # G npv formula
+    assert data[6] is not None and str(data[6]).startswith("=")
+    # I cache numeric
+    assert isinstance(data[8], (int, float))
+
+
+def test_summarize_resolves_package_and_ep_coverage(tmp_path: Path):
+    written = build_and_save_notebook("schedules_economizer", tmp_path, profile={"floor_area_ft2": 80_000})
+    man = summarize_notebook(written["xlsx"])  # no package= arg (BUG-042)
+    assert man["package_id"] == "schedules_economizer"
+    assert man["package_label"]
+    assert man["ep_coverage"]["filled_rows"] == 0
+    assert man["honesty"]["template_file"] == "scaffold_only"
+
+
+def test_cli_prefill_elec_rate(tmp_path: Path):
+    from wattlab.notebooks.cli import main
+
+    written = build_and_save_notebook(
+        "controls_first",
+        tmp_path,
+        profile={"conditioned_floor_area_ft2": 140_000, "utility": {"elec_usd_per_kwh": 0.14}},
+    )
+    rc = main(
+        [
+            "prefill",
+            "--xlsx",
+            str(written["xlsx"]),
+            "--elec-rate",
+            "0.22",
+        ]
+    )
+    assert rc == 0
+    assert read_notebook_inputs(written["xlsx"])["elec_rate"] == 0.22
+    assert read_notebook_inputs(written["xlsx"])["area_ft2"] == 140_000
+
+
+def test_workbook_does_not_load_template_file():
+    """BUG-033: builds are Workbook() — template path unused at runtime."""
+    import inspect
+
+    from wattlab.notebooks import builder as b
+
+    src = inspect.getsource(b.build_notebook_workbook)
+    assert "load_workbook" not in src
+    assert "Workbook()" in src

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
@@ -62,10 +62,17 @@ Least→radical packages (`controls_first` … `deep_retrofit`) each produce one
 under `reports/notebooks/` plus `*.notebook_manifest.json` for agents.
 
 ```bash
-wattlab notebook build --package esco_top15 --out /data/reports/notebooks/
+wattlab notebook build --package esco_top15 --out /data/reports/notebooks/ \
+  --answers /data/reports/answers.json --from-run /data/runs/<ecm_capable>
+wattlab notebook prefill --xlsx /data/reports/notebooks/esco_top15.xlsx --elec-rate 0.22
+# prefill patches Inputs in-place (keeps EPlus_Results) — never rebuilds
 wattlab notebook validate --xlsx /data/reports/notebooks/esco_top15.xlsx
 wattlab notebook summarize --xlsx … --write
 ```
+
+Honesty: ESCO kWh/therms are baked at build; ROI cost/NPV formulas follow Inputs.
+Studio preview shows formula text + `npv_usd_at_build` (openpyxl does not calc Excel).
+Prefer Twin runs with `savings_by_measure` or Compare stays YELLOW (`validate` warns).
 
 Write `reports/ecm_scenario.json` v3 with `notebook_package_id`, `notebook_path`,
 `input_overrides` so Studio Re-apply / ECMs page stays in sync.

--- a/vibe_code_apps_20/wattlab/notebooks/__init__.py
+++ b/vibe_code_apps_20/wattlab/notebooks/__init__.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from wattlab.notebooks.builder import (
     build_and_save_notebook,
     build_notebook_workbook,
+    prefill_notebook_inputs,
     preview_sheet_rows,
+    read_notebook_inputs,
     summarize_notebook,
     validate_notebook,
 )
@@ -16,7 +18,9 @@ __all__ = [
     "build_notebook_workbook",
     "get_notebook_package",
     "list_notebook_packages",
+    "prefill_notebook_inputs",
     "preview_sheet_rows",
+    "read_notebook_inputs",
     "summarize_notebook",
     "validate_notebook",
 ]

--- a/vibe_code_apps_20/wattlab/notebooks/builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/builder.py
@@ -211,7 +211,9 @@ def build_notebook_workbook(
         ("ESCO docs", ESCO_DOCS_URL),
         (
             "Note",
-            "Yellow cells on Inputs are engineer-editable. ESCO_Calcs / Compare / ROI use formulas where marked.",
+            "Yellow Inputs drive rate-linked formulas (annual $, payback, NPV, Compare). "
+            "ESCO kWh/therms are screening proxies baked at build (see Docs). "
+            "Workbook is generated in code — templates/ecm_package_v1.xlsx is a scaffold only.",
         ),
     ]
     for i, (k, v) in enumerate(rows, start=4):
@@ -269,7 +271,10 @@ def build_notebook_workbook(
         esco[f"D{i}"] = ",".join(calcs) if isinstance(calcs, list) else ""
         # Formula references Inputs named rates
         esco[f"E{i}"] = f"=B{i}*inp_elec_rate+C{i}*inp_gas_rate"
-        esco[f"F{i}"] = "Screening proxy from wattlab.studio.proxies / bench ESCO bins"
+        esco[f"F{i}"] = (
+            "B/C = Python screening proxy at build (not live Excel bins). "
+            "E updates when Inputs rates change."
+        )
     esco.column_dimensions["A"].width = 28
     esco.column_dimensions["D"].width = 28
     esco.column_dimensions["E"].width = 28
@@ -339,19 +344,31 @@ def build_notebook_workbook(
             "simple_payback_years",
             "npv_usd",
             "cost_formula",
+            "npv_usd_at_build",
         ]
     )
     _style_header(roi)
+    n_meas = max(len(measure_ids), 1)
+    # Closed-form NPV of escalated annuity (matches wattlab.finance.escalated_cash_flows + npv)
+    npv_formula = (
+        "=IF(ABS(inp_discount-inp_escalation)<1E-9,"
+        "-B{i}+E{i}*inp_life_years/(1+inp_discount),"
+        "-B{i}+E{i}*(1-((1+inp_escalation)/(1+inp_discount))^inp_life_years)"
+        "/(inp_discount-inp_escalation))"
+    )
     for i, row in enumerate(econ_rows, start=2):
         roi[f"A{i}"] = row["measure_id"]
-        roi[f"B{i}"] = row["implementation_cost_usd"]
+        # H = Inputs-driven equal-split cost; B mirrors H (engineer may overwrite B with a lump sum)
+        roi[f"H{i}"] = f"=inp_usd_per_ft2*inp_area_ft2*inp_coverage/{n_meas}"
+        roi[f"B{i}"] = f"=H{i}"
         roi[f"C{i}"] = row["kwh_saved"]
         roi[f"D{i}"] = row["therms_saved"]
         roi[f"E{i}"] = f"=C{i}*inp_elec_rate+D{i}*inp_gas_rate"
         roi[f"F{i}"] = f'=IF(E{i}=0,"",B{i}/E{i})'
-        roi[f"G{i}"] = row["npv_usd"]
-        roi[f"H{i}"] = f"=inp_usd_per_ft2*inp_area_ft2*inp_coverage/{max(len(measure_ids), 1)}"
-        _yellow(roi[f"B{i}"])  # engineer can override cost
+        roi[f"G{i}"] = npv_formula.format(i=i)
+        _yellow(roi[f"B{i}"])  # still highlight — overwrite formula with fixed $ if needed
+        # Cached build-time NPV for agents / Studio preview (not Excel-evaluated)
+        roi[f"I{i}"] = row["npv_usd"]
     # Totals
     n = len(econ_rows)
     if n:
@@ -360,9 +377,11 @@ def build_notebook_workbook(
         roi[f"B{tot}"] = f"=SUM(B2:B{n+1})"
         roi[f"E{tot}"] = f"=SUM(E2:E{n+1})"
         roi[f"G{tot}"] = f"=SUM(G2:G{n+1})"
+        roi[f"I{tot}"] = f"=SUM(I2:I{n+1})"
         roi[f"A{tot}"].font = Font(bold=True)
     roi.column_dimensions["A"].width = 28
     roi.column_dimensions["H"].width = 36
+    roi.column_dimensions["I"].width = 18
 
     # --- Guardrails ---
     gr = wb.create_sheet("Guardrails")
@@ -391,14 +410,28 @@ def build_notebook_workbook(
     docs["A5"] = "Crosscheck"
     docs["B5"] = "wattlab/crosscheck.py (~0.5–2× = reasonable)"
     docs["A6"] = "Finance / NPV"
-    docs["B6"] = "wattlab/finance.py"
+    docs["B6"] = (
+        "ROI_Capital G = live Excel closed-form NPV from Inputs rates + E; "
+        "I = Python NPV at build (wattlab/finance.py) for agents without Excel calc"
+    )
     docs["A7"] = "Catalog package"
     docs["B7"] = pkg.catalog_package
     docs["A8"] = "Measure ids"
     docs["B8"] = ", ".join(measure_ids)
+    docs["A9"] = "Template file"
+    docs["B9"] = (
+        "templates/ecm_package_v1.xlsx is a write-template scaffold only — "
+        "builds always generate Workbook() in builder.py (BUG-033 honesty)"
+    )
     docs["A10"] = "Agent CLI"
     docs["B10"] = (
-        f"wattlab notebook build --package {pkg.id} --out reports/notebooks/"
+        f"wattlab notebook build --package {pkg.id} --out reports/notebooks/ "
+        f"| wattlab notebook prefill --xlsx … --elec-rate 0.22  (in-place Inputs)"
+    )
+    docs["A11"] = "E+ Compare"
+    docs["B11"] = (
+        "YELLOW light when Twin report lacks savings_by_measure — "
+        "pick an ECM-capable run (validate warns)"
     )
     docs.column_dimensions["A"].width = 28
     docs.column_dimensions["B"].width = 80
@@ -413,6 +446,90 @@ def save_workbook(wb: Any, path: Path | str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     wb.save(path)
     return path
+
+
+# Map CLI / profile override keys → Inputs parameter names (column A)
+_INPUT_PARAM_ALIASES: dict[str, str] = {
+    "area_ft2": "area_ft2",
+    "conditioned_floor_area_ft2": "area_ft2",
+    "floor_area_ft2": "area_ft2",
+    "cooling_tons": "cooling_tons",
+    "fan_hp": "fan_hp",
+    "supply_fan_hp": "fan_hp",
+    "elec_rate": "elec_rate",
+    "elec_usd_per_kwh": "elec_rate",
+    "gas_rate": "gas_rate",
+    "gas_usd_per_therm": "gas_rate",
+    "discount": "discount",
+    "escalation": "escalation",
+    "life_years": "life_years",
+    "usd_per_ft2": "usd_per_ft2",
+    "coverage": "coverage",
+}
+
+
+def read_notebook_inputs(path: Path | str) -> dict[str, Any]:
+    """Read Inputs!A/B yellow parameters from an existing workbook."""
+    from openpyxl import load_workbook
+
+    path = Path(path)
+    wb = load_workbook(path, data_only=False)
+    if "Inputs" not in wb.sheetnames:
+        return {}
+    out: dict[str, Any] = {}
+    for row in wb["Inputs"].iter_rows(min_row=2, max_col=2, values_only=True):
+        if row[0]:
+            out[str(row[0])] = row[1]
+    return out
+
+
+def prefill_notebook_inputs(
+    path: Path | str,
+    *,
+    overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Patch yellow Inputs cells in-place — keeps EPlus_Results / ESCO / formulas (BUG-030).
+
+    Only keys present in ``overrides`` are written. Does **not** rebuild the workbook
+    or refill unspecified Inputs from defaults.
+    """
+    from openpyxl import load_workbook
+    from openpyxl.styles import PatternFill
+
+    path = Path(path)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+
+    patch: dict[str, Any] = {}
+    for k, v in (overrides or {}).items():
+        if v is None:
+            continue
+        param = _INPUT_PARAM_ALIASES.get(str(k), str(k))
+        patch[param] = v
+
+    if not patch:
+        return {"path": str(path), "updated": [], "inputs": read_notebook_inputs(path)}
+
+    wb = load_workbook(path, data_only=False)
+    if "Inputs" not in wb.sheetnames:
+        raise ValueError(f"Inputs sheet missing in {path}")
+    ws = wb["Inputs"]
+    row_by: dict[str, int] = {}
+    for r in range(2, (ws.max_row or 2) + 1):
+        key = ws.cell(r, 1).value
+        if key:
+            row_by[str(key)] = r
+    updated: list[str] = []
+    yellow = PatternFill("solid", fgColor=YELLOW)
+    for param, val in patch.items():
+        if param not in row_by:
+            continue
+        cell = ws.cell(row_by[param], 2)
+        cell.value = val
+        cell.fill = yellow
+        updated.append(param)
+    wb.save(path)
+    return {"path": str(path), "updated": updated, "inputs": read_notebook_inputs(path)}
 
 
 def build_and_save_notebook(
@@ -457,7 +574,38 @@ def validate_notebook(path: Path | str) -> dict[str, Any]:
     for n in INPUT_NAMED_RANGES:
         if n not in defined:
             warnings.append(f"missing named range: {n}")
-    return {"ok": len(errors) == 0, "errors": errors, "warnings": warnings, "sheets": list(wb.sheetnames)}
+    # BUG-034: warn when E+ sheet has no savings
+    ep_filled = 0
+    ep_rows = 0
+    if "EPlus_Results" in wb.sheetnames:
+        for row in wb["EPlus_Results"].iter_rows(min_row=2, max_col=3, values_only=True):
+            if not row[0]:
+                continue
+            ep_rows += 1
+            if row[1] is not None or row[2] is not None:
+                ep_filled += 1
+    if ep_rows and ep_filled == 0:
+        warnings.append(
+            "EPlus_Results empty (no savings_by_measure) — Compare lights will be YELLOW; "
+            "pick a Twin ECM run with measure savings"
+        )
+    # Honesty: cost B should reference H when still formula-linked
+    if "ROI_Capital" in wb.sheetnames:
+        b2 = wb["ROI_Capital"]["B2"].value
+        h2 = wb["ROI_Capital"]["H2"].value
+        if isinstance(b2, (int, float)) and isinstance(h2, str) and h2.startswith("="):
+            warnings.append(
+                "ROI_Capital!B2 is a static cost while H2 is an Inputs formula — "
+                "prefer B=H so yellow Inputs move package cost (BUG-035)"
+            )
+    return {
+        "ok": len(errors) == 0,
+        "errors": errors,
+        "warnings": warnings,
+        "sheets": list(wb.sheetnames),
+        "ep_measure_rows": ep_rows,
+        "ep_filled_rows": ep_filled,
+    }
 
 
 def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = None) -> dict[str, Any]:
@@ -491,11 +639,22 @@ def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = No
         for row in wb["Inputs"].iter_rows(min_row=2, max_col=2, values_only=True):
             if row[0]:
                 inputs[str(row[0])] = row[1]
+    # Prefer package from Cover / stem; load catalog label when possible
+    pkg_id = package.id if package else path.stem
+    pkg_label = package.label if package else None
+    if package is None:
+        try:
+            package = get_notebook_package(path.stem)
+            pkg_id = package.id
+            pkg_label = package.label
+        except Exception:
+            pass
+    validated = validate_notebook(path)
     return {
         "schema": "wattlab_notebook_manifest_v1",
         "path": str(path.resolve()),
-        "package_id": package.id if package else path.stem,
-        "package_label": package.label if package else None,
+        "package_id": pkg_id,
+        "package_label": pkg_label,
         "sheets": list(wb.sheetnames),
         "named_ranges": list(wb.defined_names.keys()),
         "measure_ids": measures,
@@ -503,14 +662,34 @@ def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = No
         "guardrail_verdict": gate,
         "inputs": inputs,
         "docs_url": ESCO_DOCS_URL,
-        "validated": validate_notebook(path),
+        "validated": validated,
+        "ep_coverage": {
+            "measure_rows": validated.get("ep_measure_rows"),
+            "filled_rows": validated.get("ep_filled_rows"),
+        },
+        "honesty": {
+            "esco_kwh_therms": "baked_at_build",
+            "roi_cost_npv": "excel_formulas_from_inputs",
+            "template_file": "scaffold_only",
+        },
     }
 
 
-def preview_sheet_rows(path: Path | str, sheet: str, *, max_rows: int = 40) -> list[list[Any]]:
+def preview_sheet_rows(
+    path: Path | str,
+    sheet: str,
+    *,
+    max_rows: int = 40,
+    data_only: bool = False,
+) -> list[list[Any]]:
+    """Preview sheet rows for Studio / agents.
+
+    Default ``data_only=False`` so formulas appear as strings and static caches
+    (e.g. npv_usd_at_build) remain readable — openpyxl never evaluates Excel (BUG-031).
+    """
     from openpyxl import load_workbook
 
-    wb = load_workbook(path, data_only=True)
+    wb = load_workbook(path, data_only=data_only)
     if sheet not in wb.sheetnames:
         return []
     ws = wb[sheet]
@@ -534,7 +713,9 @@ __all__ = [
     "build_notebook_workbook",
     "default_inputs_from_profile",
     "list_notebook_packages",
+    "prefill_notebook_inputs",
     "preview_sheet_rows",
+    "read_notebook_inputs",
     "save_workbook",
     "summarize_notebook",
     "validate_notebook",

--- a/vibe_code_apps_20/wattlab/notebooks/cli.py
+++ b/vibe_code_apps_20/wattlab/notebooks/cli.py
@@ -145,36 +145,57 @@ def _cmd_build(args: argparse.Namespace) -> int:
 
 
 def _cmd_prefill(args: argparse.Namespace) -> int:
-    """Rebuild the same package id (stem) with new inputs — simplest prefill."""
-    from wattlab.notebooks.builder import build_and_save_notebook
-    from wattlab.notebooks.packages import get_notebook_package
+    """Patch Inputs yellow cells in-place — never rebuilds (BUG-030)."""
+    from wattlab.notebooks.builder import prefill_notebook_inputs
 
-    stem = args.xlsx.stem
-    try:
-        get_notebook_package(stem)
-        package_id = stem
-    except KeyError:
-        print(
-            f"Cannot map {stem!r} to a notebook package; rebuild with wattlab notebook build",
-            file=sys.stderr,
-        )
+    if not args.xlsx.is_file():
+        print(f"missing workbook: {args.xlsx}", file=sys.stderr)
         return 2
-    profile = _load_profile(args)
+
     overrides: dict[str, Any] = {}
+    # Explicit keys from profile / answers JSON only (no default fill)
+    for src in (_load_json(getattr(args, "profile", None)), _load_json(getattr(args, "answers", None))):
+        for k, v in src.items():
+            if v is None:
+                continue
+            if k in (
+                "conditioned_floor_area_ft2",
+                "floor_area_ft2",
+                "area_ft2",
+                "cooling_tons",
+                "fan_hp",
+                "supply_fan_hp",
+                "elec_rate",
+                "gas_rate",
+                "discount",
+                "escalation",
+                "life_years",
+                "usd_per_ft2",
+                "coverage",
+            ):
+                overrides[k] = v
+            if k == "utility" and isinstance(v, dict):
+                if v.get("elec_usd_per_kwh") is not None:
+                    overrides["elec_rate"] = v["elec_usd_per_kwh"]
+                if v.get("gas_usd_per_therm") is not None:
+                    overrides["gas_rate"] = v["gas_usd_per_therm"]
+    if getattr(args, "area", None) is not None:
+        overrides["area_ft2"] = float(args.area)
+    if getattr(args, "cooling_tons", None) is not None:
+        overrides["cooling_tons"] = float(args.cooling_tons)
+    if getattr(args, "fan_hp", None) is not None:
+        overrides["fan_hp"] = float(args.fan_hp)
     if args.elec_rate is not None:
         overrides["elec_rate"] = float(args.elec_rate)
     if args.gas_rate is not None:
         overrides["gas_rate"] = float(args.gas_rate)
-    report = _load_report(args.from_run)
-    written = build_and_save_notebook(
-        package_id,
-        args.xlsx.parent,
-        profile=profile,
-        report=report,
-        input_overrides=overrides or None,
-        write_manifest=True,
-    )
-    print(json.dumps({k: str(v) for k, v in written.items()}, indent=2))
+
+    try:
+        result = prefill_notebook_inputs(args.xlsx, overrides=overrides)
+    except Exception as exc:
+        print(f"prefill failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, default=str))
     return 0
 
 

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -74,6 +74,7 @@ def _render_baseline_run_picker() -> None:
     st.subheader("Twin baseline run")
     st.caption(
         "ECMs savings/deliverable context follows the selected Twin publish. "
+        "Prefer a run with ``savings_by_measure`` so Compare is not all YELLOW. "
         "Default is best G14 (PASS preferred, else lowest |NMBE|+CVRMSE)."
     )
     try:
@@ -88,6 +89,12 @@ def _render_baseline_run_picker() -> None:
     opts = [str(r["dir"]) for r in rows if r.get("dir")]
     by_dir = {str(r["dir"]): r for r in rows if r.get("dir")}
 
+    # Annotate which runs have E+ measure savings (BUG-034)
+    has_sbm: dict[str, bool] = {}
+    for d in opts:
+        rep = _load_run_report(d)
+        has_sbm[d] = bool(rep.get("savings_by_measure"))
+
     stored = st.session_state.get("studio_ecm_baseline_run")
     if stored and str(stored) in opts:
         default_dir = str(stored)
@@ -95,6 +102,11 @@ def _render_baseline_run_picker() -> None:
         default_dir = str(best["dir"])
     else:
         default_dir = opts[-1] if opts else None
+    # Prefer ECM-capable run when default lacks savings_by_measure
+    if default_dir and not has_sbm.get(default_dir):
+        with_sbm = [d for d in opts if has_sbm.get(d)]
+        if with_sbm:
+            default_dir = with_sbm[-1]
 
     if default_dir and "studio_ecm_baseline_pick" not in st.session_state:
         st.session_state["studio_ecm_baseline_pick"] = default_dir
@@ -110,7 +122,8 @@ def _render_baseline_run_picker() -> None:
         rid = r.get("run_id") or Path(d).name
         pf = r.get("pass_fail") or "—"
         tag = " · best G14" if best and str(best.get("dir")) == d else ""
-        return f"#{n} · {rid} · {pf}{tag}" if n is not None else f"{rid} · {pf}{tag}"
+        ecm = " · E+ measures" if has_sbm.get(d) else " · ESCO-only"
+        return f"#{n} · {rid} · {pf}{tag}{ecm}" if n is not None else f"{rid} · {pf}{tag}{ecm}"
 
     pick = st.selectbox(
         "Baseline Twin run",
@@ -139,6 +152,11 @@ def _render_baseline_run_picker() -> None:
             f"G14={meta.get('pass_fail') or (score.get('utility_bills') or {}).get('pass_fail') or '—'} "
             f"· `{Path(pick).name}`"
         )
+        if not has_sbm.get(pick):
+            st.warning(
+                "This Twin run has no ``savings_by_measure`` — notebook Compare will be "
+                "mostly YELLOW (ESCO-only). Pick a run tagged **E+ measures** when available."
+            )
 
 
 def _render_engineering_notebook(profile: dict[str, Any]) -> None:
@@ -156,8 +174,9 @@ def _render_engineering_notebook(profile: dict[str, Any]) -> None:
 
     st.subheader("Engineering notebook (Excel)")
     st.caption(
-        "Pick a least→radical package, build a real spreadsheet (ESCO vs E+ + ROI formulas), "
-        "preview key sheets, download. Agents: `wattlab notebook build --package …`."
+        "Primary deliverable: least→radical Excel package (ESCO vs E+ + ROI). "
+        "Preview shows formulas as text + ``npv_usd_at_build`` cache (open Excel to evaluate). "
+        "Agents: `wattlab notebook build|prefill|validate|summarize`."
     )
     st.markdown(
         "[ESCO formula map (GitHub)]"
@@ -193,6 +212,11 @@ def _render_engineering_notebook(profile: dict[str, Any]) -> None:
             )
             st.session_state["studio_notebook_path"] = str(written["xlsx"])
             st.session_state["studio_notebook_manifest"] = str(written.get("manifest") or "")
+            from wattlab.notebooks.builder import validate_notebook
+
+            v = validate_notebook(written["xlsx"])
+            for w in v.get("warnings") or []:
+                st.warning(w)
             # Persist for agents
             scen = load_ecm_scenario()
             scen["notebook_package_id"] = pick
@@ -213,12 +237,16 @@ def _render_engineering_notebook(profile: dict[str, Any]) -> None:
             st.session_state["studio_notebook_path"] = xlsx
     if xlsx and Path(str(xlsx)).is_file():
         path = Path(str(xlsx))
+        st.caption(
+            "Preview uses formula text (not Excel-calculated). "
+            "Use ``npv_usd_at_build`` / Inputs values for agent numbers; open Excel for live NPV."
+        )
         tabs = st.tabs(["Inputs", "Compare", "ROI_Capital"])
         for tab, sheet in zip(tabs, ("Inputs", "Compare", "ROI_Capital")):
             with tab:
-                rows = preview_sheet_rows(path, sheet, max_rows=50)
+                rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=False)
                 if not rows:
-                    st.caption(f"Sheet `{sheet}` empty or missing (open Excel for formulas).")
+                    st.caption(f"Sheet `{sheet}` empty or missing.")
                 else:
                     st.dataframe(
                         pd.DataFrame(rows[1:], columns=rows[0] if rows else None),
@@ -272,138 +300,422 @@ def render() -> None:
     _render_engineering_notebook(profile)
     st.divider()
 
-    with st.expander("Advanced — Easy Buttons catalog", expanded=False):
+    with st.expander(
+        "Advanced — Easy Buttons, measure sets, capital plan, client DOCX",
+        expanded=False,
+    ):
         from wattlab.studio.pages.ecm_easy_buttons import render as render_easy
 
         render_easy(profile=profile, proxy_estimator=estimate_proxy_savings)
-
-    st.divider()
-    st.subheader("Measure set + proxy pricing")
-    st.caption("Optional legacy path — Engineering notebook above is preferred for deliverables.")
-    sets = list_measure_sets()
-    set_ids = [s["id"] for s in sets] or ["best"]
-    labels = {s["id"]: f"{s['label']} — {', '.join(s['measure_ids'])}" for s in sets}
-    mset = st.selectbox(
-        "Measure set",
-        set_ids,
-        format_func=lambda k: labels.get(k, k),
-        index=max(0, len(set_ids) - 1),
-        key="ecm_measure_set",
-    )
-    if st.button("Build measures + proxies", key="ecm_build_measures"):
-        measure_rows = expand_measure_set(str(mset))
-        ids = [str(m.get("measure_id")) for m in measure_rows if m.get("measure_id")]
-        # Prefer Easy Button scenario if present
-        scenario_ids = st.session_state.get("ecm_easy__scenario_ids") or st.session_state.get(
-            "ecm_easy_scenario_ids"
+        st.divider()
+        st.subheader("Measure set + proxy pricing")
+        st.caption("Optional legacy path — Engineering notebook above is preferred for deliverables.")
+        sets = list_measure_sets()
+        set_ids = [s["id"] for s in sets] or ["best"]
+        labels = {s["id"]: f"{s['label']} — {', '.join(s['measure_ids'])}" for s in sets}
+        mset = st.selectbox(
+            "Measure set",
+            set_ids,
+            format_func=lambda k: labels.get(k, k),
+            index=max(0, len(set_ids) - 1),
+            key="ecm_measure_set",
         )
-        if not scenario_ids:
-            # namespaced_key may use a different separator — also check common keys
+        if st.button("Build measures + proxies", key="ecm_build_measures"):
+            measure_rows = expand_measure_set(str(mset))
+            ids = [str(m.get("measure_id")) for m in measure_rows if m.get("measure_id")]
+            # Prefer Easy Button scenario if present
+            scenario_ids = st.session_state.get("ecm_easy__scenario_ids") or st.session_state.get(
+                "ecm_easy_scenario_ids"
+            )
+            if not scenario_ids:
+                # namespaced_key may use a different separator — also check common keys
+                for k, v in st.session_state.items():
+                    if "scenario_ids" in str(k) and isinstance(v, list) and v:
+                        scenario_ids = v
+                        break
+            if scenario_ids:
+                ids = list(dict.fromkeys([str(x) for x in scenario_ids] + ids))
+                measure_rows = [{"measure_id": mid} for mid in ids]
+            proxy_profile = _enrich_profile_for_proxies(profile)
+            proxies = estimate_proxy_savings(proxy_profile, ids)
+            from wattlab.studio.ecm_roi import rows_to_cost_map, seed_roi_cost_rows
+
+            area0 = float(
+                proxy_profile.get("conditioned_floor_area_ft2")
+                or proxy_profile.get("floor_area_ft2")
+                or 50000.0
+            )
+            roi_rows = seed_roi_cost_rows(
+                ids,
+                floor_area_ft2=area0,
+                existing=st.session_state.get("studio_ecm_roi_models"),
+            )
+            costs = rows_to_cost_map(roi_rows)
+            # Blend with hard-coded lump sums when ROI model is tiny
+            for mid in ids:
+                if costs.get(mid, 0) <= 0:
+                    costs[mid] = DEFAULT_MEASURE_COSTS.get(mid, 10000.0)
+            st.session_state["studio_measures"] = measure_rows
+            st.session_state["studio_proxies"] = proxies
+            st.session_state["studio_costs"] = costs
+            st.session_state["studio_ecm_roi_rows"] = roi_rows
+            st.session_state["studio_measure_set"] = str(mset)
+            # Default cherry-pick to first measure only (avoid dumping full capital stack)
+            if ids and not st.session_state.get("studio_ecm_cherry_pick"):
+                st.session_state["studio_ecm_cherry_pick"] = [ids[0]]
+            st.success(f"{len(ids)} measures priced (proxy + $/ft² ROI seed).")
+
+        measure_rows = st.session_state.get("studio_measures") or []
+        if measure_rows and isinstance(measure_rows[0], str):
+            measure_rows = [{"measure_id": m} for m in measure_rows]
+        measures = [str(m.get("measure_id")) for m in measure_rows if isinstance(m, dict) and m.get("measure_id")]
+        # Also pull Easy Button scenario into comparison when measures empty
+        if not measures:
             for k, v in st.session_state.items():
                 if "scenario_ids" in str(k) and isinstance(v, list) and v:
-                    scenario_ids = v
+                    measures = [str(x) for x in v]
                     break
-        if scenario_ids:
-            ids = list(dict.fromkeys([str(x) for x in scenario_ids] + ids))
-            measure_rows = [{"measure_id": mid} for mid in ids]
-        proxy_profile = _enrich_profile_for_proxies(profile)
-        proxies = estimate_proxy_savings(proxy_profile, ids)
-        from wattlab.studio.ecm_roi import rows_to_cost_map, seed_roi_cost_rows
+        proxies = st.session_state.get("studio_proxies") or {}
+        costs = st.session_state.get("studio_costs") or {}
 
-        area0 = float(
-            proxy_profile.get("conditioned_floor_area_ft2")
-            or proxy_profile.get("floor_area_ft2")
+        cherry: list[str] = []
+        if measures:
+            st.markdown("#### Cherry-pick package")
+            st.caption(
+                "Capital plan + ROI rollup use only the measures below. "
+                "Start with one ECM, compare ESCO ↔ EnergyPlus, then add more."
+            )
+            stored_cherry = st.session_state.get("studio_ecm_cherry_pick")
+            cur = [m for m in (stored_cherry or []) if m in measures]
+            if not cur:
+                cur = [measures[0]]
+            st.session_state["studio_ecm_cherry_pick"] = cur
+            cherry = st.multiselect(
+                "Active measures (capital plan)",
+                options=measures,
+                key="studio_ecm_cherry_pick",
+                help="Deselect everything you do not want in NPV / payback totals.",
+            )
+            c_run, c_hint = st.columns([1, 2])
+            with c_run:
+                if st.button("Recalc ESCO for cherry-pick", key="ecm_recalc_cherry"):
+                    if not cherry:
+                        st.warning("Select at least one measure.")
+                    else:
+                        proxy_profile = _enrich_profile_for_proxies(profile)
+                        from wattlab.studio.proxies import resolve_proxy_inputs
+
+                        inputs = resolve_proxy_inputs(proxy_profile)
+                        new_px = estimate_proxy_savings(proxy_profile, cherry)
+                        proxies = {**(st.session_state.get("studio_proxies") or {}), **new_px}
+                        st.session_state["studio_proxies"] = proxies
+                        src = ", ".join(inputs.get("sources") or [])
+                        st.success(
+                            f"ESCO proxies refreshed for {len(cherry)} measure(s) "
+                            f"(inputs: {src}; area={inputs['area_ft2']:,.0f} ft²"
+                            + (
+                                f", {inputs['cooling_tons']:g} tons"
+                                if inputs.get("cooling_tons")
+                                else ""
+                            )
+                            + (
+                                f", {inputs['fan_hp']:g} HP"
+                                if inputs.get("fan_hp")
+                                else ""
+                            )
+                            + ")."
+                        )
+            with c_hint:
+                st.caption(
+                    "🟢 in-line · 🟡 method difference or ESCO-only · 🔴 investigate / implausible"
+                )
+
+        if measures:
+            from wattlab.crosscheck import crosscheck_measure
+
+            rows = []
+            report = st.session_state.get("studio_report") or {}
+            ep_by = {}
+            for s in report.get("savings_by_measure") or []:
+                mid = s.get("measure_id")
+                vs = (s.get("vs_previous") or s.get("vs_baseline") or {})
+                if mid:
+                    ep_by[mid] = vs
+            focus = cherry or measures
+            for mid in measures:
+                p = proxies.get(mid) or {}
+                ep = ep_by.get(mid) or {}
+                esco_kwh = p.get("savings_kwh")
+                esco_therms = p.get("savings_therms")
+                ep_kwh = ep.get("kwh_saved")
+                ep_therms = ep.get("therms_saved")
+                has_ep = ep_kwh is not None or ep_therms is not None
+                xc = crosscheck_measure(
+                    measure_id=mid,
+                    ep_savings_kwh=None if ep_kwh is None else float(ep_kwh),
+                    proxy_savings_kwh=None if esco_kwh is None else float(esco_kwh),
+                    ep_savings_therms=None if ep_therms is None else float(ep_therms),
+                    proxy_savings_therms=None if esco_therms is None else float(esco_therms),
+                )
+                ratio = xc.get("agreement_ratio")
+                ratio_th = xc.get("agreement_ratio_therms")
+                delta_kwh = None
+                pct_kwh = None
+                if ep_kwh is not None and esco_kwh is not None:
+                    delta_kwh = float(ep_kwh) - float(esco_kwh)
+                    if abs(float(esco_kwh)) > 1e-9:
+                        pct_kwh = 100.0 * delta_kwh / float(esco_kwh)
+                delta_therms = None
+                pct_therms = None
+                if ep_therms is not None and esco_therms is not None:
+                    delta_therms = float(ep_therms) - float(esco_therms)
+                    if abs(float(esco_therms)) > 1e-9:
+                        pct_therms = 100.0 * delta_therms / float(esco_therms)
+                verdict = xc.get("verdict_canonical") or xc.get("verdict")
+                rows.append({
+                    "in_plan": "✓" if mid in focus else "",
+                    "light": _traffic_light(verdict=verdict, has_ep=has_ep),
+                    "measure_id": mid,
+                    "esco_kwh": esco_kwh,
+                    "ep_kwh": ep_kwh,
+                    "delta_kwh": None if delta_kwh is None else round(delta_kwh, 1),
+                    "pct_vs_esco_kwh": None if pct_kwh is None else round(pct_kwh, 1),
+                    "esco_therms": esco_therms,
+                    "ep_therms": ep_therms,
+                    "delta_therms": None if delta_therms is None else round(delta_therms, 1),
+                    "pct_vs_esco_therms": None if pct_therms is None else round(pct_therms, 1),
+                    "agreement_ratio": ratio,
+                    "agreement_ratio_therms": ratio_th,
+                    "verdict": verdict,
+                    "cost_usd": costs.get(mid),
+                })
+            st.markdown("#### Selected measures — ESCO spreadsheet vs EnergyPlus")
+            st.caption(
+                "ESCO = bin-method screening (`wattlab/studio/proxies.py`). "
+                "EP = Twin `savings_by_measure` when present. "
+                "Δ / % = EP − ESCO (positive ⇒ E+ saves more). "
+                "Verdict from `wattlab.crosscheck` (~0.5–2× = reasonable). "
+                "Yellow without EP columns means run Twin measure sims before trusting green."
+            )
+            st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
+
+        # Capital plan / ROI use cherry-pick when set
+        plan_measures = cherry if cherry else measures
+
+        st.divider()
+        st.subheader("ROI screening parameters")
+        st.caption(
+            "Utility rates + discount for NPV. Per-ECM capital uses $/ft² × coverage "
+            "below (Liberty-style: set coverage=0.5 when only half the building gets DDC/G36)."
+        )
+        area = float(
+            profile.get("conditioned_floor_area_ft2")
+            or profile.get("floor_area_ft2")
             or 50000.0
         )
-        roi_rows = seed_roi_cost_rows(
-            ids,
-            floor_area_ft2=area0,
-            existing=st.session_state.get("studio_ecm_roi_models"),
+        bench = st.session_state.get("studio_benchmark_summary") or {}
+        if isinstance(bench, dict) and bench.get("campus"):
+            area = float(bench["campus"].get("floor_area_ft2") or area)
+        rates = profile.get("utility") or {}
+        from wattlab.finance import (
+            DEFAULT_DISCOUNT_RATE,
+            DEFAULT_ESCALATION_RATE,
+            DEFAULT_MEASURE_LIFE_YEARS,
         )
-        costs = rows_to_cost_map(roi_rows)
-        # Blend with hard-coded lump sums when ROI model is tiny
-        for mid in ids:
-            if costs.get(mid, 0) <= 0:
-                costs[mid] = DEFAULT_MEASURE_COSTS.get(mid, 10000.0)
-        st.session_state["studio_measures"] = measure_rows
-        st.session_state["studio_proxies"] = proxies
-        st.session_state["studio_costs"] = costs
-        st.session_state["studio_ecm_roi_rows"] = roi_rows
-        st.session_state["studio_measure_set"] = str(mset)
-        # Default cherry-pick to first measure only (avoid dumping full capital stack)
-        if ids and not st.session_state.get("studio_ecm_cherry_pick"):
-            st.session_state["studio_ecm_cherry_pick"] = [ids[0]]
-        st.success(f"{len(ids)} measures priced (proxy + $/ft² ROI seed).")
 
-    measure_rows = st.session_state.get("studio_measures") or []
-    if measure_rows and isinstance(measure_rows[0], str):
-        measure_rows = [{"measure_id": m} for m in measure_rows]
-    measures = [str(m.get("measure_id")) for m in measure_rows if isinstance(m, dict) and m.get("measure_id")]
-    # Also pull Easy Button scenario into comparison when measures empty
-    if not measures:
-        for k, v in st.session_state.items():
-            if "scenario_ids" in str(k) and isinstance(v, list) and v:
-                measures = [str(x) for x in v]
-                break
-    proxies = st.session_state.get("studio_proxies") or {}
-    costs = st.session_state.get("studio_costs") or {}
+        # Prefill package rollup $/ft2 from controls_first band
+        cost_usd_per_ft2_default = 3.0
+        try:
+            from wattlab.benchmarks.costs import load_registry
 
-    cherry: list[str] = []
-    if measures:
-        st.markdown("#### Cherry-pick package")
-        st.caption(
-            "Capital plan + ROI rollup use only the measures below. "
-            "Start with one ECM, compare ESCO ↔ EnergyPlus, then add more."
-        )
-        stored_cherry = st.session_state.get("studio_ecm_cherry_pick")
-        cur = [m for m in (stored_cherry or []) if m in measures]
-        if not cur:
-            cur = [measures[0]]
-        st.session_state["studio_ecm_cherry_pick"] = cur
-        cherry = st.multiselect(
-            "Active measures (capital plan)",
-            options=measures,
-            key="studio_ecm_cherry_pick",
-            help="Deselect everything you do not want in NPV / payback totals.",
-        )
-        c_run, c_hint = st.columns([1, 2])
-        with c_run:
-            if st.button("Recalc ESCO for cherry-pick", key="ecm_recalc_cherry"):
-                if not cherry:
-                    st.warning("Select at least one measure.")
-                else:
-                    proxy_profile = _enrich_profile_for_proxies(profile)
-                    from wattlab.studio.proxies import resolve_proxy_inputs
+            bands = {r["scope"]: r for r in load_registry()}
+            if "controls_first" in bands:
+                cost_usd_per_ft2_default = float(bands["controls_first"].get("p50") or 3.0)
+        except Exception as exc:
+            st.caption(f"Retrofit cost-band prefill unavailable ({exc}); using ${cost_usd_per_ft2_default:g}/ft² default.")
 
-                    inputs = resolve_proxy_inputs(proxy_profile)
-                    new_px = estimate_proxy_savings(proxy_profile, cherry)
-                    proxies = {**(st.session_state.get("studio_proxies") or {}), **new_px}
-                    st.session_state["studio_proxies"] = proxies
-                    src = ", ".join(inputs.get("sources") or [])
-                    st.success(
-                        f"ESCO proxies refreshed for {len(cherry)} measure(s) "
-                        f"(inputs: {src}; area={inputs['area_ft2']:,.0f} ft²"
-                        + (
-                            f", {inputs['cooling_tons']:g} tons"
-                            if inputs.get("cooling_tons")
-                            else ""
-                        )
-                        + (
-                            f", {inputs['fan_hp']:g} HP"
-                            if inputs.get("fan_hp")
-                            else ""
-                        )
-                        + ")."
-                    )
-        with c_hint:
-            st.caption(
-                "🟢 in-line · 🟡 method difference or ESCO-only · 🔴 investigate / implausible"
+        r1, r2, r3 = st.columns(3)
+        with r1:
+            elec = st.number_input(
+                "Elec $/kWh",
+                min_value=0.01,
+                max_value=1.0,
+                value=float(rates.get("elec_usd_per_kwh") or 0.12),
+                step=0.01,
+                key="ecm_roi_elec",
+            )
+            gas = st.number_input(
+                "Gas $/therm",
+                min_value=0.1,
+                max_value=5.0,
+                value=float(rates.get("gas_usd_per_therm") or 0.80),
+                step=0.05,
+                key="ecm_roi_gas",
+            )
+        with r2:
+            discount = st.number_input(
+                "Discount rate",
+                min_value=0.0,
+                max_value=0.2,
+                value=float(DEFAULT_DISCOUNT_RATE),
+                step=0.005,
+                format="%.3f",
+                key="ecm_roi_discount",
+            )
+            escalation = st.number_input(
+                "Utility escalation",
+                min_value=0.0,
+                max_value=0.1,
+                value=float(DEFAULT_ESCALATION_RATE),
+                step=0.005,
+                format="%.3f",
+                key="ecm_roi_escalation",
+            )
+        with r3:
+            life_years = st.number_input(
+                "Measure life (yr)",
+                min_value=5,
+                max_value=40,
+                value=int(DEFAULT_MEASURE_LIFE_YEARS),
+                key="ecm_roi_life",
+            )
+            usd_per_ft2 = st.number_input(
+                "Fallback package $/ft²",
+                min_value=0.0,
+                max_value=100.0,
+                value=float(cost_usd_per_ft2_default),
+                step=0.25,
+                key="ecm_roi_usd_ft2",
+                help="Used only when a measure has no per-ECM $/ft² / fixed cost.",
+            )
+        st.caption(f"Floor area for $/ft² math: {area:,.0f} ft²")
+
+        # --- Per-ECM ROI cost calculator ---
+        if plan_measures:
+            from wattlab.studio.ecm_roi import (
+                implementation_cost_usd,
+                rows_to_cost_map,
+                rows_to_models,
+                seed_roi_cost_rows,
             )
 
-    if measures:
-        from wattlab.crosscheck import crosscheck_measure
+            st.markdown("#### Per-ECM ROI cost calculator")
+            st.caption(
+                "Prefills are screening defaults for the **cherry-picked** set. Edit **usd_per_ft2** and "
+                "**coverage_fraction** (0–1 of floor area) or set **fixed_usd** for a "
+                "lump-sum quote. Example: G36 needs 50% DDC → coverage=0.5."
+            )
+            seed = seed_roi_cost_rows(
+                plan_measures,
+                floor_area_ft2=area,
+                existing=st.session_state.get("studio_ecm_roi_models"),
+            )
+            edited = st.data_editor(
+                pd.DataFrame(seed),
+                width="stretch",
+                hide_index=True,
+                num_rows="fixed",
+                column_config={
+                    "measure_id": st.column_config.TextColumn("ECM", disabled=True),
+                    "usd_per_ft2": st.column_config.NumberColumn("$/ft²", min_value=0.0, step=0.05, format="%.2f"),
+                    "coverage_fraction": st.column_config.NumberColumn(
+                        "Coverage", min_value=0.0, max_value=1.0, step=0.05, format="%.2f",
+                        help="Fraction of building floor area that receives this ECM",
+                    ),
+                    "applicable_ft2": st.column_config.NumberColumn("ft² applied", disabled=True),
+                    "fixed_usd": st.column_config.NumberColumn(
+                        "Fixed $ (optional)", min_value=0.0, step=1000.0, format="%.0f",
+                    ),
+                    "implementation_cost_usd": st.column_config.NumberColumn(
+                        "Cost $", disabled=True, format="%.0f"
+                    ),
+                    "note": st.column_config.TextColumn("Note", width="large"),
+                },
+                key="ecm_roi_cost_editor",
+            )
+            # Recompute costs from edited $/ft2 + coverage / fixed
+            recomputed: list[dict] = []
+            for _, r in edited.iterrows():
+                mid = str(r["measure_id"])
+                usd = float(r.get("usd_per_ft2") or 0.0)
+                cov = float(r.get("coverage_fraction") or 1.0)
+                fixed_raw = r.get("fixed_usd")
+                fixed_f = None
+                if fixed_raw is not None and not (isinstance(fixed_raw, float) and pd.isna(fixed_raw)):
+                    try:
+                        fv = float(fixed_raw)
+                        if fv > 0:
+                            fixed_f = fv
+                    except (TypeError, ValueError):
+                        fixed_f = None
+                cost = implementation_cost_usd(
+                    floor_area_ft2=area,
+                    usd_per_ft2=usd,
+                    coverage_fraction=cov,
+                    fixed_usd=fixed_f,
+                )
+                recomputed.append(
+                    {
+                        "measure_id": mid,
+                        "usd_per_ft2": usd,
+                        "coverage_fraction": cov,
+                        "applicable_ft2": round(area * max(0.0, min(1.0, cov)), 0),
+                        "fixed_usd": fixed_f,
+                        "implementation_cost_usd": round(cost, 0),
+                        "note": str(r.get("note") or ""),
+                    }
+                )
+            st.session_state["studio_ecm_roi_rows"] = recomputed
+            st.session_state["studio_ecm_roi_models"] = rows_to_models(recomputed)
+            costs = rows_to_cost_map(recomputed)
+            st.session_state["studio_costs"] = costs
+            st.dataframe(
+                pd.DataFrame(recomputed)[
+                    ["measure_id", "applicable_ft2", "implementation_cost_usd", "note"]
+                ],
+                width="stretch",
+                hide_index=True,
+            )
 
-        rows = []
+        st.divider()
+        st.subheader("Capital plan + guardrails")
+        if not plan_measures:
+            st.info(
+                "Cherry-pick at least one measure above (or Build measures / Easy Buttons) "
+                "to roll up capital plan."
+            )
+            return
+
+        st.caption(f"Capital plan includes {len(plan_measures)} measure(s): {', '.join(plan_measures)}")
+        proxy_profile = _enrich_profile_for_proxies(profile)
+        econ_rows = []
+        for mid in plan_measures:
+            p = proxies.get(mid) or {}
+            if mid not in proxies:
+                # lazy proxy if engineer only checked Easy Buttons
+                try:
+                    proxies.update(estimate_proxy_savings(proxy_profile, [mid]))
+                    p = proxies.get(mid) or {}
+                    st.session_state["studio_proxies"] = proxies
+                except Exception:
+                    p = {}
+            cost = float(costs.get(mid) or 0.0)
+            if cost <= 0:
+                cost = (usd_per_ft2 * area) / max(len(plan_measures), 1)
+            econ_rows.append(
+                measure_economics(
+                    measure_id=mid,
+                    implementation_cost_usd=cost,
+                    kwh_saved=float(p.get("savings_kwh") or 0.0),
+                    therms_saved=float(p.get("savings_therms") or 0.0),
+                    elec_rate_usd_per_kwh=float(elec),
+                    gas_rate_usd_per_therm=float(gas),
+                    discount_rate=float(discount),
+                    escalation_rate=float(escalation),
+                    measure_life_years=int(life_years),
+                )
+            )
+        # Prefer EnergyPlus savings when a report exists
         report = st.session_state.get("studio_report") or {}
         ep_by = {}
         for s in report.get("savings_by_measure") or []:
@@ -411,469 +723,187 @@ def render() -> None:
             vs = (s.get("vs_previous") or s.get("vs_baseline") or {})
             if mid:
                 ep_by[mid] = vs
-        focus = cherry or measures
-        for mid in measures:
-            p = proxies.get(mid) or {}
-            ep = ep_by.get(mid) or {}
-            esco_kwh = p.get("savings_kwh")
-            esco_therms = p.get("savings_therms")
-            ep_kwh = ep.get("kwh_saved")
-            ep_therms = ep.get("therms_saved")
-            has_ep = ep_kwh is not None or ep_therms is not None
-            xc = crosscheck_measure(
-                measure_id=mid,
-                ep_savings_kwh=None if ep_kwh is None else float(ep_kwh),
-                proxy_savings_kwh=None if esco_kwh is None else float(esco_kwh),
-                ep_savings_therms=None if ep_therms is None else float(ep_therms),
-                proxy_savings_therms=None if esco_therms is None else float(esco_therms),
-            )
-            ratio = xc.get("agreement_ratio")
-            ratio_th = xc.get("agreement_ratio_therms")
-            delta_kwh = None
-            pct_kwh = None
-            if ep_kwh is not None and esco_kwh is not None:
-                delta_kwh = float(ep_kwh) - float(esco_kwh)
-                if abs(float(esco_kwh)) > 1e-9:
-                    pct_kwh = 100.0 * delta_kwh / float(esco_kwh)
-            delta_therms = None
-            pct_therms = None
-            if ep_therms is not None and esco_therms is not None:
-                delta_therms = float(ep_therms) - float(esco_therms)
-                if abs(float(esco_therms)) > 1e-9:
-                    pct_therms = 100.0 * delta_therms / float(esco_therms)
-            verdict = xc.get("verdict_canonical") or xc.get("verdict")
-            rows.append({
-                "in_plan": "✓" if mid in focus else "",
-                "light": _traffic_light(verdict=verdict, has_ep=has_ep),
-                "measure_id": mid,
-                "esco_kwh": esco_kwh,
-                "ep_kwh": ep_kwh,
-                "delta_kwh": None if delta_kwh is None else round(delta_kwh, 1),
-                "pct_vs_esco_kwh": None if pct_kwh is None else round(pct_kwh, 1),
-                "esco_therms": esco_therms,
-                "ep_therms": ep_therms,
-                "delta_therms": None if delta_therms is None else round(delta_therms, 1),
-                "pct_vs_esco_therms": None if pct_therms is None else round(pct_therms, 1),
-                "agreement_ratio": ratio,
-                "agreement_ratio_therms": ratio_th,
-                "verdict": verdict,
-                "cost_usd": costs.get(mid),
-            })
-        st.markdown("#### Selected measures — ESCO spreadsheet vs EnergyPlus")
-        st.caption(
-            "ESCO = bin-method screening (`wattlab/studio/proxies.py`). "
-            "EP = Twin `savings_by_measure` when present. "
-            "Δ / % = EP − ESCO (positive ⇒ E+ saves more). "
-            "Verdict from `wattlab.crosscheck` (~0.5–2× = reasonable). "
-            "Yellow without EP columns means run Twin measure sims before trusting green."
-        )
-        st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
+        if ep_by:
+            for row in econ_rows:
+                mid = row.get("measure_id")
+                if mid in ep_by:
+                    row["kwh_saved"] = float(ep_by[mid].get("kwh_saved") or row.get("kwh_saved") or 0)
+                    row["therms_saved"] = float(ep_by[mid].get("therms_saved") or row.get("therms_saved") or 0)
+                    if ep_by[mid].get("peak_demand_kw_delta") is not None:
+                        row["peak_demand_kw_delta"] = ep_by[mid]["peak_demand_kw_delta"]
 
-    # Capital plan / ROI use cherry-pick when set
-    plan_measures = cherry if cherry else measures
-
-    st.divider()
-    st.subheader("ROI screening parameters")
-    st.caption(
-        "Utility rates + discount for NPV. Per-ECM capital uses $/ft² × coverage "
-        "below (Liberty-style: set coverage=0.5 when only half the building gets DDC/G36)."
-    )
-    area = float(
-        profile.get("conditioned_floor_area_ft2")
-        or profile.get("floor_area_ft2")
-        or 50000.0
-    )
-    bench = st.session_state.get("studio_benchmark_summary") or {}
-    if isinstance(bench, dict) and bench.get("campus"):
-        area = float(bench["campus"].get("floor_area_ft2") or area)
-    rates = profile.get("utility") or {}
-    from wattlab.finance import (
-        DEFAULT_DISCOUNT_RATE,
-        DEFAULT_ESCALATION_RATE,
-        DEFAULT_MEASURE_LIFE_YEARS,
-    )
-
-    # Prefill package rollup $/ft2 from controls_first band
-    cost_usd_per_ft2_default = 3.0
-    try:
-        from wattlab.benchmarks.costs import load_registry
-
-        bands = {r["scope"]: r for r in load_registry()}
-        if "controls_first" in bands:
-            cost_usd_per_ft2_default = float(bands["controls_first"].get("p50") or 3.0)
-    except Exception as exc:
-        st.caption(f"Retrofit cost-band prefill unavailable ({exc}); using ${cost_usd_per_ft2_default:g}/ft² default.")
-
-    r1, r2, r3 = st.columns(3)
-    with r1:
-        elec = st.number_input(
-            "Elec $/kWh",
-            min_value=0.01,
-            max_value=1.0,
-            value=float(rates.get("elec_usd_per_kwh") or 0.12),
-            step=0.01,
-            key="ecm_roi_elec",
-        )
-        gas = st.number_input(
-            "Gas $/therm",
-            min_value=0.1,
-            max_value=5.0,
-            value=float(rates.get("gas_usd_per_therm") or 0.80),
-            step=0.05,
-            key="ecm_roi_gas",
-        )
-    with r2:
-        discount = st.number_input(
-            "Discount rate",
-            min_value=0.0,
-            max_value=0.2,
-            value=float(DEFAULT_DISCOUNT_RATE),
-            step=0.005,
-            format="%.3f",
-            key="ecm_roi_discount",
-        )
-        escalation = st.number_input(
-            "Utility escalation",
-            min_value=0.0,
-            max_value=0.1,
-            value=float(DEFAULT_ESCALATION_RATE),
-            step=0.005,
-            format="%.3f",
-            key="ecm_roi_escalation",
-        )
-    with r3:
-        life_years = st.number_input(
-            "Measure life (yr)",
-            min_value=5,
-            max_value=40,
-            value=int(DEFAULT_MEASURE_LIFE_YEARS),
-            key="ecm_roi_life",
-        )
-        usd_per_ft2 = st.number_input(
-            "Fallback package $/ft²",
-            min_value=0.0,
-            max_value=100.0,
-            value=float(cost_usd_per_ft2_default),
-            step=0.25,
-            key="ecm_roi_usd_ft2",
-            help="Used only when a measure has no per-ECM $/ft² / fixed cost.",
-        )
-    st.caption(f"Floor area for $/ft² math: {area:,.0f} ft²")
-
-    # --- Per-ECM ROI cost calculator ---
-    if plan_measures:
-        from wattlab.studio.ecm_roi import (
-            implementation_cost_usd,
-            rows_to_cost_map,
-            rows_to_models,
-            seed_roi_cost_rows,
-        )
-
-        st.markdown("#### Per-ECM ROI cost calculator")
-        st.caption(
-            "Prefills are screening defaults for the **cherry-picked** set. Edit **usd_per_ft2** and "
-            "**coverage_fraction** (0–1 of floor area) or set **fixed_usd** for a "
-            "lump-sum quote. Example: G36 needs 50% DDC → coverage=0.5."
-        )
-        seed = seed_roi_cost_rows(
-            plan_measures,
-            floor_area_ft2=area,
-            existing=st.session_state.get("studio_ecm_roi_models"),
-        )
-        edited = st.data_editor(
-            pd.DataFrame(seed),
-            width="stretch",
-            hide_index=True,
-            num_rows="fixed",
-            column_config={
-                "measure_id": st.column_config.TextColumn("ECM", disabled=True),
-                "usd_per_ft2": st.column_config.NumberColumn("$/ft²", min_value=0.0, step=0.05, format="%.2f"),
-                "coverage_fraction": st.column_config.NumberColumn(
-                    "Coverage", min_value=0.0, max_value=1.0, step=0.05, format="%.2f",
-                    help="Fraction of building floor area that receives this ECM",
-                ),
-                "applicable_ft2": st.column_config.NumberColumn("ft² applied", disabled=True),
-                "fixed_usd": st.column_config.NumberColumn(
-                    "Fixed $ (optional)", min_value=0.0, step=1000.0, format="%.0f",
-                ),
-                "implementation_cost_usd": st.column_config.NumberColumn(
-                    "Cost $", disabled=True, format="%.0f"
-                ),
-                "note": st.column_config.TextColumn("Note", width="large"),
-            },
-            key="ecm_roi_cost_editor",
-        )
-        # Recompute costs from edited $/ft2 + coverage / fixed
-        recomputed: list[dict] = []
-        for _, r in edited.iterrows():
-            mid = str(r["measure_id"])
-            usd = float(r.get("usd_per_ft2") or 0.0)
-            cov = float(r.get("coverage_fraction") or 1.0)
-            fixed_raw = r.get("fixed_usd")
-            fixed_f = None
-            if fixed_raw is not None and not (isinstance(fixed_raw, float) and pd.isna(fixed_raw)):
-                try:
-                    fv = float(fixed_raw)
-                    if fv > 0:
-                        fixed_f = fv
-                except (TypeError, ValueError):
-                    fixed_f = None
-            cost = implementation_cost_usd(
-                floor_area_ft2=area,
-                usd_per_ft2=usd,
-                coverage_fraction=cov,
-                fixed_usd=fixed_f,
-            )
-            recomputed.append(
-                {
-                    "measure_id": mid,
-                    "usd_per_ft2": usd,
-                    "coverage_fraction": cov,
-                    "applicable_ft2": round(area * max(0.0, min(1.0, cov)), 0),
-                    "fixed_usd": fixed_f,
-                    "implementation_cost_usd": round(cost, 0),
-                    "note": str(r.get("note") or ""),
-                }
-            )
-        st.session_state["studio_ecm_roi_rows"] = recomputed
-        st.session_state["studio_ecm_roi_models"] = rows_to_models(recomputed)
-        costs = rows_to_cost_map(recomputed)
-        st.session_state["studio_costs"] = costs
-        st.dataframe(
-            pd.DataFrame(recomputed)[
-                ["measure_id", "applicable_ft2", "implementation_cost_usd", "note"]
-            ],
-            width="stretch",
-            hide_index=True,
-        )
-
-    st.divider()
-    st.subheader("Capital plan + guardrails")
-    if not plan_measures:
-        st.info(
-            "Cherry-pick at least one measure above (or Build measures / Easy Buttons) "
-            "to roll up capital plan."
-        )
-        return
-
-    st.caption(f"Capital plan includes {len(plan_measures)} measure(s): {', '.join(plan_measures)}")
-    proxy_profile = _enrich_profile_for_proxies(profile)
-    econ_rows = []
-    for mid in plan_measures:
-        p = proxies.get(mid) or {}
-        if mid not in proxies:
-            # lazy proxy if engineer only checked Easy Buttons
-            try:
-                proxies.update(estimate_proxy_savings(proxy_profile, [mid]))
-                p = proxies.get(mid) or {}
-                st.session_state["studio_proxies"] = proxies
-            except Exception:
-                p = {}
-        cost = float(costs.get(mid) or 0.0)
-        if cost <= 0:
-            cost = (usd_per_ft2 * area) / max(len(plan_measures), 1)
-        econ_rows.append(
-            measure_economics(
-                measure_id=mid,
-                implementation_cost_usd=cost,
-                kwh_saved=float(p.get("savings_kwh") or 0.0),
-                therms_saved=float(p.get("savings_therms") or 0.0),
-                elec_rate_usd_per_kwh=float(elec),
-                gas_rate_usd_per_therm=float(gas),
-                discount_rate=float(discount),
-                escalation_rate=float(escalation),
-                measure_life_years=int(life_years),
-            )
-        )
-    # Prefer EnergyPlus savings when a report exists
-    report = st.session_state.get("studio_report") or {}
-    ep_by = {}
-    for s in report.get("savings_by_measure") or []:
-        mid = s.get("measure_id")
-        vs = (s.get("vs_previous") or s.get("vs_baseline") or {})
-        if mid:
-            ep_by[mid] = vs
-    if ep_by:
-        for row in econ_rows:
-            mid = row.get("measure_id")
-            if mid in ep_by:
-                row["kwh_saved"] = float(ep_by[mid].get("kwh_saved") or row.get("kwh_saved") or 0)
-                row["therms_saved"] = float(ep_by[mid].get("therms_saved") or row.get("therms_saved") or 0)
-                if ep_by[mid].get("peak_demand_kw_delta") is not None:
-                    row["peak_demand_kw_delta"] = ep_by[mid]["peak_demand_kw_delta"]
-
-    # Show demand columns from report when present
-    demand_preview = []
-    for s in report.get("savings_by_measure") or []:
-        if s.get("peak_demand_kw") is not None:
-            demand_preview.append(
-                {
-                    "measure_id": s.get("measure_id"),
-                    "peak_demand_kw": s.get("peak_demand_kw"),
-                    "vs_baseline_kw": (s.get("vs_baseline") or {}).get("peak_demand_kw_delta"),
-                }
-            )
-    if demand_preview:
-        st.markdown("**Peak demand (kW)** from EnergyPlus results")
-        st.dataframe(pd.DataFrame(demand_preview), width="stretch", hide_index=True)
-
-    plan = capital_plan(econ_rows)
-    st.session_state["studio_capital_plan"] = plan
-
-    from wattlab.benchmarks.guardrails import gate_capital_plan
-
-    property_type = str(profile.get("building_type") or profile.get("property_type") or "office")
-    site_eui = None
-    if isinstance(bench, dict) and bench.get("campus"):
-        site_eui = bench["campus"].get("site_eui_kbtu_ft2")
-    gate = gate_capital_plan(
-        plan,
-        property_type=property_type,
-        floor_area_ft2=area,
-        site_eui_kbtu_ft2=site_eui,
-    )
-    st.session_state["studio_guardrail_gate"] = gate
-
-    if gate["verdict"] == "INVESTIGATE":
-        st.error(f"Benchmark gate: INVESTIGATE — {gate['investigate_count']} check(s)")
-    else:
-        st.success("Benchmark gate: PUBLISH")
-    with st.expander("Guardrail checks", expanded=gate["verdict"] == "INVESTIGATE"):
-        st.dataframe(
-            pd.DataFrame([
-                {"check": c["check"], "status": c["status"], "detail": c["detail"]}
-                for c in gate["checks"]
-            ]),
-            width="stretch",
-            hide_index=True,
-        )
-
-    totals = plan["totals"]
-    c1, c2, c3, c4 = st.columns(4)
-    c1.metric("Total cost", f"${totals['implementation_cost_usd']:,.0f}")
-    c2.metric("Annual savings", f"${totals['annual_cost_saved_usd']:,.0f}")
-    pb = totals.get("blended_simple_payback_years")
-    c3.metric("Blended payback", f"{pb:.1f} yr" if pb is not None else "—")
-    c4.metric("Portfolio NPV", f"${totals['npv_usd']:,.0f}")
-    # Portfolio ROI from lifetime savings vs cost (screening)
-    life_sav = sum(float(m.get("lifetime_savings_usd") or 0) for m in plan["measures"])
-    total_cost = float(totals.get("implementation_cost_usd") or 0)
-    if total_cost > 0 and life_sav:
-        st.metric("Portfolio ROI over life", f"{(life_sav - total_cost) / total_cost * 100:.0f}%")
-
-    st.dataframe(
-        pd.DataFrame(plan["measures"]).drop(columns=["assumptions"], errors="ignore"),
-        width="stretch",
-        hide_index=True,
-    )
-    out = reports_dir() / "capital_plan.json"
-    out.write_text(json.dumps(plan, indent=2), encoding="utf-8")
-    scenario = {
-        "measures": measures,
-        "proxies": proxies,
-        "costs": costs,
-        "ecm_roi_models": st.session_state.get("studio_ecm_roi_models") or {},
-        "ecm_roi_rows": st.session_state.get("studio_ecm_roi_rows") or [],
-        "roi_params": {
-            "elec_usd_per_kwh": elec,
-            "gas_usd_per_therm": gas,
-            "discount_rate": discount,
-            "escalation_rate": escalation,
-            "measure_life_years": life_years,
-            "usd_per_ft2": usd_per_ft2,
-            "floor_area_ft2": area,
-        },
-        "capital_plan_totals": totals,
-        "guardrail_gate": {
-            "verdict": gate.get("verdict"),
-            "investigate_count": gate.get("investigate_count"),
-            "checks": gate.get("checks"),
-        },
-    }
-    (reports_dir() / "ecm_scenario_results.json").write_text(
-        json.dumps(scenario, indent=2), encoding="utf-8"
-    )
-    d1, d2, d3 = st.columns(3)
-    d1.download_button(
-        "Download capital plan CSV",
-        data=plan_to_csv(plan),
-        file_name="wattlab_capital_plan.csv",
-        mime="text/csv",
-        key="ecm_dl_csv",
-    )
-    d2.download_button(
-        "Download capital plan JSON",
-        data=json.dumps(plan, indent=2),
-        file_name="wattlab_capital_plan.json",
-        mime="application/json",
-        key="ecm_dl_json",
-    )
-    d3.download_button(
-        "Download ECM scenario results",
-        data=json.dumps(scenario, indent=2),
-        file_name="ecm_scenario_results.json",
-        mime="application/json",
-        key="ecm_dl_scenario",
-    )
-    st.caption(f"Also written to `{out}` for agents.")
-
-    st.subheader("Client energy-model package")
-    st.caption(
-        "Optional Twin zip (report + results xlsx). Prefer the Engineering notebook above for ECM ROI. "
-        "DOCX is off by default."
-    )
-    docx_available = find_spec("docx") is not None
-    include_docx = st.checkbox(
-        "Include client DOCX",
-        value=False,
-        disabled=not docx_available,
-        key="ecm_include_client_docx",
-    )
-    if not docx_available:
-        st.caption("Client DOCX is unavailable until the optional `python-docx` dependency is installed.")
-    if st.button("Build client package from ECM report", key="ecm_build_deliverable"):
-        from wattlab.deliverables import package_deliverables
-
-        if not report:
-            st.warning("No studio_report yet — run Twin / easy-button first.")
-        else:
-            rid = report.get("run_id") or "ecm_report"
-            dest = reports_dir() / f"deliverable_{rid}"
-            try:
-                sc = {
-                    "run_id": rid,
-                    "status": "screening",
-                    "annual": ((report.get("result_records") or [{}])[0] or {}).get("annual"),
-                    "weather_suitability": report.get("weather_suitability"),
-                    "prototype_area_scale": report.get("prototype_area_scale"),
-                    "sizing_scenario": report.get("sizing_scenario"),
-                    "utility_bills": {},
-                }
-                active_ids = {str(m) for m in (measures or [])}
-                proxy_for_pkg = {
-                    k: v
-                    for k, v in (proxies or {}).items()
-                    if str(k) in active_ids
-                }
-                meta = package_deliverables(
-                    out_dir=dest,
-                    scorecard=sc,
-                    report={**report, "proxy_savings": proxy_for_pkg},
-                    profile=profile,
-                    include_docx=include_docx,
+        # Show demand columns from report when present
+        demand_preview = []
+        for s in report.get("savings_by_measure") or []:
+            if s.get("peak_demand_kw") is not None:
+                demand_preview.append(
+                    {
+                        "measure_id": s.get("measure_id"),
+                        "peak_demand_kw": s.get("peak_demand_kw"),
+                        "vs_baseline_kw": (s.get("vs_baseline") or {}).get("peak_demand_kw_delta"),
+                    }
                 )
-                st.session_state["studio_deliverable"] = meta
-                st.success(f"Package → {meta.get('out_dir')}")
-                if meta.get("docx_note"):
-                    st.caption(str(meta["docx_note"]))
-            except Exception as exc:
-                st.error(str(exc))
-    deliv = st.session_state.get("studio_deliverable") or {}
-    if deliv.get("zip_path") and Path(str(deliv["zip_path"])).is_file():
-        st.download_button(
-            "Download energy-model package (.zip)",
-            data=Path(str(deliv["zip_path"])).read_bytes(),
-            file_name=Path(str(deliv["zip_path"])).name,
-            mime="application/zip",
-            key="ecm_dl_deliverable_zip",
+        if demand_preview:
+            st.markdown("**Peak demand (kW)** from EnergyPlus results")
+            st.dataframe(pd.DataFrame(demand_preview), width="stretch", hide_index=True)
+
+        plan = capital_plan(econ_rows)
+        st.session_state["studio_capital_plan"] = plan
+
+        from wattlab.benchmarks.guardrails import gate_capital_plan
+
+        property_type = str(profile.get("building_type") or profile.get("property_type") or "office")
+        site_eui = None
+        if isinstance(bench, dict) and bench.get("campus"):
+            site_eui = bench["campus"].get("site_eui_kbtu_ft2")
+        gate = gate_capital_plan(
+            plan,
+            property_type=property_type,
+            floor_area_ft2=area,
+            site_eui_kbtu_ft2=site_eui,
         )
+        st.session_state["studio_guardrail_gate"] = gate
+
+        if gate["verdict"] == "INVESTIGATE":
+            st.error(f"Benchmark gate: INVESTIGATE — {gate['investigate_count']} check(s)")
+        else:
+            st.success("Benchmark gate: PUBLISH")
+        with st.expander("Guardrail checks", expanded=gate["verdict"] == "INVESTIGATE"):
+            st.dataframe(
+                pd.DataFrame([
+                    {"check": c["check"], "status": c["status"], "detail": c["detail"]}
+                    for c in gate["checks"]
+                ]),
+                width="stretch",
+                hide_index=True,
+            )
+
+        totals = plan["totals"]
+        c1, c2, c3, c4 = st.columns(4)
+        c1.metric("Total cost", f"${totals['implementation_cost_usd']:,.0f}")
+        c2.metric("Annual savings", f"${totals['annual_cost_saved_usd']:,.0f}")
+        pb = totals.get("blended_simple_payback_years")
+        c3.metric("Blended payback", f"{pb:.1f} yr" if pb is not None else "—")
+        c4.metric("Portfolio NPV", f"${totals['npv_usd']:,.0f}")
+        # Portfolio ROI from lifetime savings vs cost (screening)
+        life_sav = sum(float(m.get("lifetime_savings_usd") or 0) for m in plan["measures"])
+        total_cost = float(totals.get("implementation_cost_usd") or 0)
+        if total_cost > 0 and life_sav:
+            st.metric("Portfolio ROI over life", f"{(life_sav - total_cost) / total_cost * 100:.0f}%")
+
+        st.dataframe(
+            pd.DataFrame(plan["measures"]).drop(columns=["assumptions"], errors="ignore"),
+            width="stretch",
+            hide_index=True,
+        )
+        out = reports_dir() / "capital_plan.json"
+        out.write_text(json.dumps(plan, indent=2), encoding="utf-8")
+        scenario = {
+            "measures": measures,
+            "proxies": proxies,
+            "costs": costs,
+            "ecm_roi_models": st.session_state.get("studio_ecm_roi_models") or {},
+            "ecm_roi_rows": st.session_state.get("studio_ecm_roi_rows") or [],
+            "roi_params": {
+                "elec_usd_per_kwh": elec,
+                "gas_usd_per_therm": gas,
+                "discount_rate": discount,
+                "escalation_rate": escalation,
+                "measure_life_years": life_years,
+                "usd_per_ft2": usd_per_ft2,
+                "floor_area_ft2": area,
+            },
+            "capital_plan_totals": totals,
+            "guardrail_gate": {
+                "verdict": gate.get("verdict"),
+                "investigate_count": gate.get("investigate_count"),
+                "checks": gate.get("checks"),
+            },
+        }
+        (reports_dir() / "ecm_scenario_results.json").write_text(
+            json.dumps(scenario, indent=2), encoding="utf-8"
+        )
+        d1, d2, d3 = st.columns(3)
+        d1.download_button(
+            "Download capital plan CSV",
+            data=plan_to_csv(plan),
+            file_name="wattlab_capital_plan.csv",
+            mime="text/csv",
+            key="ecm_dl_csv",
+        )
+        d2.download_button(
+            "Download capital plan JSON",
+            data=json.dumps(plan, indent=2),
+            file_name="wattlab_capital_plan.json",
+            mime="application/json",
+            key="ecm_dl_json",
+        )
+        d3.download_button(
+            "Download ECM scenario results",
+            data=json.dumps(scenario, indent=2),
+            file_name="ecm_scenario_results.json",
+            mime="application/json",
+            key="ecm_dl_scenario",
+        )
+        st.caption(f"Also written to `{out}` for agents.")
+
+        st.subheader("Client energy-model package")
+        st.caption(
+            "Optional Twin zip (report + results xlsx). Prefer the Engineering notebook above for ECM ROI. "
+            "DOCX is off by default."
+        )
+        docx_available = find_spec("docx") is not None
+        include_docx = st.checkbox(
+            "Include client DOCX",
+            value=False,
+            disabled=not docx_available,
+            key="ecm_include_client_docx",
+        )
+        if not docx_available:
+            st.caption("Client DOCX is unavailable until the optional `python-docx` dependency is installed.")
+        if st.button("Build client package from ECM report", key="ecm_build_deliverable"):
+            from wattlab.deliverables import package_deliverables
+
+            if not report:
+                st.warning("No studio_report yet — run Twin / easy-button first.")
+            else:
+                rid = report.get("run_id") or "ecm_report"
+                dest = reports_dir() / f"deliverable_{rid}"
+                try:
+                    sc = {
+                        "run_id": rid,
+                        "status": "screening",
+                        "annual": ((report.get("result_records") or [{}])[0] or {}).get("annual"),
+                        "weather_suitability": report.get("weather_suitability"),
+                        "prototype_area_scale": report.get("prototype_area_scale"),
+                        "sizing_scenario": report.get("sizing_scenario"),
+                        "utility_bills": {},
+                    }
+                    active_ids = {str(m) for m in (measures or [])}
+                    proxy_for_pkg = {
+                        k: v
+                        for k, v in (proxies or {}).items()
+                        if str(k) in active_ids
+                    }
+                    meta = package_deliverables(
+                        out_dir=dest,
+                        scorecard=sc,
+                        report={**report, "proxy_savings": proxy_for_pkg},
+                        profile=profile,
+                        include_docx=include_docx,
+                    )
+                    st.session_state["studio_deliverable"] = meta
+                    st.success(f"Package → {meta.get('out_dir')}")
+                    if meta.get("docx_note"):
+                        st.caption(str(meta["docx_note"]))
+                except Exception as exc:
+                    st.error(str(exc))
+        deliv = st.session_state.get("studio_deliverable") or {}
+        if deliv.get("zip_path") and Path(str(deliv["zip_path"])).is_file():
+            st.download_button(
+                "Download energy-model package (.zip)",
+                data=Path(str(deliv["zip_path"])).read_bytes(),
+                file_name=Path(str(deliv["zip_path"])).name,
+                mime="application/zip",
+                key="ecm_dl_deliverable_zip",
+            )


### PR DESCRIPTION
## Summary
- **BUG-030:** `notebook prefill` patches Inputs in-place (keeps EPlus_Results)
- **BUG-031/032/035:** ROI `B=H` + live NPV formula; `npv_usd_at_build` cache; preview `data_only=False`
- **BUG-033:** Docs/Cover honesty — template is scaffold only
- **BUG-034:** validate warning + Twin run picker prefers `savings_by_measure`
- **BUG-036:** Easy Buttons / capital / client DOCX behind Advanced expander
- **BUG-037:** `tests/test_notebook_builder.py`
- **BUG-038/039/040:** Overview chart dedupe, relative paths, `n_priority_findings`

## Test plan
- [x] `pytest vibe20/tests/test_notebook_builder.py`
- [x] vibe19 xlsx + AppTest smoke
- [ ] GHCR refresh `:8502` / `:8520`

Made with [Cursor](https://cursor.com)