### PR TITLE
feat(vibe20): agent-owned ECM Excel + Studio mirror (BUG-050/047)

### DIFF
--- a/vibe_code_apps_20/scripts/smoke_studio.py
+++ b/vibe_code_apps_20/scripts/smoke_studio.py
@@ -84,14 +84,18 @@ def main() -> int:
     print("OK: Twin deliverable build (no Streamlit exceptions)")
 
     at.radio(key="studio_page").set_value("ECMs").run()
-    at.button(key="ecm_notebook_build").click().run()
     if at.exception:
-        return _fail(at, "ECMs(notebook_build)")
+        return _fail(at, "ECMs")
     page = " ".join(str(x) for x in at.markdown) + " ".join(str(x) for x in at.caption)
     if "Advanced — Easy Buttons" in page or "Include client DOCX" in page:
         print("FAIL: Advanced / DOCX still present on ECMs (BUG-043)")
         return 1
-    print("OK: ECMs Excel-only notebook build (no Streamlit exceptions)")
+    # Mirror UI — Reload / Rebuild from scenario (no invent Build)
+    keys = [str(getattr(b, "key", "") or "") for b in at.button]
+    if not any("ecm_notebook_reload" in k or "ecm_notebook_rebuild_scenario" in k for k in keys):
+        print("FAIL: ECMs mirror buttons missing (BUG-050)")
+        return 1
+    print("OK: ECMs disk-mirror page (no Streamlit exceptions)")
     return 0
 
 

--- a/vibe_code_apps_20/tests/test_notebook_builder.py
+++ b/vibe_code_apps_20/tests/test_notebook_builder.py
@@ -1,4 +1,4 @@
-"""Engineering notebook builder / prefill / validate / preview (BUG-030–037)."""
+"""Engineering notebook builder / prefill / validate / preview (BUG-030–050)."""
 
 from __future__ import annotations
 
@@ -9,14 +9,16 @@ import pytest
 openpyxl = pytest.importorskip("openpyxl")
 
 from wattlab.notebooks.builder import (
+    FORMULA_ESCO_KWH,
+    agent_build_notebook,
     build_and_save_notebook,
-    build_notebook_workbook,
     prefill_notebook_inputs,
     preview_sheet_rows,
     read_notebook_inputs,
-    refresh_notebook_caches,
+    resolve_building_label,
     show_formulas,
     summarize_notebook,
+    sync_notebook_from_twin,
     validate_notebook,
 )
 from wattlab.notebooks.packages import INPUT_NAMED_RANGES, REQUIRED_SHEETS, list_notebook_packages
@@ -33,6 +35,31 @@ def test_list_notebook_packages_ladder():
         "deep_retrofit",
     ]
     assert [p.rank for p in pkgs] == [1, 2, 3, 4, 5]
+
+
+def test_resolve_building_label_display_name():
+    assert resolve_building_label({"display_name": "Liberty Building 100"}) == "Liberty Building 100"
+    assert resolve_building_label({"project_id": "LIB-100"}) == "LIB-100"
+    assert resolve_building_label({}) == "BUILDING"
+
+
+def test_cover_uses_display_name_bug047(tmp_path: Path):
+    written = build_and_save_notebook(
+        "controls_first",
+        tmp_path,
+        profile={
+            "display_name": "Liberty Building 100 — Detroit",
+            "conditioned_floor_area_ft2": 140_000,
+        },
+    )
+    wb = openpyxl.load_workbook(written["xlsx"], data_only=False)
+    labels = {
+        str(wb["Cover"][f"A{r}"].value): wb["Cover"][f"B{r}"].value
+        for r in range(4, 20)
+        if wb["Cover"][f"A{r}"].value
+    }
+    assert labels.get("Building") == "Liberty Building 100 — Detroit"
+    assert labels.get("Building") != "BUILDING"
 
 
 def test_build_validate_named_ranges_and_roi_formulas(tmp_path: Path):
@@ -52,17 +79,12 @@ def test_build_validate_named_ranges_and_roi_formulas(tmp_path: Path):
     defined = set(wb.defined_names.keys())
     for n in INPUT_NAMED_RANGES:
         assert n in defined
-    # BUG-035: B mirrors H formula
     assert str(wb["ROI_Capital"]["B2"].value).startswith("=H")
     assert "inp_usd_per_ft2" in str(wb["ROI_Capital"]["H2"].value)
-    # BUG-032: NPV is live formula, cache in I
     assert str(wb["ROI_Capital"]["G2"].value).startswith("=IF")
     assert isinstance(wb["ROI_Capital"]["I2"].value, (int, float))
-    # Cover honesty mentions scaffold / proxies
-    cover_note = str(wb["Cover"]["B13"].value or wb["Cover"]["B14"].value or "")
-    # find Note row
     notes = [str(wb["Cover"][f"B{r}"].value or "") for r in range(4, 20)]
-    assert any("scaffold" in n.lower() or "proxies" in n.lower() for n in notes)
+    assert any("screening" in n.lower() or "formula" in n.lower() for n in notes)
 
 
 def test_prefill_merges_in_place_keeps_eplus(tmp_path: Path):
@@ -85,14 +107,13 @@ def test_prefill_merges_in_place_keeps_eplus(tmp_path: Path):
     assert before["elec_rate"] == 0.14
 
     wb0 = openpyxl.load_workbook(xlsx, data_only=False)
-    ep_kwh = wb0["EPlus_Results"]["B2"].value
-    assert ep_kwh == 12345.0
+    assert wb0["EPlus_Results"]["B2"].value == 12345.0
 
     result = prefill_notebook_inputs(xlsx, overrides={"elec_rate": 0.22})
     assert "elec_rate" in result["updated"]
     after = read_notebook_inputs(xlsx)
     assert after["elec_rate"] == 0.22
-    assert after["area_ft2"] == 140_000  # not wiped to 50000
+    assert after["area_ft2"] == 140_000
     assert after["gas_rate"] == before["gas_rate"]
 
     wb1 = openpyxl.load_workbook(xlsx, data_only=False)
@@ -103,25 +124,22 @@ def test_preview_shows_formulas_not_none(tmp_path: Path):
     written = build_and_save_notebook("controls_first", tmp_path, profile={"floor_area_ft2": 50_000})
     rows = preview_sheet_rows(written["xlsx"], "ROI_Capital", data_only=False)
     assert rows
-    # header + data: cost / npv cells should be formula strings, not None
     header = rows[0]
     assert "npv_usd_at_build" in header
     data = rows[1]
-    # B implementation_cost
     assert data[1] is not None and str(data[1]).startswith("=")
-    # G npv formula
     assert data[6] is not None and str(data[6]).startswith("=")
-    # I cache numeric
     assert isinstance(data[8], (int, float))
 
 
 def test_summarize_resolves_package_and_ep_coverage(tmp_path: Path):
     written = build_and_save_notebook("schedules_economizer", tmp_path, profile={"floor_area_ft2": 80_000})
-    man = summarize_notebook(written["xlsx"])  # no package= arg (BUG-042)
+    man = summarize_notebook(written["xlsx"])
     assert man["package_id"] == "schedules_economizer"
     assert man["package_label"]
     assert man["ep_coverage"]["filled_rows"] == 0
-    assert man["honesty"]["template_file"] == "scaffold_only"
+    assert man["honesty"]["template_file"] in ("loaded", "scaffold_only")
+    assert man["honesty"]["openfdd"] == "not_used"
 
 
 def test_cli_prefill_elec_rate(tmp_path: Path):
@@ -132,35 +150,28 @@ def test_cli_prefill_elec_rate(tmp_path: Path):
         tmp_path,
         profile={"conditioned_floor_area_ft2": 140_000, "utility": {"elec_usd_per_kwh": 0.14}},
     )
-    rc = main(
-        [
-            "prefill",
-            "--xlsx",
-            str(written["xlsx"]),
-            "--elec-rate",
-            "0.22",
-        ]
-    )
+    rc = main(["prefill", "--xlsx", str(written["xlsx"]), "--elec-rate", "0.22"])
     assert rc == 0
     assert read_notebook_inputs(written["xlsx"])["elec_rate"] == 0.22
     assert read_notebook_inputs(written["xlsx"])["area_ft2"] == 140_000
 
 
-def test_workbook_does_not_load_template_file():
-    """BUG-033: builds are Workbook() — template path unused at runtime."""
+def test_workbook_loads_template_when_present():
+    """BUG-050: builds load templates/ecm_package_v1.xlsx when present."""
     import inspect
 
     from wattlab.notebooks import builder as b
 
     src = inspect.getsource(b.build_notebook_workbook)
-    assert "load_workbook" not in src
-    assert "Workbook()" in src
+    assert "load_workbook" in src
+    assert "default_template_path" in src
+    assert b.default_template_path().is_file()
 
 
 def test_refresh_caches_and_show_formulas(tmp_path: Path):
     from openpyxl import load_workbook
 
-    from wattlab.notebooks.builder import refresh_notebook_caches, show_formulas
+    from wattlab.notebooks.builder import refresh_notebook_caches
     from wattlab.notebooks.cli import main
 
     written = build_and_save_notebook(
@@ -172,19 +183,14 @@ def test_refresh_caches_and_show_formulas(tmp_path: Path):
     wb0 = load_workbook(xlsx, data_only=False)
     assert str(wb0["ROI_Capital"]["B2"].value).startswith("=H")
     assert str(wb0["ROI_Capital"]["G2"].value).startswith("=IF")
-    i_before = wb0["ROI_Capital"]["I2"].value
 
     prefill_notebook_inputs(xlsx, overrides={"elec_rate": 0.30})
     result = refresh_notebook_caches(xlsx)
     assert result["updated_cells"] >= 1
     wb1 = load_workbook(xlsx, data_only=False)
-    # Formulas preserved
     assert str(wb1["ROI_Capital"]["B2"].value).startswith("=H")
     assert str(wb1["ROI_Capital"]["G2"].value).startswith("=IF")
-    # Cache column refreshed (may change with higher elec rate)
-    assert wb1["ROI_Capital"]["I2"].value is not None
     assert isinstance(wb1["ROI_Capital"]["I2"].value, (int, float))
-    # Area not wiped
     assert read_notebook_inputs(xlsx)["area_ft2"] == 140_000
     assert read_notebook_inputs(xlsx)["elec_rate"] == 0.30
 
@@ -192,11 +198,8 @@ def test_refresh_caches_and_show_formulas(tmp_path: Path):
     assert "ROI_Capital" in formulas["sheets"]
     assert any(v.startswith("=") for v in formulas["sheets"]["ROI_Capital"].values())
 
-    rc = main(["show-formulas", "--xlsx", str(xlsx), "--sheet", "ROI_Capital"])
-    assert rc == 0
-    rc2 = main(["refresh-caches", "--xlsx", str(xlsx)])
-    assert rc2 == 0
-    _ = i_before  # silence unused when NPV equals
+    assert main(["show-formulas", "--xlsx", str(xlsx), "--sheet", "ROI_Capital"]) == 0
+    assert main(["refresh-caches", "--xlsx", str(xlsx)]) == 0
 
 
 def test_manifest_includes_formula_cells(tmp_path: Path):
@@ -204,4 +207,83 @@ def test_manifest_includes_formula_cells(tmp_path: Path):
     man = summarize_notebook(written["xlsx"])
     assert "formula_cells" in man
     assert "ROI_Capital" in man["formula_cells"]
-    assert man["honesty"]["esco_kwh_therms"] == "baked_at_build"
+    assert man["honesty"]["esco_kwh_therms"] == "excel_formulas_for_subset_else_baked"
+    assert "ECM-AHU-SCHED-ALIGN" in man["formula_backed_measures"]
+
+
+def test_agent_build_formula_esco_and_cli(tmp_path: Path):
+    from wattlab.notebooks.cli import main
+
+    written = agent_build_notebook(
+        "controls_first",
+        tmp_path,
+        profile={
+            "display_name": "Liberty Building 100",
+            "conditioned_floor_area_ft2": 140_000,
+            "fan_hp": 50,
+            "cooling_tons": 250,
+        },
+        measure_ids=[
+            "ECM-AHU-SCHED-ALIGN",
+            "ECM-PREMIUM-FAN-VFD",
+            "ECM-CHILLER-LOCKOUT",
+            "ECM-SENSOR-CALIBRATION",
+        ],
+    )
+    wb = openpyxl.load_workbook(written["xlsx"], data_only=False)
+    esco = wb["ESCO_Calcs"]
+    by_mid = {}
+    for r in range(2, (esco.max_row or 1) + 1):
+        mid = esco.cell(r, 1).value
+        if mid:
+            by_mid[str(mid)] = (esco.cell(r, 2).value, esco.cell(r, 6).value)
+    for mid in ("ECM-AHU-SCHED-ALIGN", "ECM-PREMIUM-FAN-VFD", "ECM-CHILLER-LOCKOUT"):
+        assert str(by_mid[mid][0]).startswith("=")
+        assert "Excel formula" in str(by_mid[mid][1])
+    assert isinstance(by_mid["ECM-SENSOR-CALIBRATION"][0], (int, float))
+    assert "proxy" in str(by_mid["ECM-SENSOR-CALIBRATION"][1]).lower()
+    assert "inp_elec_rate" in str(esco["E2"].value)
+
+    rc = main(
+        [
+            "agent-build",
+            "--package",
+            "controls_first",
+            "--ecms",
+            "ECM-AHU-SCHED-ALIGN,ECM-CHILLER-LOCKOUT",
+            "--out",
+            str(tmp_path / "cli_out"),
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "cli_out" / "controls_first.xlsx").is_file()
+
+
+def test_sync_from_twin_soft(tmp_path: Path):
+    written = build_and_save_notebook(
+        "controls_first",
+        tmp_path,
+        profile={"floor_area_ft2": 50_000, "display_name": "X"},
+    )
+    run = tmp_path / "twin_run"
+    run.mkdir()
+    result = sync_notebook_from_twin(written["xlsx"], twin_run=run)
+    assert result["updated_rows"] == 0
+    assert "no savings_by_measure" in result["note"]
+
+    (run / "report.json").write_text(
+        '{"savings_by_measure":[{"measure_id":"ECM-AHU-SCHED-ALIGN","vs_baseline":{"kwh_saved":99,"therms_saved":1}}]}',
+        encoding="utf-8",
+    )
+    result2 = sync_notebook_from_twin(written["xlsx"], twin_run=run)
+    assert result2["updated_rows"] >= 1
+    wb = openpyxl.load_workbook(written["xlsx"], data_only=False)
+    assert wb["EPlus_Results"]["B2"].value == 99
+
+
+def test_formula_esco_constants_present():
+    assert set(FORMULA_ESCO_KWH) >= {
+        "ECM-AHU-SCHED-ALIGN",
+        "ECM-PREMIUM-FAN-VFD",
+        "ECM-CHILLER-LOCKOUT",
+    }

--- a/vibe_code_apps_20/tests/test_studio_app.py
+++ b/vibe_code_apps_20/tests/test_studio_app.py
@@ -106,7 +106,23 @@ def test_studio_twin_eui_index_section():
     assert any("EUI" in str(getattr(el, "value", el)) for el in at.subheader)
 
 
-def test_studio_twin_and_ecms_dry_path():
+def test_studio_twin_and_ecms_dry_path(tmp_path, monkeypatch):
+    # Seed agent-owned notebook so ECMs is a disk mirror (BUG-050)
+    monkeypatch.setenv("WATTLAB_STUDIO_WORKSPACE", str(tmp_path))
+    from wattlab.notebooks.builder import agent_build_notebook
+
+    nb_dir = tmp_path / "reports" / "notebooks"
+    agent_build_notebook(
+        "controls_first",
+        nb_dir,
+        profile={
+            "display_name": "Liberty Building 100",
+            "conditioned_floor_area_ft2": 75_000,
+            "fan_hp": 40,
+            "cooling_tons": 200,
+        },
+    )
+
     at = _boot("Twin / calibrate")
     at.text_input(key="twin_btype").set_value("office")
     at.text_input(key="twin_city").set_value("detroit")
@@ -122,22 +138,23 @@ def test_studio_twin_and_ecms_dry_path():
 
     at.radio(key="studio_page").set_value("ECMs").run()
     assert not at.exception
-    # BUG-043: Advanced / DOCX / Easy Buttons removed
+    # BUG-043/050: no Advanced / DOCX; mirror UI (no invent Build)
     page = " ".join(str(x) for x in at.markdown) + " ".join(str(x) for x in at.caption)
     assert "Advanced — Easy Buttons" not in page
     assert "Include client DOCX" not in page
-    # Notebook primary path present
     assert any(
-        "ecm_notebook_build" in str(getattr(b, "key", "") or "")
-        or "Build" in str(getattr(b, "label", "") or "")
+        "ecm_notebook_reload" in str(getattr(b, "key", "") or "")
+        or "Reload" in str(getattr(b, "label", "") or "")
         for b in at.button
     )
-    at.button(key="ecm_notebook_build").click().run()
-    assert not at.exception
-    # Preview mode radio (Formulas / Values)
+    assert any(
+        "ecm_notebook_rebuild_scenario" in str(getattr(b, "key", "") or "") for b in at.button
+    )
+    # Preview without clicking invent-build
     assert any(
         "ecm_notebook_preview_mode" in str(getattr(r, "key", "") or "") for r in at.radio
     ) or "studio_notebook_path" in at.session_state
+    assert not at.exception
 
 
 def test_turnkey_live_html_smoke():

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
@@ -12,7 +12,7 @@ Prefer packaged WattLab commands when they cover the job:
 | Monthly vs bills score | `wattlab score-monthly` |
 | Controls FDD checklist + DOCX | `wattlab controls-checklist` |
 | Bills → EUI peer bands | `wattlab benchmark` |
-| ECM Excel notebooks (ESCO vs E+) | `wattlab notebook build/prefill/validate/summarize` |
+| ECM Excel notebooks (ESCO vs E+) | `wattlab notebook agent-build/prefill/validate/summarize` |
 
 Use `/data/tools/<script>.py` for vintage ladders, gas G14 campaigns, stacked
 floor IDFs, HWS peeks, dual-fuel G14 scorecards, or one-off site experiments.
@@ -51,30 +51,41 @@ docker exec vibe20 wattlab dial-loads …
 docker exec vibe20 wattlab score-monthly …
 docker exec vibe20 wattlab controls-checklist …
 docker exec vibe20 wattlab notebook list-packages
-docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 wattlab notebook build \
-  --package controls_first --out /data/reports/notebooks/ \
-  --answers /data/reports/answers.json --from-run /data/runs/<id>
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 wattlab notebook agent-build \
+  --package controls_first \
+  --ecms ECM-AHU-SCHED-ALIGN,ECM-CHILLER-LOCKOUT \
+  --answers /data/reports/answers.json \
+  --twin-run /data/runs/<calibrated_id> \
+  --out /data/reports/notebooks/ \
+  --write-scenario
 ```
 
-## ECM engineering notebooks
+## ECM engineering notebooks (agent-owned Excel)
 
 Least→radical packages (`controls_first` … `deep_retrofit`) each produce one `.xlsx`
-under `reports/notebooks/` plus `*.notebook_manifest.json` for agents.
+under `reports/notebooks/` plus `*.notebook_manifest.json`. **Studio ECMs is a disk
+mirror** — refresh the browser (or Reload) after the agent writes the file.
 
 ```bash
-wattlab notebook build --package esco_top15 --out /data/reports/notebooks/ \
-  --answers /data/reports/answers.json --from-run /data/runs/<ecm_capable>
-wattlab notebook prefill --xlsx /data/reports/notebooks/esco_top15.xlsx --elec-rate 0.22
-# prefill patches Inputs in-place (keeps EPlus_Results) — never rebuilds
-wattlab notebook refresh-caches --xlsx /data/reports/notebooks/esco_top15.xlsx
-wattlab notebook show-formulas --xlsx /data/reports/notebooks/esco_top15.xlsx --sheet ROI_Capital
-wattlab notebook validate --xlsx /data/reports/notebooks/esco_top15.xlsx
+# Liberty / controls_first recipe (BUG-050)
+wattlab notebook agent-build --package controls_first \
+  --ecms ECM-AHU-SCHED-ALIGN,ECM-PREMIUM-FAN-VFD,ECM-CHILLER-LOCKOUT \
+  --answers /data/reports/answers_building_100_geo.json \
+  --twin-run /data/runs/geo_b100_6stack_shape_r56_sched_mild \
+  --out /data/reports/notebooks/ --write-scenario
+wattlab notebook prefill --xlsx /data/reports/notebooks/controls_first.xlsx --elec-rate 0.14
+wattlab notebook refresh-caches --xlsx /data/reports/notebooks/controls_first.xlsx
+wattlab notebook show-formulas --xlsx /data/reports/notebooks/controls_first.xlsx --sheet ESCO_Calcs
+wattlab notebook sync-from-twin --xlsx /data/reports/notebooks/controls_first.xlsx \
+  --twin-run /data/runs/<good_report>
+wattlab notebook validate --xlsx /data/reports/notebooks/controls_first.xlsx
 wattlab notebook summarize --xlsx … --write
 ```
 
-Honesty: ESCO kWh/therms are baked at build (not live Excel bins); ROI cost/NPV formulas follow Inputs.
-Studio ECMs page: Values + Formulas preview; no Easy Buttons / DOCX (BUG-043).
-Prefer Twin runs with `savings_by_measure` or Compare stays YELLOW (`validate` warns).
+Honesty: starter ESCO rows (schedule / fan VFD / chiller lockout) are **live Excel
+formulas** on Inputs; other measures may still be Python proxies. ROI cost/NPV
+follow Inputs. Twin E+ paste is optional — never blocks the workbook.
+Studio: Values + Formulas preview of on-disk file; no Easy Buttons / DOCX / OpenFDD.
 
 ### Easy-button → notebook (Docker sock required) — BUG-045
 
@@ -92,11 +103,11 @@ docker exec -e WATTLAB_HOST_WORKSPACE=/data -e WATTLAB_STUDIO_WORKSPACE=/data vi
   --minimal-file /data/reports/answers_building_100.json
 # → publishes /data/runs/<id> with savings_by_measure when EP succeeds
 
-docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 wattlab notebook build \
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 wattlab notebook agent-build \
   --package controls_first \
   --answers /data/reports/answers_building_100.json \
-  --from-run /data/runs/<published_easy_button_run> \
-  --out /data/reports/notebooks/
+  --twin-run /data/runs/<published_easy_button_run> \
+  --out /data/reports/notebooks/ --write-scenario
 docker exec vibe20 wattlab notebook validate \
   --xlsx /data/reports/notebooks/controls_first.xlsx
 ```
@@ -105,15 +116,15 @@ Liberty 5-pack (agents, no Easy Button UI clicks):
 
 ```bash
 for pkg in controls_first schedules_economizer plant_optimization esco_top15 deep_retrofit; do
-  wattlab notebook build --package "$pkg" \
+  wattlab notebook agent-build --package "$pkg" \
     --answers /data/reports/answers_building_100.json \
-    --from-run /data/runs/<ecm_capable> \
+    --twin-run /data/runs/<ecm_capable> \
     --out /data/reports/notebooks/
 done
 ```
 
-Write `reports/ecm_scenario.json` v3 with `notebook_package_id`, `notebook_path`,
-`input_overrides` so Studio Re-apply / ECMs page stays in sync.
+Write `reports/ecm_scenario.json` v4 with `notebook_package_id`, `notebook_path`,
+`selected_ecm_ids`, `twin_run`, `input_overrides` so Studio ECMs mirror stays in sync.
 
 ```bash
 docker exec -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace \

--- a/vibe_code_apps_20/wattlab/notebooks/__init__.py
+++ b/vibe_code_apps_20/wattlab/notebooks/__init__.py
@@ -3,19 +3,23 @@
 from __future__ import annotations
 
 from wattlab.notebooks.builder import (
+    agent_build_notebook,
     build_and_save_notebook,
     build_notebook_workbook,
     prefill_notebook_inputs,
     preview_sheet_rows,
     read_notebook_inputs,
     refresh_notebook_caches,
+    resolve_building_label,
     show_formulas,
     summarize_notebook,
+    sync_notebook_from_twin,
     validate_notebook,
 )
 from wattlab.notebooks.packages import get_notebook_package, list_notebook_packages
 
 __all__ = [
+    "agent_build_notebook",
     "build_and_save_notebook",
     "build_notebook_workbook",
     "get_notebook_package",
@@ -24,7 +28,9 @@ __all__ = [
     "preview_sheet_rows",
     "read_notebook_inputs",
     "refresh_notebook_caches",
+    "resolve_building_label",
     "show_formulas",
     "summarize_notebook",
+    "sync_notebook_from_twin",
     "validate_notebook",
 ]

--- a/vibe_code_apps_20/wattlab/notebooks/builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/builder.py
@@ -23,6 +23,58 @@ YELLOW = "FFFF99"
 HEADER_FILL = "1F4E79"
 HEADER_FONT = "FFFFFF"
 
+# Starter Phase 2 — live Excel ESCO screening formulas (BUG-050).
+# Other measures stay Python-proxy with an honest notes column.
+FORMULA_ESCO_KWH: dict[str, str] = {
+    # Fan kWh from avoided hours + light cooling lock-in via tons × kW/ton × fraction of hours
+    "ECM-AHU-SCHED-ALIGN": (
+        "=IF(OR(inp_fan_hp=\"\",inp_fan_hp=0),0,inp_fan_hp*0.746*inp_sched_hours_saved)"
+        "+IF(OR(inp_cooling_tons=\"\",inp_cooling_tons=0),0,"
+        "inp_cooling_tons*inp_kw_per_ton*inp_sched_hours_saved*0.15)"
+    ),
+    # Affinity: design_kw × hours × (1 − speed³)
+    "ECM-PREMIUM-FAN-VFD": (
+        "=IF(OR(inp_fan_hp=\"\",inp_fan_hp=0),0,"
+        "inp_fan_hp*0.746*inp_fan_hours*(1-inp_fan_speed^3))"
+    ),
+    # Economizer / lockout hours × tons × kW/ton
+    "ECM-CHILLER-LOCKOUT": (
+        "=IF(OR(inp_cooling_tons=\"\",inp_cooling_tons=0),0,"
+        "inp_cooling_tons*inp_kw_per_ton*inp_lockout_hours)"
+    ),
+}
+FORMULA_ESCO_THERMS: dict[str, str] = {
+    "ECM-AHU-SCHED-ALIGN": (
+        "=IF(OR(inp_area_ft2=\"\",inp_area_ft2=0),0,inp_area_ft2*0.0004*inp_sched_hours_saved/10)"
+    ),
+}
+
+_BUILDING_LABEL_KEYS = (
+    "display_name",
+    "project_id",
+    "building_name",
+    "building",
+    "name",
+    "building_id",
+)
+
+
+def default_template_path() -> Path:
+    return Path(__file__).resolve().parent / "templates" / "ecm_package_v1.xlsx"
+
+
+def resolve_building_label(profile: dict[str, Any] | None = None) -> str:
+    """Cover Building label — prefer answers display_name (BUG-047)."""
+    profile = profile or {}
+    for key in _BUILDING_LABEL_KEYS:
+        val = profile.get(key)
+        if val is None:
+            continue
+        text = str(val).strip()
+        if text:
+            return text
+    return "BUILDING"
+
 
 def _style_header(ws, row: int = 1) -> None:
     from openpyxl.styles import Font, PatternFill
@@ -73,8 +125,14 @@ def default_inputs_from_profile(profile: dict[str, Any] | None = None) -> dict[s
         "life_years": 15,
         "usd_per_ft2": 3.0,
         "coverage": 1.0,
-        "building": str(profile.get("building_id") or profile.get("name") or "BUILDING"),
+        "building": resolve_building_label(profile),
         "property_type": str(profile.get("building_type") or profile.get("property_type") or "office"),
+        # Screening constants for formula-backed ESCO rows (yellow Inputs)
+        "sched_hours_saved": float(profile.get("sched_hours_saved") or 2500),
+        "fan_hours": float(profile.get("fan_hours") or profile.get("fan_annual_hours") or 4000),
+        "fan_speed": float(profile.get("fan_speed") or profile.get("fan_proposed_speed") or 0.7),
+        "kw_per_ton": float(profile.get("kw_per_ton") or 0.65),
+        "lockout_hours": float(profile.get("lockout_hours") or 800),
     }
 
 
@@ -97,9 +155,12 @@ def build_notebook_workbook(
     proxies: dict[str, dict[str, Any]] | None = None,
     costs: dict[str, float] | None = None,
     gate: dict[str, Any] | None = None,
+    measure_ids: list[str] | tuple[str, ...] | None = None,
+    twin_run: str | None = None,
+    use_template: bool = True,
 ) -> Any:
     """Return an openpyxl Workbook for one package notebook."""
-    from openpyxl import Workbook
+    from openpyxl import Workbook, load_workbook
     from openpyxl.styles import Font
 
     from wattlab.crosscheck import crosscheck_measure
@@ -111,18 +172,30 @@ def build_notebook_workbook(
     inputs = default_inputs_from_profile(profile)
     if input_overrides:
         inputs.update({k: v for k, v in input_overrides.items() if v is not None})
+        if any(k in input_overrides for k in _BUILDING_LABEL_KEYS) or input_overrides.get("building"):
+            # Prefer explicit Cover override keys when provided
+            overlay = {**profile, **(input_overrides or {})} if profile else dict(input_overrides or {})
+            inputs["building"] = resolve_building_label(overlay)
 
-    measure_ids = list(pkg.measure_ids)
+    ids = list(measure_ids) if measure_ids else list(pkg.measure_ids)
+    if not ids:
+        ids = list(pkg.measure_ids)
     if proxies is None:
-        proxies = estimate_proxy_savings(profile or {"floor_area_ft2": inputs["area_ft2"]}, measure_ids)
+        proxies = estimate_proxy_savings(profile or {"floor_area_ft2": inputs["area_ft2"]}, ids)
     ep_by = _ep_by_measure(report)
+    twin_note = ""
+    if twin_run:
+        twin_note = str(twin_run)
+    elif isinstance(report, dict) and report.get("run_id"):
+        twin_note = str(report.get("run_id"))
+    ep_missing = not any(ep_by.get(mid) for mid in ids)
 
     area = float(inputs["area_ft2"])
     cov = float(inputs["coverage"])
     usd_ft2 = float(inputs["usd_per_ft2"])
     if costs is None:
         costs = {}
-        for mid in measure_ids:
+        for mid in ids:
             costs[mid] = implementation_cost_usd(
                 floor_area_ft2=area,
                 usd_per_ft2=usd_ft2,
@@ -134,11 +207,14 @@ def build_notebook_workbook(
 
     econ_rows = []
     compare_rows = []
-    for mid in measure_ids:
+    formula_backed: list[str] = []
+    for mid in ids:
         p = proxies.get(mid) or {}
         ep = ep_by.get(mid) or {}
         esco_kwh = float(p.get("savings_kwh") or 0.0)
         esco_therms = float(p.get("savings_therms") or 0.0)
+        if mid in FORMULA_ESCO_KWH:
+            formula_backed.append(mid)
         ep_kwh = ep.get("kwh_saved")
         ep_therms = ep.get("therms_saved")
         xc = crosscheck_measure(
@@ -191,14 +267,36 @@ def build_notebook_workbook(
         except Exception:
             gate = {"verdict": "UNKNOWN", "checks": [], "investigate_count": 0}
 
-    wb = Workbook()
+    template_loaded = False
+    tpl = default_template_path()
+    if use_template and tpl.is_file():
+        wb = load_workbook(tpl)
+        template_loaded = True
+        keep = wb.sheetnames[0]
+        for name in list(wb.sheetnames):
+            if name != keep:
+                del wb[name]
+        cover = wb[keep]
+        cover.title = "Cover"
+        for row in cover.iter_rows():
+            for cell in row:
+                cell.value = None
+    else:
+        wb = Workbook()
+        cover = wb.active
+        cover.title = "Cover"
 
-    # --- Cover ---
-    cover = wb.active
-    cover.title = "Cover"
     cover["A1"] = "WattLab Engineering Notebook"
     cover["A1"].font = Font(bold=True, size=16)
-    cover["A2"] = "ECM package screening (ESCO bin-method vs EnergyPlus)"
+    cover["A2"] = "ECM package screening (agent-owned Excel · Studio = mirror)"
+    note = (
+        "Yellow Inputs drive rate-linked Excel formulas (annual $, payback, NPV, cost B=H). "
+        f"Formula-backed ESCO kWh: {', '.join(formula_backed) or '(none this package)'}. "
+        "Other ESCO rows are Python screening proxies. Screening — not investment-grade. "
+        "See Docs + ESCO_SPREADSHEET_CALCS.md."
+    )
+    if ep_missing:
+        note += " EPlus_Results empty — Twin attach optional (sync-from-twin when a good report exists)."
     rows = [
         ("Building", inputs.get("building")),
         ("Package id", pkg.id),
@@ -206,15 +304,12 @@ def build_notebook_workbook(
         ("Honesty", pkg.honesty),
         ("Generated (UTC)", datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")),
         ("Catalog package", pkg.catalog_package),
-        ("n_measures", len(measure_ids)),
+        ("n_measures", len(ids)),
+        ("Twin run", twin_note or "(none — E+ optional)"),
         ("Guardrail verdict", gate.get("verdict")),
         ("ESCO docs", ESCO_DOCS_URL),
-        (
-            "Note",
-            "Yellow Inputs drive rate-linked Excel formulas (annual $, payback, NPV, cost B=H). "
-            "ESCO kWh/therms are Python screening proxies baked at build — not bin-method Excel "
-            "(see Docs + ESCO_SPREADSHEET_CALCS.md). Scaffold template is not loaded at build.",
-        ),
+        ("Template", "loaded " + tpl.name if template_loaded else "Workbook() scaffold"),
+        ("Note", note),
     ]
     for i, (k, v) in enumerate(rows, start=4):
         cover[f"A{i}"] = k
@@ -223,6 +318,8 @@ def build_notebook_workbook(
     cover.column_dimensions["B"].width = 72
 
     # --- Inputs (yellow + named ranges) ---
+    if "Inputs" in wb.sheetnames:
+        del wb["Inputs"]
     inp = wb.create_sheet("Inputs")
     inp.append(["parameter", "value", "unit", "notes"])
     _style_header(inp)
@@ -237,6 +334,11 @@ def build_notebook_workbook(
         ("life_years", inputs["life_years"], "yr", "Measure life", "inp_life_years"),
         ("usd_per_ft2", inputs["usd_per_ft2"], "$/ft²", "Fallback package cost intensity", "inp_usd_per_ft2"),
         ("coverage", inputs["coverage"], "0–1", "Fraction of floor area receiving ECMs", "inp_coverage"),
+        ("sched_hours_saved", inputs["sched_hours_saved"], "h/yr", "Avoided AHU hours (schedule formula)", "inp_sched_hours_saved"),
+        ("fan_hours", inputs["fan_hours"], "h/yr", "Fan annual hours (VFD affinity)", "inp_fan_hours"),
+        ("fan_speed", inputs["fan_speed"], "0–1", "Proposed VFD speed fraction", "inp_fan_speed"),
+        ("kw_per_ton", inputs["kw_per_ton"], "kW/ton", "Cooling plant intensity", "inp_kw_per_ton"),
+        ("lockout_hours", inputs["lockout_hours"], "h/yr", "Chiller lockout / econ hours", "inp_lockout_hours"),
     ]
     for i, (param, val, unit, notes, named) in enumerate(input_rows, start=2):
         inp[f"A{i}"] = param
@@ -250,6 +352,8 @@ def build_notebook_workbook(
     inp.column_dimensions["D"].width = 40
 
     # --- ESCO_Calcs ---
+    if "ESCO_Calcs" in wb.sheetnames:
+        del wb["ESCO_Calcs"]
     esco = wb.create_sheet("ESCO_Calcs")
     esco.append(
         [
@@ -262,39 +366,51 @@ def build_notebook_workbook(
         ]
     )
     _style_header(esco)
-    for i, mid in enumerate(measure_ids, start=2):
+    for i, mid in enumerate(ids, start=2):
         p = proxies.get(mid) or {}
         esco[f"A{i}"] = mid
-        esco[f"B{i}"] = float(p.get("savings_kwh") or 0)
-        esco[f"C{i}"] = float(p.get("savings_therms") or 0)
-        calcs = p.get("calculators")
-        esco[f"D{i}"] = ",".join(calcs) if isinstance(calcs, list) else ""
-        # Formula references Inputs named rates
+        if mid in FORMULA_ESCO_KWH:
+            esco[f"B{i}"] = FORMULA_ESCO_KWH[mid]
+            esco[f"C{i}"] = FORMULA_ESCO_THERMS.get(mid, 0.0)
+            esco[f"D{i}"] = "excel_formula"
+            esco[f"F{i}"] = (
+                "Excel formula referencing Inputs named ranges "
+                "(ESCO_SPREADSHEET_CALCS.md / bench analogs). Not a Python bake."
+            )
+        else:
+            esco[f"B{i}"] = float(p.get("savings_kwh") or 0)
+            esco[f"C{i}"] = float(p.get("savings_therms") or 0)
+            calcs = p.get("calculators")
+            esco[f"D{i}"] = ",".join(calcs) if isinstance(calcs, list) else ""
+            esco[f"F{i}"] = "proxy (not Excel yet) — Python screening at build"
         esco[f"E{i}"] = f"=B{i}*inp_elec_rate+C{i}*inp_gas_rate"
-        esco[f"F{i}"] = (
-            "B/C = Python screening proxy at build (not live Excel bins). "
-            "E updates when Inputs rates change."
-        )
     esco.column_dimensions["A"].width = 28
     esco.column_dimensions["D"].width = 28
     esco.column_dimensions["E"].width = 28
     esco.column_dimensions["F"].width = 48
 
     # --- EPlus_Results ---
+    if "EPlus_Results" in wb.sheetnames:
+        del wb["EPlus_Results"]
     ep_ws = wb.create_sheet("EPlus_Results")
     ep_ws.append(["measure_id", "kwh_saved", "therms_saved", "peak_kw_delta", "source"])
     _style_header(ep_ws)
-    for i, mid in enumerate(measure_ids, start=2):
+    for i, mid in enumerate(ids, start=2):
         ep = ep_by.get(mid) or {}
         ep_ws[f"A{i}"] = mid
         ep_ws[f"B{i}"] = ep.get("kwh_saved")
         ep_ws[f"C{i}"] = ep.get("therms_saved")
         ep_ws[f"D{i}"] = ep.get("peak_demand_kw_delta")
-        ep_ws[f"E{i}"] = "Twin savings_by_measure" if ep else "E+ not run — ESCO only"
+        if ep:
+            ep_ws[f"E{i}"] = f"Twin savings_by_measure{(' · ' + twin_note) if twin_note else ''}"
+        else:
+            ep_ws[f"E{i}"] = "E+ not attached — leave blank; optional sync-from-twin"
     ep_ws.column_dimensions["A"].width = 28
-    ep_ws.column_dimensions["E"].width = 28
+    ep_ws.column_dimensions["E"].width = 40
 
     # --- Compare (formulas vs ESCO / E+ sheets) ---
+    if "Compare" in wb.sheetnames:
+        del wb["Compare"]
     cmp_ws = wb.create_sheet("Compare")
     cmp_ws.append(
         [
@@ -333,6 +449,8 @@ def build_notebook_workbook(
     cmp_ws.column_dimensions["A"].width = 28
 
     # --- ROI_Capital ---
+    if "ROI_Capital" in wb.sheetnames:
+        del wb["ROI_Capital"]
     roi = wb.create_sheet("ROI_Capital")
     roi.append(
         [
@@ -348,7 +466,7 @@ def build_notebook_workbook(
         ]
     )
     _style_header(roi)
-    n_meas = max(len(measure_ids), 1)
+    n_meas = max(len(ids), 1)
     # Closed-form NPV of escalated annuity (matches wattlab.finance.escalated_cash_flows + npv)
     npv_formula = (
         "=IF(ABS(inp_discount-inp_escalation)<1E-9,"
@@ -357,12 +475,17 @@ def build_notebook_workbook(
         "/(inp_discount-inp_escalation))"
     )
     for i, row in enumerate(econ_rows, start=2):
-        roi[f"A{i}"] = row["measure_id"]
+        mid = row["measure_id"]
+        roi[f"A{i}"] = mid
         # H = Inputs-driven equal-split cost; B mirrors H (engineer may overwrite B with a lump sum)
         roi[f"H{i}"] = f"=inp_usd_per_ft2*inp_area_ft2*inp_coverage/{n_meas}"
         roi[f"B{i}"] = f"=H{i}"
-        roi[f"C{i}"] = row["kwh_saved"]
-        roi[f"D{i}"] = row["therms_saved"]
+        if mid in FORMULA_ESCO_KWH:
+            roi[f"C{i}"] = f"=ESCO_Calcs!B{i}"
+            roi[f"D{i}"] = f"=ESCO_Calcs!C{i}"
+        else:
+            roi[f"C{i}"] = row["kwh_saved"]
+            roi[f"D{i}"] = row["therms_saved"]
         roi[f"E{i}"] = f"=C{i}*inp_elec_rate+D{i}*inp_gas_rate"
         roi[f"F{i}"] = f'=IF(E{i}=0,"",B{i}/E{i})'
         roi[f"G{i}"] = npv_formula.format(i=i)
@@ -384,6 +507,8 @@ def build_notebook_workbook(
     roi.column_dimensions["I"].width = 18
 
     # --- Guardrails ---
+    if "Guardrails" in wb.sheetnames:
+        del wb["Guardrails"]
     gr = wb.create_sheet("Guardrails")
     gr.append(["check", "status", "detail"])
     _style_header(gr)
@@ -400,6 +525,8 @@ def build_notebook_workbook(
     gr.column_dimensions["C"].width = 60
 
     # --- Docs ---
+    if "Docs" in wb.sheetnames:
+        del wb["Docs"]
     docs = wb.create_sheet("Docs")
     docs["A1"] = "Documentation & calculator map"
     docs["A1"].font = Font(bold=True, size=14)
@@ -417,37 +544,41 @@ def build_notebook_workbook(
     docs["A7"] = "Catalog package"
     docs["B7"] = pkg.catalog_package
     docs["A8"] = "Measure ids"
-    docs["B8"] = ", ".join(measure_ids)
+    docs["B8"] = ", ".join(ids)
     docs["A9"] = "Template file"
     docs["B9"] = (
-        "templates/ecm_package_v1.xlsx is a write-template scaffold only — "
-        "builds always generate Workbook() in builder.py (BUG-033 honesty)"
+        f"templates/ecm_package_v1.xlsx {'LOADED then rebuilt' if template_loaded else 'missing — Workbook()'} "
+        "(agent-owned Excel; Studio mirrors disk)"
     )
     docs["A10"] = "Agent CLI"
     docs["B10"] = (
-        f"wattlab notebook build --package {pkg.id} --out reports/notebooks/ "
-        f"| wattlab notebook prefill --xlsx … --elec-rate 0.22  (in-place Inputs)"
+        f"wattlab notebook agent-build --package {pkg.id} --ecms … "
+        f"--out reports/notebooks/ | prefill | refresh-caches | sync-from-twin"
     )
     docs["A11"] = "E+ Compare"
     docs["B11"] = (
         "YELLOW light when Twin report lacks savings_by_measure — "
-        "pick an ECM-capable run (validate warns); easy-button needs Docker sock"
+        "optional sync-from-twin; never blocks workbook ship"
     )
     docs["A12"] = "ESCO kWh/therms honesty"
     docs["B12"] = (
-        "Baked at build via wattlab.studio.proxies / bench/esco.py — "
-        "not live Excel bin blocks. Human map: docs/ESCO_SPREADSHEET_CALCS.md"
+        f"Formula-backed: {', '.join(sorted(FORMULA_ESCO_KWH))}. "
+        "Others: Python proxy at build. Screening — not investment-grade."
     )
     docs["A13"] = "Agent refresh"
     docs["B13"] = (
         "wattlab notebook prefill (Inputs) | refresh-caches (npv_usd_at_build) | "
-        "show-formulas --sheet ROI_Capital"
+        "show-formulas --sheet ROI_Capital | sync-from-twin"
     )
     docs.column_dimensions["A"].width = 28
     docs.column_dimensions["B"].width = 80
 
     wb.properties.title = f"WattLab notebook · {pkg.id}"
     wb.properties.creator = "WattLab"
+    # Stash for summarize via custom prop isn't needed — Cover Template row is enough
+    wb._wattlab_template_loaded = template_loaded  # type: ignore[attr-defined]
+    wb._wattlab_formula_backed = list(formula_backed)  # type: ignore[attr-defined]
+    wb._wattlab_twin_run = twin_note  # type: ignore[attr-defined]
     return wb
 
 
@@ -475,6 +606,13 @@ _INPUT_PARAM_ALIASES: dict[str, str] = {
     "life_years": "life_years",
     "usd_per_ft2": "usd_per_ft2",
     "coverage": "coverage",
+    "sched_hours_saved": "sched_hours_saved",
+    "fan_hours": "fan_hours",
+    "fan_annual_hours": "fan_hours",
+    "fan_speed": "fan_speed",
+    "fan_proposed_speed": "fan_speed",
+    "kw_per_ton": "kw_per_ton",
+    "lockout_hours": "lockout_hours",
 }
 
 
@@ -501,7 +639,7 @@ def prefill_notebook_inputs(
     """Patch yellow Inputs cells in-place — keeps EPlus_Results / ESCO / formulas (BUG-030).
 
     Only keys present in ``overrides`` are written. Does **not** rebuild the workbook
-    or refill unspecified Inputs from defaults.
+    or refill unspecified Inputs from defaults. Updates Cover Building when identity keys given.
     """
     from openpyxl import load_workbook
     from openpyxl.styles import PatternFill
@@ -515,29 +653,47 @@ def prefill_notebook_inputs(
         if v is None:
             continue
         param = _INPUT_PARAM_ALIASES.get(str(k), str(k))
+        if param in _BUILDING_LABEL_KEYS or param == "building":
+            continue
         patch[param] = v
 
-    if not patch:
+    building_label = None
+    if overrides:
+        building_label = resolve_building_label(overrides)
+        if building_label == "BUILDING" and not any(
+            overrides.get(k) for k in _BUILDING_LABEL_KEYS
+        ):
+            building_label = None
+
+    if not patch and not building_label:
         return {"path": str(path), "updated": [], "inputs": read_notebook_inputs(path)}
 
     wb = load_workbook(path, data_only=False)
-    if "Inputs" not in wb.sheetnames:
-        raise ValueError(f"Inputs sheet missing in {path}")
-    ws = wb["Inputs"]
-    row_by: dict[str, int] = {}
-    for r in range(2, (ws.max_row or 2) + 1):
-        key = ws.cell(r, 1).value
-        if key:
-            row_by[str(key)] = r
     updated: list[str] = []
-    yellow = PatternFill("solid", fgColor=YELLOW)
-    for param, val in patch.items():
-        if param not in row_by:
-            continue
-        cell = ws.cell(row_by[param], 2)
-        cell.value = val
-        cell.fill = yellow
-        updated.append(param)
+    if patch:
+        if "Inputs" not in wb.sheetnames:
+            raise ValueError(f"Inputs sheet missing in {path}")
+        ws = wb["Inputs"]
+        row_by: dict[str, int] = {}
+        for r in range(2, (ws.max_row or 2) + 1):
+            key = ws.cell(r, 1).value
+            if key:
+                row_by[str(key)] = r
+        yellow = PatternFill("solid", fgColor=YELLOW)
+        for param, val in patch.items():
+            if param not in row_by:
+                continue
+            cell = ws.cell(row_by[param], 2)
+            cell.value = val
+            cell.fill = yellow
+            updated.append(param)
+    if building_label and "Cover" in wb.sheetnames:
+        cover = wb["Cover"]
+        for r in range(4, (cover.max_row or 4) + 1):
+            if str(cover.cell(r, 1).value or "").strip().lower() == "building":
+                cover.cell(r, 2).value = building_label
+                updated.append("cover.building")
+                break
     wb.save(path)
     return {"path": str(path), "updated": updated, "inputs": read_notebook_inputs(path)}
 
@@ -721,23 +877,141 @@ def build_and_save_notebook(
     profile: dict[str, Any] | None = None,
     report: dict[str, Any] | None = None,
     input_overrides: dict[str, Any] | None = None,
+    measure_ids: list[str] | tuple[str, ...] | None = None,
+    twin_run: str | None = None,
     write_manifest: bool = True,
+    use_template: bool = True,
 ) -> dict[str, Path]:
     pkg = get_notebook_package(package_id)
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     xlsx = out_dir / f"{pkg.id}.xlsx"
     wb = build_notebook_workbook(
-        pkg, profile=profile, report=report, input_overrides=input_overrides
+        pkg,
+        profile=profile,
+        report=report,
+        input_overrides=input_overrides,
+        measure_ids=measure_ids,
+        twin_run=twin_run,
+        use_template=use_template,
     )
     save_workbook(wb, xlsx)
     written = {"xlsx": xlsx}
     if write_manifest:
-        man = summarize_notebook(xlsx, package=pkg)
+        man = summarize_notebook(
+            xlsx,
+            package=pkg,
+            twin_run=twin_run,
+            selected_ecm_ids=list(measure_ids) if measure_ids else None,
+            template_loaded=bool(getattr(wb, "_wattlab_template_loaded", False)),
+            formula_backed=list(getattr(wb, "_wattlab_formula_backed", []) or []),
+        )
         mp = out_dir / f"{pkg.id}.notebook_manifest.json"
         mp.write_text(json.dumps(man, indent=2) + "\n", encoding="utf-8")
         written["manifest"] = mp
     return written
+
+
+def agent_build_notebook(
+    package_id: str,
+    out_dir: Path | str,
+    *,
+    profile: dict[str, Any] | None = None,
+    report: dict[str, Any] | None = None,
+    input_overrides: dict[str, Any] | None = None,
+    measure_ids: list[str] | tuple[str, ...] | None = None,
+    twin_run: str | Path | None = None,
+    write_manifest: bool = True,
+) -> dict[str, Path]:
+    """Agent-owned workbook write (BUG-050). Soft Twin paste — never fails on missing E+."""
+    twin_label = None
+    if twin_run is not None:
+        twin_label = str(twin_run)
+    return build_and_save_notebook(
+        package_id,
+        out_dir,
+        profile=profile,
+        report=report or {},
+        input_overrides=input_overrides,
+        measure_ids=measure_ids,
+        twin_run=twin_label,
+        write_manifest=write_manifest,
+        use_template=True,
+    )
+
+
+def sync_notebook_from_twin(
+    path: Path | str,
+    *,
+    twin_run: Path | str | None = None,
+    report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Refresh EPlus_Results (+ Cover twin id) only. Soft no-op when report missing."""
+    from openpyxl import load_workbook
+
+    path = Path(path)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+
+    loaded: dict[str, Any] = dict(report or {})
+    twin_label = ""
+    if twin_run is not None:
+        twin_label = str(twin_run)
+        root = Path(twin_run)
+        if root.is_dir():
+            twin_label = root.name
+            for name in ("report.json", "wattlab_report.json", "calibration_scorecard.json"):
+                p = root / name
+                if p.is_file():
+                    try:
+                        data = json.loads(p.read_text(encoding="utf-8"))
+                        if isinstance(data, dict):
+                            loaded = {**loaded, **data}
+                    except (OSError, json.JSONDecodeError):
+                        continue
+
+    ep_by = _ep_by_measure(loaded)
+    wb = load_workbook(path, data_only=False)
+    updated = 0
+    note = "ok"
+    if not ep_by:
+        note = "no savings_by_measure — EPlus_Results left unchanged"
+    elif "EPlus_Results" not in wb.sheetnames:
+        note = "EPlus_Results sheet missing"
+    else:
+        ws = wb["EPlus_Results"]
+        for r in range(2, (ws.max_row or 1) + 1):
+            mid = ws.cell(r, 1).value
+            if not mid:
+                continue
+            ep = ep_by.get(str(mid)) or {}
+            if not ep:
+                continue
+            ws.cell(r, 2).value = ep.get("kwh_saved")
+            ws.cell(r, 3).value = ep.get("therms_saved")
+            ws.cell(r, 4).value = ep.get("peak_demand_kw_delta")
+            ws.cell(r, 5).value = f"Twin sync · {twin_label or 'report'}"
+            updated += 1
+    if twin_label and "Cover" in wb.sheetnames:
+        cover = wb["Cover"]
+        for r in range(4, (cover.max_row or 4) + 1):
+            if str(cover.cell(r, 1).value or "").strip().lower() == "twin run":
+                cover.cell(r, 2).value = twin_label
+                break
+    wb.save(path)
+    man_path = path.parent / f"{path.stem}.notebook_manifest.json"
+    try:
+        man = summarize_notebook(path, twin_run=twin_label or None)
+        man_path.write_text(json.dumps(man, indent=2) + "\n", encoding="utf-8")
+    except Exception:
+        man_path = Path("")
+    return {
+        "path": str(path),
+        "updated_rows": updated,
+        "note": note,
+        "twin_run": twin_label or None,
+        "manifest": str(man_path) if man_path else None,
+    }
 
 
 def validate_notebook(path: Path | str) -> dict[str, Any]:
@@ -790,7 +1064,15 @@ def validate_notebook(path: Path | str) -> dict[str, Any]:
     }
 
 
-def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = None) -> dict[str, Any]:
+def summarize_notebook(
+    path: Path | str,
+    *,
+    package: NotebookPackage | None = None,
+    twin_run: str | None = None,
+    selected_ecm_ids: list[str] | None = None,
+    template_loaded: bool | None = None,
+    formula_backed: list[str] | None = None,
+) -> dict[str, Any]:
     from openpyxl import load_workbook
 
     path = Path(path)
@@ -821,6 +1103,18 @@ def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = No
         for row in wb["Inputs"].iter_rows(min_row=2, max_col=2, values_only=True):
             if row[0]:
                 inputs[str(row[0])] = row[1]
+    cover_building = None
+    cover_twin = None
+    cover_template = None
+    if "Cover" in wb.sheetnames:
+        for row in wb["Cover"].iter_rows(min_row=4, max_col=2, values_only=True):
+            key = str(row[0] or "").strip().lower()
+            if key == "building":
+                cover_building = row[1]
+            elif key == "twin run":
+                cover_twin = row[1]
+            elif key == "template":
+                cover_template = row[1]
     # Prefer package from Cover / stem; load catalog label when possible
     pkg_id = package.id if package else path.stem
     pkg_label = package.label if package else None
@@ -833,6 +1127,12 @@ def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = No
             pass
     validated = validate_notebook(path)
     formula_cells = collect_formula_cells(path)
+    fb = list(formula_backed) if formula_backed is not None else [
+        m for m in measures if m in FORMULA_ESCO_KWH
+    ]
+    tpl_loaded = template_loaded
+    if tpl_loaded is None:
+        tpl_loaded = bool(cover_template and "loaded" in str(cover_template).lower())
     return {
         "schema": "wattlab_notebook_manifest_v1",
         "path": str(path.resolve()),
@@ -841,10 +1141,14 @@ def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = No
         "sheets": list(wb.sheetnames),
         "named_ranges": list(wb.defined_names.keys()),
         "measure_ids": measures,
+        "selected_ecm_ids": selected_ecm_ids or measures,
+        "twin_run": twin_run or (str(cover_twin) if cover_twin else None),
+        "building": cover_building,
         "compare": verdicts,
         "guardrail_verdict": gate,
         "inputs": inputs,
         "formula_cells": formula_cells,
+        "formula_backed_measures": fb,
         "docs_url": ESCO_DOCS_URL,
         "validated": validated,
         "ep_coverage": {
@@ -852,9 +1156,12 @@ def summarize_notebook(path: Path | str, *, package: NotebookPackage | None = No
             "filled_rows": validated.get("ep_filled_rows"),
         },
         "honesty": {
-            "esco_kwh_therms": "baked_at_build",
+            "band": "screening_not_investment_grade",
+            "esco_kwh_therms": "excel_formulas_for_subset_else_baked",
+            "formula_backed": fb,
             "roi_cost_npv": "excel_formulas_from_inputs",
-            "template_file": "scaffold_only",
+            "template_file": "loaded" if tpl_loaded else "scaffold_only",
+            "openfdd": "not_used",
         },
     }
 
@@ -893,18 +1200,23 @@ def write_template_stub(path: Path | str) -> Path:
 
 
 __all__ = [
+    "FORMULA_ESCO_KWH",
+    "agent_build_notebook",
     "build_and_save_notebook",
     "build_notebook_workbook",
     "collect_formula_cells",
     "default_inputs_from_profile",
+    "default_template_path",
     "list_notebook_packages",
     "prefill_notebook_inputs",
     "preview_sheet_rows",
     "read_notebook_inputs",
     "refresh_notebook_caches",
+    "resolve_building_label",
     "save_workbook",
     "show_formulas",
     "summarize_notebook",
+    "sync_notebook_from_twin",
     "validate_notebook",
     "write_template_stub",
 ]

--- a/vibe_code_apps_20/wattlab/notebooks/cli.py
+++ b/vibe_code_apps_20/wattlab/notebooks/cli.py
@@ -1,4 +1,4 @@
-"""``wattlab notebook`` — build / prefill / validate / summarize ECM Excel notebooks."""
+"""``wattlab notebook`` — agent-owned ECM Excel + Studio mirror helpers."""
 
 from __future__ import annotations
 
@@ -32,6 +32,8 @@ def _load_profile(args: argparse.Namespace) -> dict[str, Any]:
         overrides["cooling_tons"] = float(args.cooling_tons)
     if getattr(args, "fan_hp", None):
         overrides["fan_hp"] = float(args.fan_hp)
+    if getattr(args, "building", None):
+        overrides["display_name"] = str(args.building)
     profile.update(overrides)
     return profile
 
@@ -47,10 +49,26 @@ def _load_report(run_dir: Path | None) -> dict[str, Any]:
     return {}
 
 
+def _parse_ecms(raw: str | None) -> list[str] | None:
+    if not raw:
+        return None
+    parts = [p.strip() for p in str(raw).replace(";", ",").split(",")]
+    return [p for p in parts if p]
+
+
+def _rate_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+    if getattr(args, "elec_rate", None) is not None:
+        overrides["elec_rate"] = float(args.elec_rate)
+    if getattr(args, "gas_rate", None) is not None:
+        overrides["gas_rate"] = float(args.gas_rate)
+    return overrides
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(
         prog="wattlab notebook",
-        description="ECM engineering notebooks (Excel) — ESCO vs EnergyPlus + ROI",
+        description="ECM engineering notebooks (Excel) — agent-owned; Studio mirrors disk",
     )
     sub = p.add_subparsers(dest="cmd", required=True)
 
@@ -58,24 +76,43 @@ def main(argv: list[str] | None = None) -> int:
     sp.set_defaults(func=_cmd_list)
 
     bp = sub.add_parser("build", help="Build one package workbook + manifest")
-    bp.add_argument("--package", required=True, help="Notebook package id (e.g. controls_first)")
-    bp.add_argument("--out", type=Path, required=True, help="Output directory")
-    bp.add_argument("--profile", type=Path, help="building profile JSON")
-    bp.add_argument("--answers", type=Path, help="answers.json (merged into profile)")
-    bp.add_argument("--from-run", type=Path, help="Twin run dir with savings_by_measure")
-    bp.add_argument("--area", type=float, help="Override floor area ft²")
-    bp.add_argument("--cooling-tons", type=float, dest="cooling_tons")
-    bp.add_argument("--fan-hp", type=float, dest="fan_hp")
-    bp.add_argument("--elec-rate", type=float, dest="elec_rate")
-    bp.add_argument("--gas-rate", type=float, dest="gas_rate")
-    bp.add_argument("--no-manifest", action="store_true")
+    _add_build_args(bp)
     bp.set_defaults(func=_cmd_build)
+
+    ab = sub.add_parser(
+        "agent-build",
+        help="Agent-owned workbook write (--ecms / --scenario / optional twin)",
+    )
+    _add_build_args(ab, package_required=False)
+    ab.add_argument("--ecms", type=str, default=None, help="Comma-separated catalog ECM ids")
+    ab.add_argument("--scenario", type=Path, help="ecm_scenario.json (v4)")
+    ab.add_argument(
+        "--twin-run",
+        type=Path,
+        dest="twin_run",
+        help="Twin run dir (soft EPlus_Results paste; never fails build)",
+    )
+    ab.add_argument(
+        "--write-scenario",
+        action="store_true",
+        help="Update scenario notebook_path / selected ids / twin_run",
+    )
+    ab.set_defaults(func=_cmd_agent_build)
+
+    st = sub.add_parser(
+        "sync-from-twin",
+        help="Refresh EPlus_Results only from a Twin run (soft if missing)",
+    )
+    st.add_argument("--xlsx", type=Path, required=True)
+    st.add_argument("--twin-run", type=Path, dest="twin_run", required=True)
+    st.set_defaults(func=_cmd_sync_twin)
 
     pp = sub.add_parser("prefill", help="Rewrite Inputs yellow cells on an existing workbook")
     pp.add_argument("--xlsx", type=Path, required=True)
     pp.add_argument("--profile", type=Path)
     pp.add_argument("--answers", type=Path)
     pp.add_argument("--from-run", type=Path)
+    pp.add_argument("--building", type=str, help="Cover Building label override")
     pp.add_argument("--area", type=float)
     pp.add_argument("--cooling-tons", type=float, dest="cooling_tons")
     pp.add_argument("--fan-hp", type=float, dest="fan_hp")
@@ -117,6 +154,26 @@ def main(argv: list[str] | None = None) -> int:
     return int(args.func(args) or 0)
 
 
+def _add_build_args(bp: argparse.ArgumentParser, *, package_required: bool = True) -> None:
+    bp.add_argument(
+        "--package",
+        required=package_required,
+        default=None,
+        help="Notebook package id (e.g. controls_first)",
+    )
+    bp.add_argument("--out", type=Path, required=True, help="Output directory")
+    bp.add_argument("--profile", type=Path, help="building profile JSON")
+    bp.add_argument("--answers", type=Path, help="answers.json (merged into profile)")
+    bp.add_argument("--from-run", type=Path, help="Twin run dir with savings_by_measure")
+    bp.add_argument("--building", type=str, help="Cover Building label (BUG-047)")
+    bp.add_argument("--area", type=float, help="Override floor area ft²")
+    bp.add_argument("--cooling-tons", type=float, dest="cooling_tons")
+    bp.add_argument("--fan-hp", type=float, dest="fan_hp")
+    bp.add_argument("--elec-rate", type=float, dest="elec_rate")
+    bp.add_argument("--gas-rate", type=float, dest="gas_rate")
+    bp.add_argument("--no-manifest", action="store_true")
+
+
 def _cmd_list(_args: argparse.Namespace) -> int:
     from wattlab.notebooks.packages import list_notebook_packages
 
@@ -138,21 +195,82 @@ def _cmd_build(args: argparse.Namespace) -> int:
     from wattlab.notebooks.builder import build_and_save_notebook
 
     profile = _load_profile(args)
-    overrides: dict[str, Any] = {}
-    if args.elec_rate is not None:
-        overrides["elec_rate"] = float(args.elec_rate)
-    if args.gas_rate is not None:
-        overrides["gas_rate"] = float(args.gas_rate)
-    report = _load_report(args.from_run)
+    overrides = _rate_overrides(args)
+    twin = getattr(args, "from_run", None)
+    report = _load_report(twin)
     written = build_and_save_notebook(
         args.package,
         args.out,
         profile=profile,
         report=report,
         input_overrides=overrides or None,
+        twin_run=str(twin) if twin else None,
         write_manifest=not args.no_manifest,
     )
     print(json.dumps({k: str(v) for k, v in written.items()}, indent=2))
+    return 0
+
+
+def _cmd_agent_build(args: argparse.Namespace) -> int:
+    from wattlab.notebooks.builder import agent_build_notebook
+    from wattlab.studio.ecm_scenario import load_ecm_scenario, save_ecm_scenario
+
+    scen: dict[str, Any] = {}
+    if getattr(args, "scenario", None):
+        scen = load_ecm_scenario(args.scenario)
+
+    package = args.package or scen.get("notebook_package_id") or "controls_first"
+    ecms = _parse_ecms(getattr(args, "ecms", None))
+    if not ecms and scen.get("selected_ecm_ids"):
+        ecms = list(scen["selected_ecm_ids"])
+
+    profile = _load_profile(args)
+    overrides = dict(scen.get("input_overrides") or {})
+    overrides.update(_rate_overrides(args))
+
+    twin = getattr(args, "twin_run", None) or getattr(args, "from_run", None)
+    if twin is None and scen.get("twin_run"):
+        twin = Path(str(scen["twin_run"]))
+    report = _load_report(Path(twin) if twin else None)
+
+    written = agent_build_notebook(
+        str(package),
+        args.out,
+        profile=profile,
+        report=report,
+        input_overrides=overrides or None,
+        measure_ids=ecms,
+        twin_run=twin,
+        write_manifest=not args.no_manifest,
+    )
+
+    if getattr(args, "write_scenario", False) or getattr(args, "scenario", None):
+        scen_path = args.scenario if getattr(args, "scenario", None) else None
+        body = load_ecm_scenario(scen_path) if scen_path else dict(scen or {})
+        body["notebook_package_id"] = str(package)
+        body["notebook_path"] = str(written["xlsx"])
+        body["selected_ecm_ids"] = list(ecms) if ecms else body.get("selected_ecm_ids") or []
+        if twin:
+            body["twin_run"] = str(twin)
+        body["input_overrides"] = overrides
+        save_ecm_scenario(body, path=scen_path)
+
+    print(json.dumps({k: str(v) for k, v in written.items()}, indent=2))
+    return 0
+
+
+def _cmd_sync_twin(args: argparse.Namespace) -> int:
+    from wattlab.notebooks.builder import sync_notebook_from_twin
+
+    if not args.xlsx.is_file():
+        print(f"missing workbook: {args.xlsx}", file=sys.stderr)
+        return 2
+    try:
+        result = sync_notebook_from_twin(args.xlsx, twin_run=args.twin_run)
+    except Exception as exc:
+        print(f"sync-from-twin failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, default=str))
     return 0
 
 
@@ -184,6 +302,17 @@ def _cmd_prefill(args: argparse.Namespace) -> int:
                 "life_years",
                 "usd_per_ft2",
                 "coverage",
+                "display_name",
+                "project_id",
+                "building_name",
+                "building",
+                "name",
+                "building_id",
+                "sched_hours_saved",
+                "fan_hours",
+                "fan_speed",
+                "kw_per_ton",
+                "lockout_hours",
             ):
                 overrides[k] = v
             if k == "utility" and isinstance(v, dict):
@@ -191,6 +320,8 @@ def _cmd_prefill(args: argparse.Namespace) -> int:
                     overrides["elec_rate"] = v["elec_usd_per_kwh"]
                 if v.get("gas_usd_per_therm") is not None:
                     overrides["gas_rate"] = v["gas_usd_per_therm"]
+    if getattr(args, "building", None):
+        overrides["display_name"] = str(args.building)
     if getattr(args, "area", None) is not None:
         overrides["area_ft2"] = float(args.area)
     if getattr(args, "cooling_tons", None) is not None:

--- a/vibe_code_apps_20/wattlab/notebooks/packages.py
+++ b/vibe_code_apps_20/wattlab/notebooks/packages.py
@@ -63,6 +63,11 @@ INPUT_NAMED_RANGES = (
     "inp_life_years",
     "inp_usd_per_ft2",
     "inp_coverage",
+    "inp_sched_hours_saved",
+    "inp_fan_hours",
+    "inp_fan_speed",
+    "inp_kw_per_ton",
+    "inp_lockout_hours",
 )
 
 

--- a/vibe_code_apps_20/wattlab/studio/ecm_scenario.py
+++ b/vibe_code_apps_20/wattlab/studio/ecm_scenario.py
@@ -1,13 +1,14 @@
-"""Load / save ``reports/ecm_scenario.json`` for Easy Buttons ↔ agent handoff."""
+"""Load / save ``reports/ecm_scenario.json`` for agent ↔ Studio ECMs mirror."""
 
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 DEFAULT_ECM_SCENARIO_NAME = "ecm_scenario.json"
-ECM_SCENARIO_VERSION = 3
+ECM_SCENARIO_VERSION = 4
 
 
 def default_ecm_scenario_path(workspace: Path | None = None) -> Path:
@@ -30,10 +31,24 @@ def empty_ecm_scenario() -> dict[str, Any]:
         "notebook_package_id": None,
         "notebook_path": None,
         "input_overrides": {},
+        "twin_run": None,
+        "updated_at": None,
         "notes": "",
         "recommendations": [],
-        "status": "empty — waiting agent or Easy Buttons",
+        "status": "empty — waiting agent or Rebuild from scenario",
     }
+
+
+def _normalize_status(body: dict[str, Any]) -> None:
+    ids = body.get("selected_ecm_ids") or []
+    if ids:
+        body["status"] = f"{len(ids)} ECMs selected"
+        if body.get("notebook_package_id"):
+            body["status"] += f" · notebook={body['notebook_package_id']}"
+        if body.get("twin_run"):
+            body["status"] += " · twin attached"
+    else:
+        body["status"] = "empty — waiting agent or Rebuild from scenario"
 
 
 def load_ecm_scenario(path: Path | str | None = None) -> dict[str, Any]:
@@ -63,12 +78,11 @@ def load_ecm_scenario(path: Path | str | None = None) -> dict[str, Any]:
         out["notebook_package_id"] = str(out["notebook_package_id"])
     if out.get("notebook_path"):
         out["notebook_path"] = str(out["notebook_path"])
-    if out["selected_ecm_ids"]:
-        out["status"] = f"{len(out['selected_ecm_ids'])} ECMs selected"
-        if out.get("notebook_package_id"):
-            out["status"] += f" · notebook={out['notebook_package_id']}"
+    if out.get("twin_run"):
+        out["twin_run"] = str(out["twin_run"])
     else:
-        out["status"] = "empty — waiting agent or Easy Buttons"
+        out["twin_run"] = None
+    _normalize_status(out)
     return out
 
 
@@ -94,11 +108,11 @@ def save_ecm_scenario(
         body["notebook_package_id"] = str(body["notebook_package_id"])
     if body.get("notebook_path"):
         body["notebook_path"] = str(body["notebook_path"])
-    if body["selected_ecm_ids"]:
-        body["status"] = f"{len(body['selected_ecm_ids'])} ECMs selected"
-        if body.get("notebook_package_id"):
-            body["status"] += f" · notebook={body['notebook_package_id']}"
+    if body.get("twin_run"):
+        body["twin_run"] = str(body["twin_run"])
     else:
-        body["status"] = "empty — waiting agent or Easy Buttons"
+        body["twin_run"] = None
+    body["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _normalize_status(body)
     p.write_text(json.dumps(body, indent=2), encoding="utf-8")
     return p

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -1,4 +1,4 @@
-"""ECMs — Excel engineering notebooks only (BUG-043)."""
+"""ECMs — disk mirror of agent-owned Excel notebooks (BUG-050)."""
 
 from __future__ import annotations
 
@@ -9,131 +9,7 @@ from typing import Any
 import pandas as pd
 import streamlit as st
 
-from wattlab.studio.g14_history import assign_run_numbers, iter_g14_history, pick_best_g14_run
-from wattlab.studio.workspace import reports_dir, runs_dir
-
-
-def _load_run_report(run_dir: Path | str | None) -> dict[str, Any]:
-    if not run_dir:
-        return {}
-    root = Path(run_dir)
-    for name in ("report.json", "wattlab_report.json", "calibration_scorecard.json"):
-        p = root / name
-        if p.is_file():
-            try:
-                data = json.loads(p.read_text(encoding="utf-8"))
-                return data if isinstance(data, dict) else {}
-            except (OSError, json.JSONDecodeError, TypeError):
-                continue
-    return {}
-
-
-def _enrich_profile_for_proxies(profile: dict[str, Any]) -> dict[str, Any]:
-    """Merge answers / hard_size nameplate into a profile copy for ESCO bins."""
-    out = dict(profile)
-    answers = st.session_state.get("studio_answers")
-    if isinstance(answers, dict):
-        for key in (
-            "cooling_tons",
-            "fan_hp",
-            "supply_fan_hp",
-            "conditioned_floor_area_ft2",
-            "floor_area_ft2",
-        ):
-            if out.get(key) is None and answers.get(key) is not None:
-                out[key] = answers[key]
-    hard = st.session_state.get("studio_hard_size")
-    if isinstance(hard, dict) and not isinstance(out.get("hard_size"), dict):
-        out["hard_size"] = hard
-    return out
-
-
-def _render_baseline_run_picker() -> None:
-    """Selectbox of Twin runs; prefer savings_by_measure (E+ measures)."""
-    st.subheader("Twin baseline run")
-    st.caption(
-        "Notebook Compare uses Twin ``savings_by_measure`` when present. "
-        "Prefer a run tagged **E+ measures**. Easy-button EP cascades need Docker "
-        "socket + EnergyPlus on the host (see AGENT_TOOLS.md)."
-    )
-    try:
-        rows = assign_run_numbers(iter_g14_history(runs_dir(), limit=40))
-    except Exception:
-        rows = []
-    if not rows:
-        st.info("No published Twin runs yet — calibrate on Twin first.")
-        return
-
-    best = pick_best_g14_run(rows)
-    opts = [str(r["dir"]) for r in rows if r.get("dir")]
-    by_dir = {str(r["dir"]): r for r in rows if r.get("dir")}
-
-    has_sbm: dict[str, bool] = {}
-    for d in opts:
-        rep = _load_run_report(d)
-        has_sbm[d] = bool(rep.get("savings_by_measure"))
-
-    stored = st.session_state.get("studio_ecm_baseline_run")
-    if stored and str(stored) in opts:
-        default_dir = str(stored)
-    elif best and best.get("dir"):
-        default_dir = str(best["dir"])
-    else:
-        default_dir = opts[-1] if opts else None
-    if default_dir and not has_sbm.get(default_dir):
-        with_sbm = [d for d in opts if has_sbm.get(d)]
-        if with_sbm:
-            default_dir = with_sbm[-1]
-
-    if default_dir and "studio_ecm_baseline_pick" not in st.session_state:
-        st.session_state["studio_ecm_baseline_pick"] = default_dir
-    cur = st.session_state.get("studio_ecm_baseline_pick")
-    if cur is not None and cur not in opts:
-        st.session_state.pop("studio_ecm_baseline_pick", None)
-        if default_dir:
-            st.session_state["studio_ecm_baseline_pick"] = default_dir
-
-    def _label(d: str) -> str:
-        r = by_dir.get(d) or {}
-        n = r.get("run")
-        rid = r.get("run_id") or Path(d).name
-        pf = r.get("pass_fail") or "—"
-        tag = " · best G14" if best and str(best.get("dir")) == d else ""
-        ecm = " · E+ measures" if has_sbm.get(d) else " · ESCO-only"
-        return f"#{n} · {rid} · {pf}{tag}{ecm}" if n is not None else f"{rid} · {pf}{tag}{ecm}"
-
-    pick = st.selectbox(
-        "Baseline Twin run",
-        options=opts,
-        format_func=_label,
-        key="studio_ecm_baseline_pick",
-    )
-    if pick:
-        st.session_state["studio_ecm_baseline_run"] = pick
-        report = _load_run_report(pick)
-        score = {}
-        sp = Path(pick) / "calibration_scorecard.json"
-        if sp.is_file():
-            try:
-                score = json.loads(sp.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError, TypeError):
-                score = {}
-        if report:
-            st.session_state["studio_report"] = {
-                **(st.session_state.get("studio_report") or {}),
-                **report,
-            }
-        meta = by_dir.get(pick) or {}
-        st.caption(
-            f"Active ECM baseline: #{meta.get('run')} · {meta.get('run_id')} · "
-            f"G14={meta.get('pass_fail') or (score.get('utility_bills') or {}).get('pass_fail') or '—'} "
-            f"· `{Path(pick).name}`"
-        )
-        if not has_sbm.get(pick):
-            st.warning(
-                "This Twin run has no ``savings_by_measure`` — notebook Compare will be "
-                "mostly YELLOW (ESCO-only). Pick a run tagged **E+ measures** when available."
-            )
+from wattlab.studio.workspace import reports_dir
 
 
 def _preview_sheet_frame(path: Path, sheet: str, *, mode: str) -> pd.DataFrame | None:
@@ -141,7 +17,6 @@ def _preview_sheet_frame(path: Path, sheet: str, *, mode: str) -> pd.DataFrame |
     from wattlab.notebooks.builder import preview_sheet_rows
 
     if mode == "values":
-        # Prefer formula-text overlay for formula cells + numeric caches
         formula_rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=False)
         value_rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=True)
         if not formula_rows:
@@ -153,7 +28,6 @@ def _preview_sheet_frame(path: Path, sheet: str, *, mode: str) -> pd.DataFrame |
             merged: list[Any] = []
             for j, cell in enumerate(frow):
                 if isinstance(cell, str) and cell.startswith("="):
-                    # Values mode: show cache-friendly display — use data_only if present else keep formula
                     vc = vrow[j] if j < len(vrow) else None
                     merged.append(vc if vc is not None else cell)
                 else:
@@ -167,87 +41,178 @@ def _preview_sheet_frame(path: Path, sheet: str, *, mode: str) -> pd.DataFrame |
     return pd.DataFrame(rows[1:], columns=rows[0])
 
 
-def _render_engineering_notebook(profile: dict[str, Any]) -> None:
-    """Primary ECM deliverable: package Excel notebook (Values/Formulas + download)."""
-    from wattlab.notebooks import (
-        build_and_save_notebook,
-        list_notebook_packages,
+def _list_notebook_files(out_dir: Path) -> list[Path]:
+    if not out_dir.is_dir():
+        return []
+    return sorted(out_dir.glob("*.xlsx"))
+
+
+def _enrich_profile(profile: dict[str, Any] | None) -> dict[str, Any]:
+    out = dict(profile or {})
+    answers = st.session_state.get("studio_answers")
+    if isinstance(answers, dict):
+        for key in (
+            "display_name",
+            "project_id",
+            "building_name",
+            "building",
+            "name",
+            "building_id",
+            "cooling_tons",
+            "fan_hp",
+            "supply_fan_hp",
+            "conditioned_floor_area_ft2",
+            "floor_area_ft2",
+        ):
+            if out.get(key) is None and answers.get(key) is not None:
+                out[key] = answers[key]
+    return out
+
+
+def _render_mirror() -> None:
+    from wattlab.notebooks import list_notebook_packages
+    from wattlab.notebooks.builder import (
+        agent_build_notebook,
+        refresh_notebook_caches,
+        validate_notebook,
     )
-    from wattlab.notebooks.builder import refresh_notebook_caches, validate_notebook
     from wattlab.studio.ecm_scenario import (
         default_ecm_scenario_path,
         load_ecm_scenario,
         save_ecm_scenario,
     )
 
-    st.subheader("Engineering notebook (Excel)")
+    st.subheader("Engineering notebook (Excel mirror)")
     st.caption(
-        "Excel is the ECM contract: build/refresh → Values + Formulas preview → download. "
-        "Agents: `wattlab notebook build|prefill|refresh-caches|show-formulas|validate|summarize`."
+        "Agent owns the `.xlsx` under `reports/notebooks/`. "
+        "Refresh the browser or **Reload from disk** to see the latest bytes. "
+        "CLI: `wattlab notebook agent-build|prefill|refresh-caches|sync-from-twin|show-formulas`."
     )
     st.markdown(
         "[ESCO formula map (GitHub)]"
         "(https://github.com/bbartling/py-bacnet-stacks-playground/blob/develop/"
         "vibe_code_apps_20/docs/ESCO_SPREADSHEET_CALCS.md)"
     )
+
+    out_dir = reports_dir() / "notebooks"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    scen = load_ecm_scenario()
     pkgs = list_notebook_packages()
     by_id = {p.id: p for p in pkgs}
     labels = {p.id: p.label for p in pkgs}
+
+    on_disk = _list_notebook_files(out_dir)
+    disk_stems = {p.stem: p for p in on_disk}
+
+    default_pkg = scen.get("notebook_package_id") or (pkgs[0].id if pkgs else "controls_first")
+    if default_pkg not in by_id and disk_stems:
+        default_pkg = next(iter(disk_stems))
+    pkg_ids = [p.id for p in pkgs]
+    for stem in disk_stems:
+        if stem not in pkg_ids:
+            pkg_ids.append(stem)
+
+    if "ecm_notebook_package" not in st.session_state and default_pkg in pkg_ids:
+        st.session_state["ecm_notebook_package"] = default_pkg
+
     pick = st.selectbox(
-        "Package",
-        [p.id for p in pkgs],
-        format_func=lambda k: labels.get(k, k),
+        "Package / file",
+        pkg_ids,
+        format_func=lambda k: labels.get(k, k) + (" · on disk" if k in disk_stems else " · not built yet"),
         key="ecm_notebook_package",
     )
-    pkg = by_id[pick]
-    st.caption(f"{pkg.honesty} · {len(pkg.measure_ids)} measures · catalog `{pkg.catalog_package}`")
+    pkg = by_id.get(pick)
+    if pkg:
+        st.caption(f"{pkg.honesty} · {len(pkg.measure_ids)} catalog measures · `{pkg.catalog_package}`")
+    if scen.get("status"):
+        st.caption(f"Scenario: {scen.get('status')} · twin={scen.get('twin_run') or '—'}")
 
-    out_dir = reports_dir() / "notebooks"
-    c1, c2 = st.columns(2)
+    c1, c2, c3 = st.columns(3)
     with c1:
-        build_clicked = st.button("Build / refresh notebook", type="primary", key="ecm_notebook_build")
+        reload_clicked = st.button("Reload from disk", key="ecm_notebook_reload")
     with c2:
         refresh_clicked = st.button("Refresh caches only", key="ecm_notebook_refresh_caches")
+    with c3:
+        rebuild_clicked = st.button(
+            "Rebuild from scenario.json",
+            key="ecm_notebook_rebuild_scenario",
+            help="Same helper as `wattlab notebook agent-build --scenario …`",
+        )
 
-    if build_clicked:
+    if reload_clicked:
+        st.session_state.pop("studio_notebook_path", None)
+        st.session_state.pop("studio_notebook_manifest", None)
+        st.info("Session path cleared — re-reading disk.")
+
+    if rebuild_clicked:
         try:
-            proxy_profile = _enrich_profile_for_proxies(profile)
-            report = st.session_state.get("studio_report") or {}
-            run = st.session_state.get("studio_ecm_baseline_run")
-            if run and not report.get("savings_by_measure"):
-                report = {**report, **_load_run_report(run)}
-            written = build_and_save_notebook(
-                pick,
+            profile = _enrich_profile(st.session_state.get("studio_profile"))
+            scen = load_ecm_scenario()
+            package_id = scen.get("notebook_package_id") or pick
+            ecms = scen.get("selected_ecm_ids") or None
+            twin = scen.get("twin_run")
+            report: dict[str, Any] = {}
+            if twin:
+                root = Path(str(twin))
+                if not root.is_absolute():
+                    # allow run id relative to runs/
+                    from wattlab.studio.workspace import runs_dir
+
+                    cand = runs_dir() / str(twin)
+                    if cand.is_dir():
+                        root = cand
+                for name in ("report.json", "wattlab_report.json", "calibration_scorecard.json"):
+                    rp = root / name if root.is_dir() else Path()
+                    if rp.is_file():
+                        try:
+                            data = json.loads(rp.read_text(encoding="utf-8"))
+                            if isinstance(data, dict):
+                                report = data
+                        except (OSError, json.JSONDecodeError, TypeError):
+                            pass
+                        break
+            written = agent_build_notebook(
+                str(package_id),
                 out_dir,
-                profile=proxy_profile,
-                report=report if isinstance(report, dict) else {},
+                profile=profile,
+                report=report,
+                input_overrides=scen.get("input_overrides") or None,
+                measure_ids=list(ecms) if ecms else None,
+                twin_run=twin,
                 write_manifest=True,
             )
             st.session_state["studio_notebook_path"] = str(written["xlsx"])
             st.session_state["studio_notebook_manifest"] = str(written.get("manifest") or "")
-            v = validate_notebook(written["xlsx"])
-            for w in v.get("warnings") or []:
-                st.warning(w)
-            scen = load_ecm_scenario()
-            scen["notebook_package_id"] = pick
+            scen["notebook_package_id"] = str(package_id)
             scen["notebook_path"] = str(written["xlsx"])
-            scen["selected_ecm_ids"] = list(pkg.measure_ids)
+            if ecms:
+                scen["selected_ecm_ids"] = list(ecms)
             save_ecm_scenario(scen)
-            st.success(f"Notebook → {written['xlsx']}")
+            for w in (validate_notebook(written["xlsx"]).get("warnings") or []):
+                st.warning(w)
+            st.success(f"Rebuilt from scenario → {written['xlsx']}")
         except Exception as exc:
-            st.error(f"Notebook build failed: {exc}")
-            return
+            st.error(f"Rebuild from scenario failed: {exc}")
 
     xlsx = st.session_state.get("studio_notebook_path")
-    if not xlsx or not Path(str(xlsx)).is_file():
-        candidate = out_dir / f"{pick}.xlsx"
-        if candidate.is_file():
+    scen_path = scen.get("notebook_path")
+    if scen_path and Path(str(scen_path)).is_file() and (
+        not xlsx or Path(str(xlsx)).stem != pick
+    ):
+        if Path(str(scen_path)).stem == pick:
+            xlsx = str(scen_path)
+            st.session_state["studio_notebook_path"] = xlsx
+    if not xlsx or not Path(str(xlsx)).is_file() or Path(str(xlsx)).stem != pick:
+        candidate = disk_stems.get(pick) or (out_dir / f"{pick}.xlsx")
+        if Path(candidate).is_file():
             xlsx = str(candidate)
             st.session_state["studio_notebook_path"] = xlsx
+        else:
+            xlsx = None
 
     if refresh_clicked:
         if not xlsx or not Path(str(xlsx)).is_file():
-            st.warning("Build a notebook first, then refresh caches.")
+            st.warning("No notebook on disk for this package yet — agent-build or Rebuild from scenario.")
         else:
             try:
                 result = refresh_notebook_caches(xlsx)
@@ -255,67 +220,57 @@ def _render_engineering_notebook(profile: dict[str, Any]) -> None:
             except Exception as exc:
                 st.error(f"refresh-caches failed: {exc}")
 
-    if xlsx and Path(str(xlsx)).is_file():
-        path = Path(str(xlsx))
-        mode = st.radio(
-            "Preview mode",
-            options=["formulas", "values"],
-            format_func=lambda k: "Formulas (Excel code)" if k == "formulas" else "Values (caches / static)",
-            horizontal=True,
-            key="ecm_notebook_preview_mode",
-            help="Formulas = exact cell formula text. Values = numeric caches where Excel has not calc'd.",
+    if not xlsx or not Path(str(xlsx)).is_file():
+        st.info(
+            f"No `{pick}.xlsx` under `{out_dir}` yet. "
+            "Agent: `wattlab notebook agent-build --package … --out /data/reports/notebooks/` "
+            "or use **Rebuild from scenario.json**."
         )
-        tabs = st.tabs(["Inputs", "Compare", "ROI_Capital"])
-        for tab, sheet in zip(tabs, ("Inputs", "Compare", "ROI_Capital")):
-            with tab:
-                df = _preview_sheet_frame(path, sheet, mode=mode)
-                if df is None or df.empty:
-                    st.caption(f"Sheet `{sheet}` empty or missing.")
-                else:
-                    st.dataframe(df, width="stretch", hide_index=True)
+        st.caption(f"Scenario file → `{default_ecm_scenario_path()}`")
+        return
+
+    path = Path(str(xlsx))
+    mode = st.radio(
+        "Preview mode",
+        options=["formulas", "values"],
+        format_func=lambda k: "Formulas (Excel code)" if k == "formulas" else "Values (caches / static)",
+        horizontal=True,
+        key="ecm_notebook_preview_mode",
+        help="Formulas = exact cell formula text. Values = numeric caches where Excel has not calc'd.",
+    )
+    tabs = st.tabs(["Inputs", "ESCO_Calcs", "Compare", "ROI_Capital"])
+    for tab, sheet in zip(tabs, ("Inputs", "ESCO_Calcs", "Compare", "ROI_Capital")):
+        with tab:
+            df = _preview_sheet_frame(path, sheet, mode=mode)
+            if df is None or df.empty:
+                st.caption(f"Sheet `{sheet}` empty or missing.")
+            else:
+                st.dataframe(df, width="stretch", hide_index=True)
+    st.download_button(
+        "Download engineering notebook (.xlsx)",
+        data=path.read_bytes(),
+        file_name=path.name,
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        key="ecm_dl_notebook_xlsx",
+        type="primary",
+    )
+    man = path.parent / f"{path.stem}.notebook_manifest.json"
+    if man.is_file():
         st.download_button(
-            "Download engineering notebook (.xlsx)",
-            data=path.read_bytes(),
-            file_name=path.name,
-            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            key="ecm_dl_notebook_xlsx",
-            type="primary",
+            "Download notebook_manifest.json (agents)",
+            data=man.read_bytes(),
+            file_name=man.name,
+            mime="application/json",
+            key="ecm_dl_notebook_manifest",
         )
-        man = path.parent / f"{path.stem}.notebook_manifest.json"
-        if man.is_file():
-            st.download_button(
-                "Download notebook_manifest.json (agents)",
-                data=man.read_bytes(),
-                file_name=man.name,
-                mime="application/json",
-                key="ecm_dl_notebook_manifest",
-            )
-        st.caption(f"Also on disk: `{path}` · scenario → `{default_ecm_scenario_path()}`")
+    st.caption(f"On disk: `{path}` · scenario → `{default_ecm_scenario_path()}`")
 
 
 def render() -> None:
     st.header("ECMs — engineering notebooks")
     st.caption(
-        "Excel is the primary ECM deliverable (one package → one `.xlsx`). "
-        "No Easy Buttons / capital-plan / client DOCX on this page — use Twin + "
-        "`wattlab easy-button` / `wattlab notebook` CLIs for EP cascades."
+        "Studio is a **read-only mirror** of agent-written Excel under `reports/notebooks/`. "
+        "No Easy Buttons / capital-plan / client DOCX / OpenFDD. "
+        "Chat picks ECMs → agent writes `.xlsx` → refresh browser → download."
     )
-
-    profile = st.session_state.get("studio_profile")
-    if not profile:
-        answers = st.session_state.get("studio_answers")
-        st.info(
-            "Resolve a profile on **Twin / calibrate** first — or bootstrap with "
-            "`answers_path` so Re-apply builds `studio_profile` automatically. "
-            "Agents: `wattlab notebook build --package controls_first --out reports/notebooks/`."
-        )
-        if isinstance(answers, dict):
-            st.caption(
-                f"answers.json present (type={answers.get('building_type')}, "
-                f"city={answers.get('city')}) — Re-apply bootstrap to unlock ECMs."
-            )
-        return
-
-    _render_baseline_run_picker()
-    st.divider()
-    _render_engineering_notebook(profile)
+    _render_mirror()


### PR DESCRIPTION
## Summary
- **BUG-050:** Agent owns ECM `.xlsx` via `agent-build` / `sync-from-twin`; scenario v4; Studio ECMs mirrors disk.
- **BUG-047:** Cover building label uses `display_name` → `project_id` cascade.
- Starter Excel ESCO formulas for schedule / fan VFD / chiller lockout; template load; soft Twin paste.

## Test plan
- [x] Host pytest notebook builder + ECMs AppTest
- [ ] Merge → `vibe20-ghcr` green
- [ ] Refresh `:8502` / `:8520`; prune branch

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent-managed Excel notebook workflows, including ECM selection, twin-run synchronization, scenario updates, and optional template use.
  * Added formula-backed ESCO calculations with expanded input controls and improved building names in workbook outputs.
  * Studio ECMs now provides a disk-backed notebook mirror with reload, cache refresh, scenario rebuild, sheet previews, and downloads.

* **Bug Fixes**
  * Improved notebook summaries, formulas, cached values, and CLI override handling.
  * Updated ECM scenario status and timestamps for more accurate workflow tracking.

* **Documentation**
  * Updated notebook workflow guidance and scenario format details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->