### PR TITLE
feat(vibe20): Excel-only ECMs + agent formula UX (BUG-043–046)

### DIFF
--- a/vibe_code_apps_20/scripts/smoke_studio.py
+++ b/vibe_code_apps_20/scripts/smoke_studio.py
@@ -84,18 +84,14 @@ def main() -> int:
     print("OK: Twin deliverable build (no Streamlit exceptions)")
 
     at.radio(key="studio_page").set_value("ECMs").run()
-    at.button(key="ecm_build_measures").click().run()
+    at.button(key="ecm_notebook_build").click().run()
     if at.exception:
-        return _fail(at, "ECMs(build)")
-    try:
-        gate = at.session_state["studio_guardrail_gate"]
-    except KeyError:
-        print("FAIL: studio_guardrail_gate missing after ECMs build")
+        return _fail(at, "ECMs(notebook_build)")
+    page = " ".join(str(x) for x in at.markdown) + " ".join(str(x) for x in at.caption)
+    if "Advanced — Easy Buttons" in page or "Include client DOCX" in page:
+        print("FAIL: Advanced / DOCX still present on ECMs (BUG-043)")
         return 1
-    print(
-        f"OK: loaded walk complete - guardrail verdict {gate.get('verdict')} "
-        f"({gate.get('investigate_count')} investigate)"
-    )
+    print("OK: ECMs Excel-only notebook build (no Streamlit exceptions)")
     return 0
 
 

--- a/vibe_code_apps_20/tests/test_monthly_pct_off.py
+++ b/vibe_code_apps_20/tests/test_monthly_pct_off.py
@@ -108,3 +108,42 @@ def test_load_per_month_from_run(tmp_path: Path):
 def test_format_empty():
     empty = {"n": 0, "over": [], "under": [], "ok": [], "ok_band_pct": 15}
     assert "no monthly" in format_fuel_narrative(empty, label="Gas").lower()
+
+
+def test_gas_only_scorecard_elec_n_zero():
+    """G14 can still show elec aggregates while per_month lacks kWh pairs."""
+    rows = [
+        {"month": "2024-01", "observed_therms": 100, "modeled_therms": 110},
+        {"month": "2024-07", "observed_therms": 50, "modeled_therms": 40},
+        {"month": "2024-12", "observed_therms": 100, "modeled_therms": 130},
+    ]
+    analysis = build_monthly_pct_off(rows)
+    assert analysis["has_data"]
+    assert analysis["gas"]["n"] == 3
+    assert analysis["elec"]["n"] == 0
+    assert "Gas" in (analysis["gas_narrative"] or "")
+    assert analysis["elec_narrative"]  # still a "no monthly" style line from format
+
+
+def test_fuel_filter_both_vs_elec_only_counts():
+    rows = [
+        {
+            "month": "2024-01",
+            "observed_kwh": 100,
+            "modeled_kwh": 120,
+            "observed_therms": 50,
+            "modeled_therms": 40,
+        },
+        {
+            "month": "2024-07",
+            "observed_kwh": 100,
+            "modeled_kwh": 90,
+            "observed_therms": 20,
+            "modeled_therms": 20,
+        },
+    ]
+    a = build_monthly_pct_off(rows)
+    assert a["elec"]["n"] == 2
+    assert a["gas"]["n"] == 2
+    # Panel is Streamlit-only; filter semantics match analyze counts above
+    assert a["elec"]["over"] or a["elec"]["under"] or a["elec"]["ok"]

--- a/vibe_code_apps_20/tests/test_notebook_builder.py
+++ b/vibe_code_apps_20/tests/test_notebook_builder.py
@@ -14,6 +14,8 @@ from wattlab.notebooks.builder import (
     prefill_notebook_inputs,
     preview_sheet_rows,
     read_notebook_inputs,
+    refresh_notebook_caches,
+    show_formulas,
     summarize_notebook,
     validate_notebook,
 )
@@ -153,3 +155,53 @@ def test_workbook_does_not_load_template_file():
     src = inspect.getsource(b.build_notebook_workbook)
     assert "load_workbook" not in src
     assert "Workbook()" in src
+
+
+def test_refresh_caches_and_show_formulas(tmp_path: Path):
+    from openpyxl import load_workbook
+
+    from wattlab.notebooks.builder import refresh_notebook_caches, show_formulas
+    from wattlab.notebooks.cli import main
+
+    written = build_and_save_notebook(
+        "controls_first",
+        tmp_path,
+        profile={"conditioned_floor_area_ft2": 140_000, "utility": {"elec_usd_per_kwh": 0.14}},
+    )
+    xlsx = written["xlsx"]
+    wb0 = load_workbook(xlsx, data_only=False)
+    assert str(wb0["ROI_Capital"]["B2"].value).startswith("=H")
+    assert str(wb0["ROI_Capital"]["G2"].value).startswith("=IF")
+    i_before = wb0["ROI_Capital"]["I2"].value
+
+    prefill_notebook_inputs(xlsx, overrides={"elec_rate": 0.30})
+    result = refresh_notebook_caches(xlsx)
+    assert result["updated_cells"] >= 1
+    wb1 = load_workbook(xlsx, data_only=False)
+    # Formulas preserved
+    assert str(wb1["ROI_Capital"]["B2"].value).startswith("=H")
+    assert str(wb1["ROI_Capital"]["G2"].value).startswith("=IF")
+    # Cache column refreshed (may change with higher elec rate)
+    assert wb1["ROI_Capital"]["I2"].value is not None
+    assert isinstance(wb1["ROI_Capital"]["I2"].value, (int, float))
+    # Area not wiped
+    assert read_notebook_inputs(xlsx)["area_ft2"] == 140_000
+    assert read_notebook_inputs(xlsx)["elec_rate"] == 0.30
+
+    formulas = show_formulas(xlsx, sheet="ROI_Capital")
+    assert "ROI_Capital" in formulas["sheets"]
+    assert any(v.startswith("=") for v in formulas["sheets"]["ROI_Capital"].values())
+
+    rc = main(["show-formulas", "--xlsx", str(xlsx), "--sheet", "ROI_Capital"])
+    assert rc == 0
+    rc2 = main(["refresh-caches", "--xlsx", str(xlsx)])
+    assert rc2 == 0
+    _ = i_before  # silence unused when NPV equals
+
+
+def test_manifest_includes_formula_cells(tmp_path: Path):
+    written = build_and_save_notebook("controls_first", tmp_path, profile={"floor_area_ft2": 50_000})
+    man = summarize_notebook(written["xlsx"])
+    assert "formula_cells" in man
+    assert "ROI_Capital" in man["formula_cells"]
+    assert man["honesty"]["esco_kwh_therms"] == "baked_at_build"

--- a/vibe_code_apps_20/tests/test_studio_app.py
+++ b/vibe_code_apps_20/tests/test_studio_app.py
@@ -122,9 +122,22 @@ def test_studio_twin_and_ecms_dry_path():
 
     at.radio(key="studio_page").set_value("ECMs").run()
     assert not at.exception
-    at.button(key="ecm_build_measures").click().run()
+    # BUG-043: Advanced / DOCX / Easy Buttons removed
+    page = " ".join(str(x) for x in at.markdown) + " ".join(str(x) for x in at.caption)
+    assert "Advanced — Easy Buttons" not in page
+    assert "Include client DOCX" not in page
+    # Notebook primary path present
+    assert any(
+        "ecm_notebook_build" in str(getattr(b, "key", "") or "")
+        or "Build" in str(getattr(b, "label", "") or "")
+        for b in at.button
+    )
+    at.button(key="ecm_notebook_build").click().run()
     assert not at.exception
-    assert "studio_guardrail_gate" in at.session_state
+    # Preview mode radio (Formulas / Values)
+    assert any(
+        "ecm_notebook_preview_mode" in str(getattr(r, "key", "") or "") for r in at.radio
+    ) or "studio_notebook_path" in at.session_state
 
 
 def test_turnkey_live_html_smoke():

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_DOCKER_WORKSPACE.md
@@ -279,6 +279,12 @@ docker exec vibe20 ls -la /data/runs
 EnergyPlus itself runs in `energyplus-mcp-dev` via the mounted docker socket
 (DinD). Do **not** expect host `pyenergyplus` or a live Flask mid-run server.
 
+**bensbench / QA gap (BUG-045):** if `docker exec vibe20 ls /var/run/docker.sock`
+fails, easy-button EP cascades cannot run and Twin dials often lack
+`savings_by_measure`. Recreate the container with the sock mount above, then
+`wattlab energyplus-ensure`, then the one-shot recipe in `AGENT_TOOLS.md`
+(easy-button → notebook build `--from-run`).
+
 ## Equal look-and-feel (ops)
 
 | Concern | vibe19 | vibe20 |

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
@@ -66,13 +66,51 @@ wattlab notebook build --package esco_top15 --out /data/reports/notebooks/ \
   --answers /data/reports/answers.json --from-run /data/runs/<ecm_capable>
 wattlab notebook prefill --xlsx /data/reports/notebooks/esco_top15.xlsx --elec-rate 0.22
 # prefill patches Inputs in-place (keeps EPlus_Results) — never rebuilds
+wattlab notebook refresh-caches --xlsx /data/reports/notebooks/esco_top15.xlsx
+wattlab notebook show-formulas --xlsx /data/reports/notebooks/esco_top15.xlsx --sheet ROI_Capital
 wattlab notebook validate --xlsx /data/reports/notebooks/esco_top15.xlsx
 wattlab notebook summarize --xlsx … --write
 ```
 
-Honesty: ESCO kWh/therms are baked at build; ROI cost/NPV formulas follow Inputs.
-Studio preview shows formula text + `npv_usd_at_build` (openpyxl does not calc Excel).
+Honesty: ESCO kWh/therms are baked at build (not live Excel bins); ROI cost/NPV formulas follow Inputs.
+Studio ECMs page: Values + Formulas preview; no Easy Buttons / DOCX (BUG-043).
 Prefer Twin runs with `savings_by_measure` or Compare stays YELLOW (`validate` warns).
+
+### Easy-button → notebook (Docker sock required) — BUG-045
+
+Host must mount `/var/run/docker.sock` into vibe20 and pull the EnergyPlus image.
+Without the sock, `wattlab easy-button` plans OK but cannot run EP cascades.
+
+```bash
+# Host: recreate vibe20 with sock (see AGENT_DOCKER_WORKSPACE.md)
+# docker run … -v /var/run/docker.sock:/var/run/docker.sock \
+#   -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace …
+
+docker exec vibe20 wattlab energyplus-ensure
+docker exec -e WATTLAB_HOST_WORKSPACE=/data -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 \
+  wattlab easy-button --measure-set better \
+  --minimal-file /data/reports/answers_building_100.json
+# → publishes /data/runs/<id> with savings_by_measure when EP succeeds
+
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 wattlab notebook build \
+  --package controls_first \
+  --answers /data/reports/answers_building_100.json \
+  --from-run /data/runs/<published_easy_button_run> \
+  --out /data/reports/notebooks/
+docker exec vibe20 wattlab notebook validate \
+  --xlsx /data/reports/notebooks/controls_first.xlsx
+```
+
+Liberty 5-pack (agents, no Easy Button UI clicks):
+
+```bash
+for pkg in controls_first schedules_economizer plant_optimization esco_top15 deep_retrofit; do
+  wattlab notebook build --package "$pkg" \
+    --answers /data/reports/answers_building_100.json \
+    --from-run /data/runs/<ecm_capable> \
+    --out /data/reports/notebooks/
+done
+```
 
 Write `reports/ecm_scenario.json` v3 with `notebook_package_id`, `notebook_path`,
 `input_overrides` so Studio Re-apply / ECMs page stays in sync.

--- a/vibe_code_apps_20/wattlab/notebooks/__init__.py
+++ b/vibe_code_apps_20/wattlab/notebooks/__init__.py
@@ -8,6 +8,8 @@ from wattlab.notebooks.builder import (
     prefill_notebook_inputs,
     preview_sheet_rows,
     read_notebook_inputs,
+    refresh_notebook_caches,
+    show_formulas,
     summarize_notebook,
     validate_notebook,
 )
@@ -21,6 +23,8 @@ __all__ = [
     "prefill_notebook_inputs",
     "preview_sheet_rows",
     "read_notebook_inputs",
+    "refresh_notebook_caches",
+    "show_formulas",
     "summarize_notebook",
     "validate_notebook",
 ]

--- a/vibe_code_apps_20/wattlab/notebooks/builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/builder.py
@@ -211,9 +211,9 @@ def build_notebook_workbook(
         ("ESCO docs", ESCO_DOCS_URL),
         (
             "Note",
-            "Yellow Inputs drive rate-linked formulas (annual $, payback, NPV, Compare). "
-            "ESCO kWh/therms are screening proxies baked at build (see Docs). "
-            "Workbook is generated in code — templates/ecm_package_v1.xlsx is a scaffold only.",
+            "Yellow Inputs drive rate-linked Excel formulas (annual $, payback, NPV, cost B=H). "
+            "ESCO kWh/therms are Python screening proxies baked at build — not bin-method Excel "
+            "(see Docs + ESCO_SPREADSHEET_CALCS.md). Scaffold template is not loaded at build.",
         ),
     ]
     for i, (k, v) in enumerate(rows, start=4):
@@ -431,7 +431,17 @@ def build_notebook_workbook(
     docs["A11"] = "E+ Compare"
     docs["B11"] = (
         "YELLOW light when Twin report lacks savings_by_measure — "
-        "pick an ECM-capable run (validate warns)"
+        "pick an ECM-capable run (validate warns); easy-button needs Docker sock"
+    )
+    docs["A12"] = "ESCO kWh/therms honesty"
+    docs["B12"] = (
+        "Baked at build via wattlab.studio.proxies / bench/esco.py — "
+        "not live Excel bin blocks. Human map: docs/ESCO_SPREADSHEET_CALCS.md"
+    )
+    docs["A13"] = "Agent refresh"
+    docs["B13"] = (
+        "wattlab notebook prefill (Inputs) | refresh-caches (npv_usd_at_build) | "
+        "show-formulas --sheet ROI_Capital"
     )
     docs.column_dimensions["A"].width = 28
     docs.column_dimensions["B"].width = 80
@@ -530,6 +540,178 @@ def prefill_notebook_inputs(
         updated.append(param)
     wb.save(path)
     return {"path": str(path), "updated": updated, "inputs": read_notebook_inputs(path)}
+
+
+def collect_formula_cells(
+    path: Path | str,
+    *,
+    sheets: tuple[str, ...] = ("ESCO_Calcs", "Compare", "ROI_Capital"),
+    max_cells: int = 500,
+) -> dict[str, dict[str, str]]:
+    """Map sheet → {A1: formula} for agent formula UX (BUG-044)."""
+    from openpyxl import load_workbook
+    from openpyxl.utils import get_column_letter
+
+    path = Path(path)
+    wb = load_workbook(path, data_only=False)
+    out: dict[str, dict[str, str]] = {}
+    n = 0
+    for sheet in sheets:
+        if sheet not in wb.sheetnames:
+            continue
+        ws = wb[sheet]
+        cells: dict[str, str] = {}
+        for row in ws.iter_rows(min_row=1, max_row=ws.max_row or 1, max_col=ws.max_column or 1):
+            for cell in row:
+                val = cell.value
+                if isinstance(val, str) and val.startswith("="):
+                    addr = f"{get_column_letter(cell.column)}{cell.row}"
+                    cells[addr] = val
+                    n += 1
+                    if n >= max_cells:
+                        out[sheet] = cells
+                        return out
+        if cells:
+            out[sheet] = cells
+    return out
+
+
+def show_formulas(
+    path: Path | str,
+    *,
+    sheet: str | None = None,
+) -> dict[str, Any]:
+    """CLI-friendly formula dump for one sheet or all formula sheets."""
+    path = Path(path)
+    sheets = (sheet,) if sheet else ("ESCO_Calcs", "Compare", "ROI_Capital", "Inputs")
+    cells = collect_formula_cells(path, sheets=tuple(s for s in sheets if s))
+    return {"path": str(path.resolve()), "sheets": cells}
+
+
+def refresh_notebook_caches(path: Path | str) -> dict[str, Any]:
+    """Recompute Python cache columns without wiping formulas (BUG-044).
+
+    Updates ``ROI_Capital!I`` (npv_usd_at_build) from current Inputs rates +
+    ROI C/D savings and cost (H formula evaluated in Python from Inputs).
+    Does not rewrite Inputs, Compare formulas, ESCO B/C, or EPlus_Results.
+    """
+    from openpyxl import load_workbook
+
+    from wattlab.finance import measure_economics
+
+    path = Path(path)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    wb = load_workbook(path, data_only=False)
+    if "Inputs" not in wb.sheetnames or "ROI_Capital" not in wb.sheetnames:
+        raise ValueError("Inputs and ROI_Capital sheets required")
+
+    inputs = {}
+    for row in wb["Inputs"].iter_rows(min_row=2, max_col=2, values_only=True):
+        if row[0]:
+            inputs[str(row[0])] = row[1]
+
+    def _f(key: str, default: float) -> float:
+        try:
+            v = inputs.get(key)
+            return float(v) if v is not None and v != "" else float(default)
+        except (TypeError, ValueError):
+            return float(default)
+
+    area = _f("area_ft2", 50000)
+    usd = _f("usd_per_ft2", 3.0)
+    cov = _f("coverage", 1.0)
+    elec = _f("elec_rate", 0.12)
+    gas = _f("gas_rate", 0.80)
+    disc = _f("discount", 0.05)
+    esc = _f("escalation", 0.02)
+    life = int(_f("life_years", 15))
+
+    roi = wb["ROI_Capital"]
+    # Count measure rows (stop at TOTAL / blank)
+    measure_rows: list[int] = []
+    for r in range(2, (roi.max_row or 2) + 1):
+        mid = roi.cell(r, 1).value
+        if mid is None or str(mid).strip() == "" or str(mid).upper() == "TOTAL":
+            break
+        measure_rows.append(r)
+    n_meas = max(len(measure_rows), 1)
+    package_cost = usd * area * cov / n_meas
+
+    updated = 0
+    for r in measure_rows:
+        mid = str(roi.cell(r, 1).value)
+        # Cost: if B is formula, use package_cost; else numeric override
+        bval = roi.cell(r, 2).value
+        if isinstance(bval, str) and bval.startswith("="):
+            cost = package_cost
+        else:
+            try:
+                cost = float(bval) if bval is not None else package_cost
+            except (TypeError, ValueError):
+                cost = package_cost
+        try:
+            kwh = float(roi.cell(r, 3).value or 0)
+        except (TypeError, ValueError):
+            kwh = 0.0
+        try:
+            therms = float(roi.cell(r, 4).value or 0)
+        except (TypeError, ValueError):
+            therms = 0.0
+        econ = measure_economics(
+            measure_id=mid,
+            implementation_cost_usd=cost,
+            kwh_saved=kwh,
+            therms_saved=therms,
+            elec_rate_usd_per_kwh=elec,
+            gas_rate_usd_per_therm=gas,
+            discount_rate=disc,
+            escalation_rate=esc,
+            measure_life_years=life,
+        )
+        # Column I = npv_usd_at_build (header row 1)
+        roi.cell(r, 9).value = econ["npv_usd"]
+        updated += 1
+
+    # Refresh TOTAL row I if present
+    tot_row = (measure_rows[-1] + 1) if measure_rows else None
+    if tot_row and str(roi.cell(tot_row + 1, 1).value or "").upper() == "TOTAL":
+        # TOTAL is n+2 in builder (blank line?) — builder uses tot = n+2 with A=TOTAL
+        pass
+    for r in range(2, (roi.max_row or 2) + 1):
+        if str(roi.cell(r, 1).value or "").upper() == "TOTAL":
+            # Leave SUM formula on I if present; else sum caches
+            ival = roi.cell(r, 9).value
+            if not (isinstance(ival, str) and ival.startswith("=")):
+                s = 0.0
+                for mr in measure_rows:
+                    try:
+                        s += float(roi.cell(mr, 9).value or 0)
+                    except (TypeError, ValueError):
+                        pass
+                roi.cell(r, 9).value = round(s, 2)
+            break
+
+    wb.save(path)
+    # Rewrite manifest formula map
+    man_path = path.parent / f"{path.stem}.notebook_manifest.json"
+    if man_path.is_file() or True:
+        man = summarize_notebook(path)
+        man_path.write_text(json.dumps(man, indent=2) + "\n", encoding="utf-8")
+    return {
+        "path": str(path),
+        "updated_cells": updated,
+        "manifest": str(man_path),
+        "inputs_used": {
+            "area_ft2": area,
+            "elec_rate": elec,
+            "gas_rate": gas,
+            "discount": disc,
+            "escalation": esc,
+            "life_years": life,
+            "package_cost_per_measure": round(package_cost, 2),
+        },
+    }
 
 
 def build_and_save_notebook(
@@ -650,6 +832,7 @@ def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = No
         except Exception:
             pass
     validated = validate_notebook(path)
+    formula_cells = collect_formula_cells(path)
     return {
         "schema": "wattlab_notebook_manifest_v1",
         "path": str(path.resolve()),
@@ -661,6 +844,7 @@ def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = No
         "compare": verdicts,
         "guardrail_verdict": gate,
         "inputs": inputs,
+        "formula_cells": formula_cells,
         "docs_url": ESCO_DOCS_URL,
         "validated": validated,
         "ep_coverage": {
@@ -711,12 +895,15 @@ def write_template_stub(path: Path | str) -> Path:
 __all__ = [
     "build_and_save_notebook",
     "build_notebook_workbook",
+    "collect_formula_cells",
     "default_inputs_from_profile",
     "list_notebook_packages",
     "prefill_notebook_inputs",
     "preview_sheet_rows",
     "read_notebook_inputs",
+    "refresh_notebook_caches",
     "save_workbook",
+    "show_formulas",
     "summarize_notebook",
     "validate_notebook",
     "write_template_stub",

--- a/vibe_code_apps_20/wattlab/notebooks/cli.py
+++ b/vibe_code_apps_20/wattlab/notebooks/cli.py
@@ -92,6 +92,18 @@ def main(argv: list[str] | None = None) -> int:
     sm.add_argument("--write", action="store_true", help="Write sidecar next to xlsx")
     sm.set_defaults(func=_cmd_summarize)
 
+    rc = sub.add_parser(
+        "refresh-caches",
+        help="Recompute npv_usd_at_build from Inputs without wiping formulas (BUG-044)",
+    )
+    rc.add_argument("--xlsx", type=Path, required=True)
+    rc.set_defaults(func=_cmd_refresh)
+
+    sf = sub.add_parser("show-formulas", help="Dump Excel formula cells as JSON (BUG-044)")
+    sf.add_argument("--xlsx", type=Path, required=True)
+    sf.add_argument("--sheet", type=str, default=None, help="Limit to one sheet (e.g. ROI_Capital)")
+    sf.set_defaults(func=_cmd_show_formulas)
+
     tp = sub.add_parser("write-template", help="Write scaffold template xlsx under templates/")
     tp.add_argument(
         "--out",
@@ -213,11 +225,34 @@ def _cmd_summarize(args: argparse.Namespace) -> int:
     man = summarize_notebook(args.xlsx)
     print(json.dumps(man, indent=2))
     if args.write:
-        mp = args.xlsx.with_suffix("").with_name(args.xlsx.stem + ".notebook_manifest.json")
-        # stem.xlsx → stem.notebook_manifest.json
         mp = args.xlsx.parent / f"{args.xlsx.stem}.notebook_manifest.json"
         mp.write_text(json.dumps(man, indent=2) + "\n", encoding="utf-8")
         print(f"wrote {mp}", file=sys.stderr)
+    return 0
+
+
+def _cmd_refresh(args: argparse.Namespace) -> int:
+    from wattlab.notebooks.builder import refresh_notebook_caches
+
+    if not args.xlsx.is_file():
+        print(f"missing workbook: {args.xlsx}", file=sys.stderr)
+        return 2
+    try:
+        result = refresh_notebook_caches(args.xlsx)
+    except Exception as exc:
+        print(f"refresh-caches failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, default=str))
+    return 0
+
+
+def _cmd_show_formulas(args: argparse.Namespace) -> int:
+    from wattlab.notebooks.builder import show_formulas
+
+    if not args.xlsx.is_file():
+        print(f"missing workbook: {args.xlsx}", file=sys.stderr)
+        return 2
+    print(json.dumps(show_formulas(args.xlsx, sheet=args.sheet), indent=2))
     return 0
 
 

--- a/vibe_code_apps_20/wattlab/studio/monthly_pct_off.py
+++ b/vibe_code_apps_20/wattlab/studio/monthly_pct_off.py
@@ -205,8 +205,18 @@ def load_per_month_from_run(run_dir: Path | str | None) -> list[dict[str, Any]]:
     return []
 
 
-def render_monthly_pct_off_panel(analysis: dict[str, Any]) -> None:
-    """Streamlit panel for Inspect / Modeled-vs-actual."""
+def render_monthly_pct_off_panel(
+    analysis: dict[str, Any],
+    *,
+    fuel_filter: str = "both",
+    key_prefix: str = "monthly_pct_off",
+) -> None:
+    """Streamlit panel for Inspect / Modeled-vs-actual.
+
+    ``fuel_filter``: ``elec`` | ``gas`` | ``both`` (default).
+    Always surfaces a caption when a requested fuel lacks monthly pairs,
+    even if the other fuel (or aggregate G14 stats) look fine.
+    """
     import streamlit as st
 
     if not analysis.get("has_data"):
@@ -223,13 +233,38 @@ def render_monthly_pct_off_panel(analysis: dict[str, Any]) -> None:
     )
     gas_n = (analysis.get("gas") or {}).get("n") or 0
     elec_n = (analysis.get("elec") or {}).get("n") or 0
-    if gas_n:
-        st.markdown(analysis.get("gas_narrative") or "")
-    if elec_n:
-        st.markdown(analysis.get("elec_narrative") or "")
-    # Compact table
+    want = (fuel_filter or "both").lower().strip()
+    show_elec = want in ("elec", "electricity", "both", "all")
+    show_gas = want in ("gas", "natural_gas", "ng", "both", "all")
+
+    if show_gas:
+        if gas_n:
+            st.markdown(analysis.get("gas_narrative") or "")
+        else:
+            st.info(
+                "Gas: no monthly bill↔model pairs in this scorecard "
+                "(`observed_therms` + `modeled_therms` / `simulated_therms`). "
+                "G14 gas metrics above may still come from annual aggregates."
+            )
+    if show_elec:
+        if elec_n:
+            st.markdown(analysis.get("elec_narrative") or "")
+        else:
+            st.info(
+                "Elec: no monthly bill↔model pairs in this scorecard "
+                "(`observed_kwh` + `modeled_kwh` / `simulated_kwh`). "
+                "G14 elec metrics above may still come from annual aggregates — "
+                "that is why PASS can show without an elec monthly ±% panel."
+            )
+
+    # Compact table (filtered)
     rows_out: list[dict[str, Any]] = []
-    for fuel_key, label in (("elec", "Elec"), ("gas", "Gas")):
+    fuels = []
+    if show_elec:
+        fuels.append(("elec", "Elec"))
+    if show_gas:
+        fuels.append(("gas", "Gas"))
+    for fuel_key, label in fuels:
         b = analysis.get(fuel_key) or {}
         for bucket_name, items in (
             ("over", b.get("over") or []),
@@ -248,4 +283,9 @@ def render_monthly_pct_off_panel(analysis: dict[str, Any]) -> None:
     if rows_out:
         import pandas as pd
 
-        st.dataframe(pd.DataFrame(rows_out), width="stretch", hide_index=True, height=220)
+        st.dataframe(
+            pd.DataFrame(rows_out),
+            width="stretch",
+            hide_index=True,
+            height=220,
+        )

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -1,19 +1,15 @@
-"""ECMs + capital plan guardrails (folded Easy Buttons)."""
+"""ECMs — Excel engineering notebooks only (BUG-043)."""
 
 from __future__ import annotations
 
 import json
-from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
 import streamlit as st
 
-from wattlab.finance import capital_plan, measure_economics, plan_to_csv
-from wattlab.measures.measure_sets import expand_measure_set, list_measure_sets
 from wattlab.studio.g14_history import assign_run_numbers, iter_g14_history, pick_best_g14_run
-from wattlab.studio.proxies import DEFAULT_MEASURE_COSTS, estimate_proxy_savings
 from wattlab.studio.workspace import reports_dir, runs_dir
 
 
@@ -52,30 +48,13 @@ def _enrich_profile_for_proxies(profile: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-def _traffic_light(*, verdict: str | None, has_ep: bool) -> str:
-    """🟢 in-line · 🟡 method gap / ESCO-only · 🔴 investigate / implausible."""
-    if not has_ep:
-        return "🟡"
-    canon = str(verdict or "").upper()
-    legacy = str(verdict or "").lower()
-    if canon == "IN_LINE" or legacy == "in_line":
-        return "🟢"
-    if (
-        canon == "REASONABLE_METHOD_DIFFERENCE"
-        or canon == "INSUFFICIENT_EVIDENCE"
-        or legacy == "investigate"
-    ):
-        return "🟡"
-    return "🔴"
-
-
 def _render_baseline_run_picker() -> None:
-    """Selectbox of Twin runs; default = best G14; store studio_ecm_baseline_run."""
+    """Selectbox of Twin runs; prefer savings_by_measure (E+ measures)."""
     st.subheader("Twin baseline run")
     st.caption(
-        "ECMs savings/deliverable context follows the selected Twin publish. "
-        "Prefer a run with ``savings_by_measure`` so Compare is not all YELLOW. "
-        "Default is best G14 (PASS preferred, else lowest |NMBE|+CVRMSE)."
+        "Notebook Compare uses Twin ``savings_by_measure`` when present. "
+        "Prefer a run tagged **E+ measures**. Easy-button EP cascades need Docker "
+        "socket + EnergyPlus on the host (see AGENT_TOOLS.md)."
     )
     try:
         rows = assign_run_numbers(iter_g14_history(runs_dir(), limit=40))
@@ -89,7 +68,6 @@ def _render_baseline_run_picker() -> None:
     opts = [str(r["dir"]) for r in rows if r.get("dir")]
     by_dir = {str(r["dir"]): r for r in rows if r.get("dir")}
 
-    # Annotate which runs have E+ measure savings (BUG-034)
     has_sbm: dict[str, bool] = {}
     for d in opts:
         rep = _load_run_report(d)
@@ -102,7 +80,6 @@ def _render_baseline_run_picker() -> None:
         default_dir = str(best["dir"])
     else:
         default_dir = opts[-1] if opts else None
-    # Prefer ECM-capable run when default lacks savings_by_measure
     if default_dir and not has_sbm.get(default_dir):
         with_sbm = [d for d in opts if has_sbm.get(d)]
         if with_sbm:
@@ -159,13 +136,44 @@ def _render_baseline_run_picker() -> None:
             )
 
 
+def _preview_sheet_frame(path: Path, sheet: str, *, mode: str) -> pd.DataFrame | None:
+    """Build a Values or Formulas preview frame (never blank formula cells)."""
+    from wattlab.notebooks.builder import preview_sheet_rows
+
+    if mode == "values":
+        # Prefer formula-text overlay for formula cells + numeric caches
+        formula_rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=False)
+        value_rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=True)
+        if not formula_rows:
+            return None
+        header = formula_rows[0]
+        body: list[list[Any]] = []
+        for i, frow in enumerate(formula_rows[1:]):
+            vrow = value_rows[i + 1] if value_rows and i + 1 < len(value_rows) else []
+            merged: list[Any] = []
+            for j, cell in enumerate(frow):
+                if isinstance(cell, str) and cell.startswith("="):
+                    # Values mode: show cache-friendly display — use data_only if present else keep formula
+                    vc = vrow[j] if j < len(vrow) else None
+                    merged.append(vc if vc is not None else cell)
+                else:
+                    merged.append(cell)
+            body.append(merged)
+        return pd.DataFrame(body, columns=header)
+
+    rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=False)
+    if not rows:
+        return None
+    return pd.DataFrame(rows[1:], columns=rows[0])
+
+
 def _render_engineering_notebook(profile: dict[str, Any]) -> None:
-    """Primary ECM deliverable: package Excel notebook (preview + download)."""
+    """Primary ECM deliverable: package Excel notebook (Values/Formulas + download)."""
     from wattlab.notebooks import (
         build_and_save_notebook,
         list_notebook_packages,
-        preview_sheet_rows,
     )
+    from wattlab.notebooks.builder import refresh_notebook_caches, validate_notebook
     from wattlab.studio.ecm_scenario import (
         default_ecm_scenario_path,
         load_ecm_scenario,
@@ -174,9 +182,8 @@ def _render_engineering_notebook(profile: dict[str, Any]) -> None:
 
     st.subheader("Engineering notebook (Excel)")
     st.caption(
-        "Primary deliverable: least→radical Excel package (ESCO vs E+ + ROI). "
-        "Preview shows formulas as text + ``npv_usd_at_build`` cache (open Excel to evaluate). "
-        "Agents: `wattlab notebook build|prefill|validate|summarize`."
+        "Excel is the ECM contract: build/refresh → Values + Formulas preview → download. "
+        "Agents: `wattlab notebook build|prefill|refresh-caches|show-formulas|validate|summarize`."
     )
     st.markdown(
         "[ESCO formula map (GitHub)]"
@@ -196,7 +203,13 @@ def _render_engineering_notebook(profile: dict[str, Any]) -> None:
     st.caption(f"{pkg.honesty} · {len(pkg.measure_ids)} measures · catalog `{pkg.catalog_package}`")
 
     out_dir = reports_dir() / "notebooks"
-    if st.button("Build / refresh notebook", type="primary", key="ecm_notebook_build"):
+    c1, c2 = st.columns(2)
+    with c1:
+        build_clicked = st.button("Build / refresh notebook", type="primary", key="ecm_notebook_build")
+    with c2:
+        refresh_clicked = st.button("Refresh caches only", key="ecm_notebook_refresh_caches")
+
+    if build_clicked:
         try:
             proxy_profile = _enrich_profile_for_proxies(profile)
             report = st.session_state.get("studio_report") or {}
@@ -212,12 +225,9 @@ def _render_engineering_notebook(profile: dict[str, Any]) -> None:
             )
             st.session_state["studio_notebook_path"] = str(written["xlsx"])
             st.session_state["studio_notebook_manifest"] = str(written.get("manifest") or "")
-            from wattlab.notebooks.builder import validate_notebook
-
             v = validate_notebook(written["xlsx"])
             for w in v.get("warnings") or []:
                 st.warning(w)
-            # Persist for agents
             scen = load_ecm_scenario()
             scen["notebook_package_id"] = pick
             scen["notebook_path"] = str(written["xlsx"])
@@ -230,29 +240,39 @@ def _render_engineering_notebook(profile: dict[str, Any]) -> None:
 
     xlsx = st.session_state.get("studio_notebook_path")
     if not xlsx or not Path(str(xlsx)).is_file():
-        # Autoload if package file already on disk
         candidate = out_dir / f"{pick}.xlsx"
         if candidate.is_file():
             xlsx = str(candidate)
             st.session_state["studio_notebook_path"] = xlsx
+
+    if refresh_clicked:
+        if not xlsx or not Path(str(xlsx)).is_file():
+            st.warning("Build a notebook first, then refresh caches.")
+        else:
+            try:
+                result = refresh_notebook_caches(xlsx)
+                st.success(f"Caches refreshed: {result.get('updated_cells', 0)} cells")
+            except Exception as exc:
+                st.error(f"refresh-caches failed: {exc}")
+
     if xlsx and Path(str(xlsx)).is_file():
         path = Path(str(xlsx))
-        st.caption(
-            "Preview uses formula text (not Excel-calculated). "
-            "Use ``npv_usd_at_build`` / Inputs values for agent numbers; open Excel for live NPV."
+        mode = st.radio(
+            "Preview mode",
+            options=["formulas", "values"],
+            format_func=lambda k: "Formulas (Excel code)" if k == "formulas" else "Values (caches / static)",
+            horizontal=True,
+            key="ecm_notebook_preview_mode",
+            help="Formulas = exact cell formula text. Values = numeric caches where Excel has not calc'd.",
         )
         tabs = st.tabs(["Inputs", "Compare", "ROI_Capital"])
         for tab, sheet in zip(tabs, ("Inputs", "Compare", "ROI_Capital")):
             with tab:
-                rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=False)
-                if not rows:
+                df = _preview_sheet_frame(path, sheet, mode=mode)
+                if df is None or df.empty:
                     st.caption(f"Sheet `{sheet}` empty or missing.")
                 else:
-                    st.dataframe(
-                        pd.DataFrame(rows[1:], columns=rows[0] if rows else None),
-                        width="stretch",
-                        hide_index=True,
-                    )
+                    st.dataframe(df, width="stretch", hide_index=True)
         st.download_button(
             "Download engineering notebook (.xlsx)",
             data=path.read_bytes(),
@@ -276,8 +296,9 @@ def _render_engineering_notebook(profile: dict[str, Any]) -> None:
 def render() -> None:
     st.header("ECMs — engineering notebooks")
     st.caption(
-        "Primary deliverable is an Excel notebook per package (ESCO vs EnergyPlus + ROI). "
-        "Easy Buttons / capital-plan details live under Advanced."
+        "Excel is the primary ECM deliverable (one package → one `.xlsx`). "
+        "No Easy Buttons / capital-plan / client DOCX on this page — use Twin + "
+        "`wattlab easy-button` / `wattlab notebook` CLIs for EP cascades."
     )
 
     profile = st.session_state.get("studio_profile")
@@ -298,612 +319,3 @@ def render() -> None:
     _render_baseline_run_picker()
     st.divider()
     _render_engineering_notebook(profile)
-    st.divider()
-
-    with st.expander(
-        "Advanced — Easy Buttons, measure sets, capital plan, client DOCX",
-        expanded=False,
-    ):
-        from wattlab.studio.pages.ecm_easy_buttons import render as render_easy
-
-        render_easy(profile=profile, proxy_estimator=estimate_proxy_savings)
-        st.divider()
-        st.subheader("Measure set + proxy pricing")
-        st.caption("Optional legacy path — Engineering notebook above is preferred for deliverables.")
-        sets = list_measure_sets()
-        set_ids = [s["id"] for s in sets] or ["best"]
-        labels = {s["id"]: f"{s['label']} — {', '.join(s['measure_ids'])}" for s in sets}
-        mset = st.selectbox(
-            "Measure set",
-            set_ids,
-            format_func=lambda k: labels.get(k, k),
-            index=max(0, len(set_ids) - 1),
-            key="ecm_measure_set",
-        )
-        if st.button("Build measures + proxies", key="ecm_build_measures"):
-            measure_rows = expand_measure_set(str(mset))
-            ids = [str(m.get("measure_id")) for m in measure_rows if m.get("measure_id")]
-            # Prefer Easy Button scenario if present
-            scenario_ids = st.session_state.get("ecm_easy__scenario_ids") or st.session_state.get(
-                "ecm_easy_scenario_ids"
-            )
-            if not scenario_ids:
-                # namespaced_key may use a different separator — also check common keys
-                for k, v in st.session_state.items():
-                    if "scenario_ids" in str(k) and isinstance(v, list) and v:
-                        scenario_ids = v
-                        break
-            if scenario_ids:
-                ids = list(dict.fromkeys([str(x) for x in scenario_ids] + ids))
-                measure_rows = [{"measure_id": mid} for mid in ids]
-            proxy_profile = _enrich_profile_for_proxies(profile)
-            proxies = estimate_proxy_savings(proxy_profile, ids)
-            from wattlab.studio.ecm_roi import rows_to_cost_map, seed_roi_cost_rows
-
-            area0 = float(
-                proxy_profile.get("conditioned_floor_area_ft2")
-                or proxy_profile.get("floor_area_ft2")
-                or 50000.0
-            )
-            roi_rows = seed_roi_cost_rows(
-                ids,
-                floor_area_ft2=area0,
-                existing=st.session_state.get("studio_ecm_roi_models"),
-            )
-            costs = rows_to_cost_map(roi_rows)
-            # Blend with hard-coded lump sums when ROI model is tiny
-            for mid in ids:
-                if costs.get(mid, 0) <= 0:
-                    costs[mid] = DEFAULT_MEASURE_COSTS.get(mid, 10000.0)
-            st.session_state["studio_measures"] = measure_rows
-            st.session_state["studio_proxies"] = proxies
-            st.session_state["studio_costs"] = costs
-            st.session_state["studio_ecm_roi_rows"] = roi_rows
-            st.session_state["studio_measure_set"] = str(mset)
-            # Default cherry-pick to first measure only (avoid dumping full capital stack)
-            if ids and not st.session_state.get("studio_ecm_cherry_pick"):
-                st.session_state["studio_ecm_cherry_pick"] = [ids[0]]
-            st.success(f"{len(ids)} measures priced (proxy + $/ft² ROI seed).")
-
-        measure_rows = st.session_state.get("studio_measures") or []
-        if measure_rows and isinstance(measure_rows[0], str):
-            measure_rows = [{"measure_id": m} for m in measure_rows]
-        measures = [str(m.get("measure_id")) for m in measure_rows if isinstance(m, dict) and m.get("measure_id")]
-        # Also pull Easy Button scenario into comparison when measures empty
-        if not measures:
-            for k, v in st.session_state.items():
-                if "scenario_ids" in str(k) and isinstance(v, list) and v:
-                    measures = [str(x) for x in v]
-                    break
-        proxies = st.session_state.get("studio_proxies") or {}
-        costs = st.session_state.get("studio_costs") or {}
-
-        cherry: list[str] = []
-        if measures:
-            st.markdown("#### Cherry-pick package")
-            st.caption(
-                "Capital plan + ROI rollup use only the measures below. "
-                "Start with one ECM, compare ESCO ↔ EnergyPlus, then add more."
-            )
-            stored_cherry = st.session_state.get("studio_ecm_cherry_pick")
-            cur = [m for m in (stored_cherry or []) if m in measures]
-            if not cur:
-                cur = [measures[0]]
-            st.session_state["studio_ecm_cherry_pick"] = cur
-            cherry = st.multiselect(
-                "Active measures (capital plan)",
-                options=measures,
-                key="studio_ecm_cherry_pick",
-                help="Deselect everything you do not want in NPV / payback totals.",
-            )
-            c_run, c_hint = st.columns([1, 2])
-            with c_run:
-                if st.button("Recalc ESCO for cherry-pick", key="ecm_recalc_cherry"):
-                    if not cherry:
-                        st.warning("Select at least one measure.")
-                    else:
-                        proxy_profile = _enrich_profile_for_proxies(profile)
-                        from wattlab.studio.proxies import resolve_proxy_inputs
-
-                        inputs = resolve_proxy_inputs(proxy_profile)
-                        new_px = estimate_proxy_savings(proxy_profile, cherry)
-                        proxies = {**(st.session_state.get("studio_proxies") or {}), **new_px}
-                        st.session_state["studio_proxies"] = proxies
-                        src = ", ".join(inputs.get("sources") or [])
-                        st.success(
-                            f"ESCO proxies refreshed for {len(cherry)} measure(s) "
-                            f"(inputs: {src}; area={inputs['area_ft2']:,.0f} ft²"
-                            + (
-                                f", {inputs['cooling_tons']:g} tons"
-                                if inputs.get("cooling_tons")
-                                else ""
-                            )
-                            + (
-                                f", {inputs['fan_hp']:g} HP"
-                                if inputs.get("fan_hp")
-                                else ""
-                            )
-                            + ")."
-                        )
-            with c_hint:
-                st.caption(
-                    "🟢 in-line · 🟡 method difference or ESCO-only · 🔴 investigate / implausible"
-                )
-
-        if measures:
-            from wattlab.crosscheck import crosscheck_measure
-
-            rows = []
-            report = st.session_state.get("studio_report") or {}
-            ep_by = {}
-            for s in report.get("savings_by_measure") or []:
-                mid = s.get("measure_id")
-                vs = (s.get("vs_previous") or s.get("vs_baseline") or {})
-                if mid:
-                    ep_by[mid] = vs
-            focus = cherry or measures
-            for mid in measures:
-                p = proxies.get(mid) or {}
-                ep = ep_by.get(mid) or {}
-                esco_kwh = p.get("savings_kwh")
-                esco_therms = p.get("savings_therms")
-                ep_kwh = ep.get("kwh_saved")
-                ep_therms = ep.get("therms_saved")
-                has_ep = ep_kwh is not None or ep_therms is not None
-                xc = crosscheck_measure(
-                    measure_id=mid,
-                    ep_savings_kwh=None if ep_kwh is None else float(ep_kwh),
-                    proxy_savings_kwh=None if esco_kwh is None else float(esco_kwh),
-                    ep_savings_therms=None if ep_therms is None else float(ep_therms),
-                    proxy_savings_therms=None if esco_therms is None else float(esco_therms),
-                )
-                ratio = xc.get("agreement_ratio")
-                ratio_th = xc.get("agreement_ratio_therms")
-                delta_kwh = None
-                pct_kwh = None
-                if ep_kwh is not None and esco_kwh is not None:
-                    delta_kwh = float(ep_kwh) - float(esco_kwh)
-                    if abs(float(esco_kwh)) > 1e-9:
-                        pct_kwh = 100.0 * delta_kwh / float(esco_kwh)
-                delta_therms = None
-                pct_therms = None
-                if ep_therms is not None and esco_therms is not None:
-                    delta_therms = float(ep_therms) - float(esco_therms)
-                    if abs(float(esco_therms)) > 1e-9:
-                        pct_therms = 100.0 * delta_therms / float(esco_therms)
-                verdict = xc.get("verdict_canonical") or xc.get("verdict")
-                rows.append({
-                    "in_plan": "✓" if mid in focus else "",
-                    "light": _traffic_light(verdict=verdict, has_ep=has_ep),
-                    "measure_id": mid,
-                    "esco_kwh": esco_kwh,
-                    "ep_kwh": ep_kwh,
-                    "delta_kwh": None if delta_kwh is None else round(delta_kwh, 1),
-                    "pct_vs_esco_kwh": None if pct_kwh is None else round(pct_kwh, 1),
-                    "esco_therms": esco_therms,
-                    "ep_therms": ep_therms,
-                    "delta_therms": None if delta_therms is None else round(delta_therms, 1),
-                    "pct_vs_esco_therms": None if pct_therms is None else round(pct_therms, 1),
-                    "agreement_ratio": ratio,
-                    "agreement_ratio_therms": ratio_th,
-                    "verdict": verdict,
-                    "cost_usd": costs.get(mid),
-                })
-            st.markdown("#### Selected measures — ESCO spreadsheet vs EnergyPlus")
-            st.caption(
-                "ESCO = bin-method screening (`wattlab/studio/proxies.py`). "
-                "EP = Twin `savings_by_measure` when present. "
-                "Δ / % = EP − ESCO (positive ⇒ E+ saves more). "
-                "Verdict from `wattlab.crosscheck` (~0.5–2× = reasonable). "
-                "Yellow without EP columns means run Twin measure sims before trusting green."
-            )
-            st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
-
-        # Capital plan / ROI use cherry-pick when set
-        plan_measures = cherry if cherry else measures
-
-        st.divider()
-        st.subheader("ROI screening parameters")
-        st.caption(
-            "Utility rates + discount for NPV. Per-ECM capital uses $/ft² × coverage "
-            "below (Liberty-style: set coverage=0.5 when only half the building gets DDC/G36)."
-        )
-        area = float(
-            profile.get("conditioned_floor_area_ft2")
-            or profile.get("floor_area_ft2")
-            or 50000.0
-        )
-        bench = st.session_state.get("studio_benchmark_summary") or {}
-        if isinstance(bench, dict) and bench.get("campus"):
-            area = float(bench["campus"].get("floor_area_ft2") or area)
-        rates = profile.get("utility") or {}
-        from wattlab.finance import (
-            DEFAULT_DISCOUNT_RATE,
-            DEFAULT_ESCALATION_RATE,
-            DEFAULT_MEASURE_LIFE_YEARS,
-        )
-
-        # Prefill package rollup $/ft2 from controls_first band
-        cost_usd_per_ft2_default = 3.0
-        try:
-            from wattlab.benchmarks.costs import load_registry
-
-            bands = {r["scope"]: r for r in load_registry()}
-            if "controls_first" in bands:
-                cost_usd_per_ft2_default = float(bands["controls_first"].get("p50") or 3.0)
-        except Exception as exc:
-            st.caption(f"Retrofit cost-band prefill unavailable ({exc}); using ${cost_usd_per_ft2_default:g}/ft² default.")
-
-        r1, r2, r3 = st.columns(3)
-        with r1:
-            elec = st.number_input(
-                "Elec $/kWh",
-                min_value=0.01,
-                max_value=1.0,
-                value=float(rates.get("elec_usd_per_kwh") or 0.12),
-                step=0.01,
-                key="ecm_roi_elec",
-            )
-            gas = st.number_input(
-                "Gas $/therm",
-                min_value=0.1,
-                max_value=5.0,
-                value=float(rates.get("gas_usd_per_therm") or 0.80),
-                step=0.05,
-                key="ecm_roi_gas",
-            )
-        with r2:
-            discount = st.number_input(
-                "Discount rate",
-                min_value=0.0,
-                max_value=0.2,
-                value=float(DEFAULT_DISCOUNT_RATE),
-                step=0.005,
-                format="%.3f",
-                key="ecm_roi_discount",
-            )
-            escalation = st.number_input(
-                "Utility escalation",
-                min_value=0.0,
-                max_value=0.1,
-                value=float(DEFAULT_ESCALATION_RATE),
-                step=0.005,
-                format="%.3f",
-                key="ecm_roi_escalation",
-            )
-        with r3:
-            life_years = st.number_input(
-                "Measure life (yr)",
-                min_value=5,
-                max_value=40,
-                value=int(DEFAULT_MEASURE_LIFE_YEARS),
-                key="ecm_roi_life",
-            )
-            usd_per_ft2 = st.number_input(
-                "Fallback package $/ft²",
-                min_value=0.0,
-                max_value=100.0,
-                value=float(cost_usd_per_ft2_default),
-                step=0.25,
-                key="ecm_roi_usd_ft2",
-                help="Used only when a measure has no per-ECM $/ft² / fixed cost.",
-            )
-        st.caption(f"Floor area for $/ft² math: {area:,.0f} ft²")
-
-        # --- Per-ECM ROI cost calculator ---
-        if plan_measures:
-            from wattlab.studio.ecm_roi import (
-                implementation_cost_usd,
-                rows_to_cost_map,
-                rows_to_models,
-                seed_roi_cost_rows,
-            )
-
-            st.markdown("#### Per-ECM ROI cost calculator")
-            st.caption(
-                "Prefills are screening defaults for the **cherry-picked** set. Edit **usd_per_ft2** and "
-                "**coverage_fraction** (0–1 of floor area) or set **fixed_usd** for a "
-                "lump-sum quote. Example: G36 needs 50% DDC → coverage=0.5."
-            )
-            seed = seed_roi_cost_rows(
-                plan_measures,
-                floor_area_ft2=area,
-                existing=st.session_state.get("studio_ecm_roi_models"),
-            )
-            edited = st.data_editor(
-                pd.DataFrame(seed),
-                width="stretch",
-                hide_index=True,
-                num_rows="fixed",
-                column_config={
-                    "measure_id": st.column_config.TextColumn("ECM", disabled=True),
-                    "usd_per_ft2": st.column_config.NumberColumn("$/ft²", min_value=0.0, step=0.05, format="%.2f"),
-                    "coverage_fraction": st.column_config.NumberColumn(
-                        "Coverage", min_value=0.0, max_value=1.0, step=0.05, format="%.2f",
-                        help="Fraction of building floor area that receives this ECM",
-                    ),
-                    "applicable_ft2": st.column_config.NumberColumn("ft² applied", disabled=True),
-                    "fixed_usd": st.column_config.NumberColumn(
-                        "Fixed $ (optional)", min_value=0.0, step=1000.0, format="%.0f",
-                    ),
-                    "implementation_cost_usd": st.column_config.NumberColumn(
-                        "Cost $", disabled=True, format="%.0f"
-                    ),
-                    "note": st.column_config.TextColumn("Note", width="large"),
-                },
-                key="ecm_roi_cost_editor",
-            )
-            # Recompute costs from edited $/ft2 + coverage / fixed
-            recomputed: list[dict] = []
-            for _, r in edited.iterrows():
-                mid = str(r["measure_id"])
-                usd = float(r.get("usd_per_ft2") or 0.0)
-                cov = float(r.get("coverage_fraction") or 1.0)
-                fixed_raw = r.get("fixed_usd")
-                fixed_f = None
-                if fixed_raw is not None and not (isinstance(fixed_raw, float) and pd.isna(fixed_raw)):
-                    try:
-                        fv = float(fixed_raw)
-                        if fv > 0:
-                            fixed_f = fv
-                    except (TypeError, ValueError):
-                        fixed_f = None
-                cost = implementation_cost_usd(
-                    floor_area_ft2=area,
-                    usd_per_ft2=usd,
-                    coverage_fraction=cov,
-                    fixed_usd=fixed_f,
-                )
-                recomputed.append(
-                    {
-                        "measure_id": mid,
-                        "usd_per_ft2": usd,
-                        "coverage_fraction": cov,
-                        "applicable_ft2": round(area * max(0.0, min(1.0, cov)), 0),
-                        "fixed_usd": fixed_f,
-                        "implementation_cost_usd": round(cost, 0),
-                        "note": str(r.get("note") or ""),
-                    }
-                )
-            st.session_state["studio_ecm_roi_rows"] = recomputed
-            st.session_state["studio_ecm_roi_models"] = rows_to_models(recomputed)
-            costs = rows_to_cost_map(recomputed)
-            st.session_state["studio_costs"] = costs
-            st.dataframe(
-                pd.DataFrame(recomputed)[
-                    ["measure_id", "applicable_ft2", "implementation_cost_usd", "note"]
-                ],
-                width="stretch",
-                hide_index=True,
-            )
-
-        st.divider()
-        st.subheader("Capital plan + guardrails")
-        if not plan_measures:
-            st.info(
-                "Cherry-pick at least one measure above (or Build measures / Easy Buttons) "
-                "to roll up capital plan."
-            )
-            return
-
-        st.caption(f"Capital plan includes {len(plan_measures)} measure(s): {', '.join(plan_measures)}")
-        proxy_profile = _enrich_profile_for_proxies(profile)
-        econ_rows = []
-        for mid in plan_measures:
-            p = proxies.get(mid) or {}
-            if mid not in proxies:
-                # lazy proxy if engineer only checked Easy Buttons
-                try:
-                    proxies.update(estimate_proxy_savings(proxy_profile, [mid]))
-                    p = proxies.get(mid) or {}
-                    st.session_state["studio_proxies"] = proxies
-                except Exception:
-                    p = {}
-            cost = float(costs.get(mid) or 0.0)
-            if cost <= 0:
-                cost = (usd_per_ft2 * area) / max(len(plan_measures), 1)
-            econ_rows.append(
-                measure_economics(
-                    measure_id=mid,
-                    implementation_cost_usd=cost,
-                    kwh_saved=float(p.get("savings_kwh") or 0.0),
-                    therms_saved=float(p.get("savings_therms") or 0.0),
-                    elec_rate_usd_per_kwh=float(elec),
-                    gas_rate_usd_per_therm=float(gas),
-                    discount_rate=float(discount),
-                    escalation_rate=float(escalation),
-                    measure_life_years=int(life_years),
-                )
-            )
-        # Prefer EnergyPlus savings when a report exists
-        report = st.session_state.get("studio_report") or {}
-        ep_by = {}
-        for s in report.get("savings_by_measure") or []:
-            mid = s.get("measure_id")
-            vs = (s.get("vs_previous") or s.get("vs_baseline") or {})
-            if mid:
-                ep_by[mid] = vs
-        if ep_by:
-            for row in econ_rows:
-                mid = row.get("measure_id")
-                if mid in ep_by:
-                    row["kwh_saved"] = float(ep_by[mid].get("kwh_saved") or row.get("kwh_saved") or 0)
-                    row["therms_saved"] = float(ep_by[mid].get("therms_saved") or row.get("therms_saved") or 0)
-                    if ep_by[mid].get("peak_demand_kw_delta") is not None:
-                        row["peak_demand_kw_delta"] = ep_by[mid]["peak_demand_kw_delta"]
-
-        # Show demand columns from report when present
-        demand_preview = []
-        for s in report.get("savings_by_measure") or []:
-            if s.get("peak_demand_kw") is not None:
-                demand_preview.append(
-                    {
-                        "measure_id": s.get("measure_id"),
-                        "peak_demand_kw": s.get("peak_demand_kw"),
-                        "vs_baseline_kw": (s.get("vs_baseline") or {}).get("peak_demand_kw_delta"),
-                    }
-                )
-        if demand_preview:
-            st.markdown("**Peak demand (kW)** from EnergyPlus results")
-            st.dataframe(pd.DataFrame(demand_preview), width="stretch", hide_index=True)
-
-        plan = capital_plan(econ_rows)
-        st.session_state["studio_capital_plan"] = plan
-
-        from wattlab.benchmarks.guardrails import gate_capital_plan
-
-        property_type = str(profile.get("building_type") or profile.get("property_type") or "office")
-        site_eui = None
-        if isinstance(bench, dict) and bench.get("campus"):
-            site_eui = bench["campus"].get("site_eui_kbtu_ft2")
-        gate = gate_capital_plan(
-            plan,
-            property_type=property_type,
-            floor_area_ft2=area,
-            site_eui_kbtu_ft2=site_eui,
-        )
-        st.session_state["studio_guardrail_gate"] = gate
-
-        if gate["verdict"] == "INVESTIGATE":
-            st.error(f"Benchmark gate: INVESTIGATE — {gate['investigate_count']} check(s)")
-        else:
-            st.success("Benchmark gate: PUBLISH")
-        with st.expander("Guardrail checks", expanded=gate["verdict"] == "INVESTIGATE"):
-            st.dataframe(
-                pd.DataFrame([
-                    {"check": c["check"], "status": c["status"], "detail": c["detail"]}
-                    for c in gate["checks"]
-                ]),
-                width="stretch",
-                hide_index=True,
-            )
-
-        totals = plan["totals"]
-        c1, c2, c3, c4 = st.columns(4)
-        c1.metric("Total cost", f"${totals['implementation_cost_usd']:,.0f}")
-        c2.metric("Annual savings", f"${totals['annual_cost_saved_usd']:,.0f}")
-        pb = totals.get("blended_simple_payback_years")
-        c3.metric("Blended payback", f"{pb:.1f} yr" if pb is not None else "—")
-        c4.metric("Portfolio NPV", f"${totals['npv_usd']:,.0f}")
-        # Portfolio ROI from lifetime savings vs cost (screening)
-        life_sav = sum(float(m.get("lifetime_savings_usd") or 0) for m in plan["measures"])
-        total_cost = float(totals.get("implementation_cost_usd") or 0)
-        if total_cost > 0 and life_sav:
-            st.metric("Portfolio ROI over life", f"{(life_sav - total_cost) / total_cost * 100:.0f}%")
-
-        st.dataframe(
-            pd.DataFrame(plan["measures"]).drop(columns=["assumptions"], errors="ignore"),
-            width="stretch",
-            hide_index=True,
-        )
-        out = reports_dir() / "capital_plan.json"
-        out.write_text(json.dumps(plan, indent=2), encoding="utf-8")
-        scenario = {
-            "measures": measures,
-            "proxies": proxies,
-            "costs": costs,
-            "ecm_roi_models": st.session_state.get("studio_ecm_roi_models") or {},
-            "ecm_roi_rows": st.session_state.get("studio_ecm_roi_rows") or [],
-            "roi_params": {
-                "elec_usd_per_kwh": elec,
-                "gas_usd_per_therm": gas,
-                "discount_rate": discount,
-                "escalation_rate": escalation,
-                "measure_life_years": life_years,
-                "usd_per_ft2": usd_per_ft2,
-                "floor_area_ft2": area,
-            },
-            "capital_plan_totals": totals,
-            "guardrail_gate": {
-                "verdict": gate.get("verdict"),
-                "investigate_count": gate.get("investigate_count"),
-                "checks": gate.get("checks"),
-            },
-        }
-        (reports_dir() / "ecm_scenario_results.json").write_text(
-            json.dumps(scenario, indent=2), encoding="utf-8"
-        )
-        d1, d2, d3 = st.columns(3)
-        d1.download_button(
-            "Download capital plan CSV",
-            data=plan_to_csv(plan),
-            file_name="wattlab_capital_plan.csv",
-            mime="text/csv",
-            key="ecm_dl_csv",
-        )
-        d2.download_button(
-            "Download capital plan JSON",
-            data=json.dumps(plan, indent=2),
-            file_name="wattlab_capital_plan.json",
-            mime="application/json",
-            key="ecm_dl_json",
-        )
-        d3.download_button(
-            "Download ECM scenario results",
-            data=json.dumps(scenario, indent=2),
-            file_name="ecm_scenario_results.json",
-            mime="application/json",
-            key="ecm_dl_scenario",
-        )
-        st.caption(f"Also written to `{out}` for agents.")
-
-        st.subheader("Client energy-model package")
-        st.caption(
-            "Optional Twin zip (report + results xlsx). Prefer the Engineering notebook above for ECM ROI. "
-            "DOCX is off by default."
-        )
-        docx_available = find_spec("docx") is not None
-        include_docx = st.checkbox(
-            "Include client DOCX",
-            value=False,
-            disabled=not docx_available,
-            key="ecm_include_client_docx",
-        )
-        if not docx_available:
-            st.caption("Client DOCX is unavailable until the optional `python-docx` dependency is installed.")
-        if st.button("Build client package from ECM report", key="ecm_build_deliverable"):
-            from wattlab.deliverables import package_deliverables
-
-            if not report:
-                st.warning("No studio_report yet — run Twin / easy-button first.")
-            else:
-                rid = report.get("run_id") or "ecm_report"
-                dest = reports_dir() / f"deliverable_{rid}"
-                try:
-                    sc = {
-                        "run_id": rid,
-                        "status": "screening",
-                        "annual": ((report.get("result_records") or [{}])[0] or {}).get("annual"),
-                        "weather_suitability": report.get("weather_suitability"),
-                        "prototype_area_scale": report.get("prototype_area_scale"),
-                        "sizing_scenario": report.get("sizing_scenario"),
-                        "utility_bills": {},
-                    }
-                    active_ids = {str(m) for m in (measures or [])}
-                    proxy_for_pkg = {
-                        k: v
-                        for k, v in (proxies or {}).items()
-                        if str(k) in active_ids
-                    }
-                    meta = package_deliverables(
-                        out_dir=dest,
-                        scorecard=sc,
-                        report={**report, "proxy_savings": proxy_for_pkg},
-                        profile=profile,
-                        include_docx=include_docx,
-                    )
-                    st.session_state["studio_deliverable"] = meta
-                    st.success(f"Package → {meta.get('out_dir')}")
-                    if meta.get("docx_note"):
-                        st.caption(str(meta["docx_note"]))
-                except Exception as exc:
-                    st.error(str(exc))
-        deliv = st.session_state.get("studio_deliverable") or {}
-        if deliv.get("zip_path") and Path(str(deliv["zip_path"])).is_file():
-            st.download_button(
-                "Download energy-model package (.zip)",
-                data=Path(str(deliv["zip_path"])).read_bytes(),
-                file_name=Path(str(deliv["zip_path"])).name,
-                mime="application/zip",
-                key="ecm_dl_deliverable_zip",
-            )

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -865,18 +865,47 @@ def render() -> None:
         g3.metric("G14 NMBE % (gas)", f"{stats_g.get('nmbe_pct', '—')}" if stats_g else "—")
         g4.metric("G14 CV(RMSE) % (gas)", f"{stats_g.get('cvrmse_pct', '—')}" if stats_g else "—")
         g5.metric("Pass/fail", str(ubills.get("pass_fail") or "—"))
+
+        from wattlab.studio.monthly_dial_chart import monthly_pct_series
         from wattlab.studio.monthly_pct_off import (
             build_monthly_pct_off,
             render_monthly_pct_off_panel,
         )
 
-        render_monthly_pct_off_panel(build_monthly_pct_off(bills_rows))
+        # Fuel view control — both fuels when data exists; clear empty-state captions (no silent skip)
+        _elec_n = len(monthly_pct_series(bills_rows, fuel="elec"))
+        _gas_n = len(monthly_pct_series(bills_rows, fuel="gas"))
+        fuel_opts = ["both", "elec", "gas"]
+        fuel_labels = {
+            "both": f"Both fuels (elec {_elec_n} mo · gas {_gas_n} mo)",
+            "elec": f"Electricity only ({_elec_n} monthly pairs)",
+            "gas": f"Natural gas only ({_gas_n} monthly pairs)",
+        }
+        # Default to both; if only one fuel has pairs, still default both so the empty caption shows
+        fuel_view = st.radio(
+            "Monthly dial / % off fuel view",
+            options=fuel_opts,
+            format_func=lambda k: fuel_labels.get(k, k),
+            horizontal=True,
+            key="twin_monthly_fuel_view",
+            help=(
+                "G14 metrics above can pass from annual aggregates even when one fuel "
+                "lacks month-level bill↔model pairs. Use this to focus elec or gas dials."
+            ),
+        )
+        show_elec = fuel_view in ("both", "elec")
+        show_gas = fuel_view in ("both", "gas")
+
+        render_monthly_pct_off_panel(
+            build_monthly_pct_off(bills_rows),
+            fuel_filter=fuel_view,
+            key_prefix="twin_pct_off",
+        )
 
         from wattlab.studio.g14_history import assign_run_numbers, iter_g14_history
         from wattlab.studio.monthly_dial_chart import (
             build_history_heatmap_figure,
             build_monthly_pm_figure,
-            monthly_pct_series,
             season_summary,
         )
 
@@ -885,18 +914,36 @@ def render() -> None:
             "Positive = model over-predicts bills; negative = under. "
             "Use seasons to choose the next dial lever (OA hours, SAT bands, schedules)."
         )
-        fig_e = build_monthly_pm_figure(bills_rows, fuel="elec")
-        if fig_e is not None:
-            st.plotly_chart(fig_e, width="stretch", key="twin_monthly_pm_elec")
-            seas_e = season_summary(monthly_pct_series(bills_rows, fuel="elec"))
-            if seas_e:
-                st.caption("Elec season mean ±%: " + ", ".join(f"{k} {v:+.0f}%" for k, v in seas_e.items()))
-        fig_g = build_monthly_pm_figure(bills_rows, fuel="gas")
-        if fig_g is not None:
-            st.plotly_chart(fig_g, width="stretch", key="twin_monthly_pm_gas")
-            seas_g = season_summary(monthly_pct_series(bills_rows, fuel="gas"))
-            if seas_g:
-                st.caption("Gas season mean ±%: " + ", ".join(f"{k} {v:+.0f}%" for k, v in seas_g.items()))
+        if show_elec:
+            fig_e = build_monthly_pm_figure(bills_rows, fuel="elec")
+            if fig_e is not None:
+                st.plotly_chart(fig_e, width="stretch", key="twin_monthly_pm_elec")
+                seas_e = season_summary(monthly_pct_series(bills_rows, fuel="elec"))
+                if seas_e:
+                    st.caption(
+                        "Elec season mean ±%: "
+                        + ", ".join(f"{k} {v:+.0f}%" for k, v in seas_e.items())
+                    )
+            else:
+                st.info(
+                    "Elec dial chart unavailable — no monthly `observed_kwh` + "
+                    "`modeled_kwh`/`simulated_kwh` pairs in this scorecard."
+                )
+        if show_gas:
+            fig_g = build_monthly_pm_figure(bills_rows, fuel="gas")
+            if fig_g is not None:
+                st.plotly_chart(fig_g, width="stretch", key="twin_monthly_pm_gas")
+                seas_g = season_summary(monthly_pct_series(bills_rows, fuel="gas"))
+                if seas_g:
+                    st.caption(
+                        "Gas season mean ±%: "
+                        + ", ".join(f"{k} {v:+.0f}%" for k, v in seas_g.items())
+                    )
+            else:
+                st.info(
+                    "Gas dial chart unavailable — no monthly `observed_therms` + "
+                    "`modeled_therms`/`simulated_therms` pairs in this scorecard."
+                )
 
         try:
             hist_rows = assign_run_numbers(iter_g14_history(runs_dir(), limit=20))
@@ -904,14 +951,23 @@ def render() -> None:
             hist_rows = []
         if len(hist_rows) >= 2:
             with st.expander("Dial-attempt history (monthly ±% by run)", expanded=False):
-                h_e = build_history_heatmap_figure(hist_rows, fuel="elec", limit=12)
-                if h_e is not None:
-                    st.plotly_chart(h_e, width="stretch", key="twin_hist_pm_elec")
-                h_g = build_history_heatmap_figure(hist_rows, fuel="gas", limit=12)
-                if h_g is not None:
-                    st.plotly_chart(h_g, width="stretch", key="twin_hist_pm_gas")
-                if h_e is None and h_g is None:
-                    st.caption("Prior runs lack utility_bills.per_month — publish scorecards to enable history.")
+                h_e = h_g = None
+                if show_elec:
+                    h_e = build_history_heatmap_figure(hist_rows, fuel="elec", limit=12)
+                    if h_e is not None:
+                        st.plotly_chart(h_e, width="stretch", key="twin_hist_pm_elec")
+                    else:
+                        st.caption("Elec history: prior runs lack monthly kWh pairs.")
+                if show_gas:
+                    h_g = build_history_heatmap_figure(hist_rows, fuel="gas", limit=12)
+                    if h_g is not None:
+                        st.plotly_chart(h_g, width="stretch", key="twin_hist_pm_gas")
+                    else:
+                        st.caption("Gas history: prior runs lack monthly therms pairs.")
+                if show_elec and show_gas and h_e is None and h_g is None:
+                    st.caption(
+                        "Prior runs lack utility_bills.per_month — publish scorecards to enable history."
+                    )
     elif monthly_model:
         st.dataframe(pd.DataFrame(monthly_model).head(24), width="stretch", hide_index=True)
         st.caption(


### PR DESCRIPTION
## Summary
- Keep Twin monthly dial fuel radio + empty-pair captions (`3e52b8b`).
- **BUG-043:** Strip ECMs Advanced stack (Easy Buttons / capital plan / client DOCX); page is baseline picker + package notebook only.
- **BUG-044:** Values/Formulas preview; `wattlab notebook refresh-caches` + `show-formulas`; `formula_cells` in manifest; tests cover refresh after prefill and non-blank formula preview.
- **BUG-045:** AGENT_TOOLS / AGENT_DOCKER_WORKSPACE one-shot sock recipe: energyplus-ensure → easy-button → notebook build `--from-run` (Liberty 5-pack loop documented).
- **BUG-046:** Cover/Docs honesty — ESCO kWh/therms Python-baked at build; rates/NPV/cost live Excel.

## Test plan
- [x] Host: `pytest tests/test_notebook_builder.py` + studio AppTest dry path / every-page (14 passed)
- [ ] Merge → watch `vibe20-ghcr` (+ `vibe19-ghcr` if path-filter) green
- [ ] Refresh `:8502` / `:8520`; smoke ECMs Values/Formulas + download
- [ ] Tidy: no open PRs; prune merged feature branch

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ECMs Studio now focuses on engineering notebook creation and refresh, with formula/value preview modes and cache refresh controls.
  - Added notebook tools to refresh cached calculations and display workbook formulas.
  - Monthly calibration views can now be filtered to combined, electricity-only, or gas-only results.

- **Bug Fixes**
  - Improved handling and messaging when monthly data is unavailable for a selected fuel.

- **Documentation**
  - Expanded guidance for notebook workflows, formula validation, and Docker-based EnergyPlus setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->