### PR TITLE
feat(vibe20): ECM screening results UI (numbers, not formula soup)

### DIFF
--- a/vibe_code_apps_20/tests/test_notebook_builder.py
+++ b/vibe_code_apps_20/tests/test_notebook_builder.py
@@ -258,7 +258,7 @@ def test_agent_build_formula_esco_and_cli(tmp_path: Path):
         ]
     )
     assert rc == 0
-    assert (tmp_path / "cli_out" / "controls_first.xlsx").is_file()
+    assert (tmp_path / "cli_out" / "01_controls_first_rcx.xlsx").is_file()
 
 
 def test_sync_from_twin_soft(tmp_path: Path):

--- a/vibe_code_apps_20/tests/test_notebook_builder.py
+++ b/vibe_code_apps_20/tests/test_notebook_builder.py
@@ -367,6 +367,8 @@ def test_calibrated_twin_sheet_from_scorecard(tmp_path: Path):
     written2 = build_and_save_notebook("deep_retrofit", tmp_path / "empty", report={})
     wb2 = openpyxl.load_workbook(written2["xlsx"], data_only=False)
     assert "Calibrated_Twin" in wb2.sheetnames
+    assert wb2.sheetnames[1] == "Screening_Results"
+    assert wb2.active.title == "Screening_Results"
     status = None
     for r in range(2, 20):
         if wb2["Calibrated_Twin"][f"A{r}"].value == "status":
@@ -380,6 +382,32 @@ def test_calibrated_twin_sheet_from_scorecard(tmp_path: Path):
         if esco2.cell(r, 1).value
     }
     assert str(by_mid["ECM-ERV"]).startswith("=")
+
+    # Screening_Results: fuel-switch honesty (no huge negative "savings_kwh")
+    scr2 = wb2["Screening_Results"]
+    hdr = [scr2.cell(1, c).value for c in range(1, 12)]
+    assert hdr[:5] == [
+        "measure_id",
+        "basis",
+        "elec_delta_kwh",
+        "savings_kwh",
+        "savings_therms",
+    ]
+    rows_by = {}
+    for r in range(2, (scr2.max_row or 1) + 1):
+        mid = scr2.cell(r, 1).value
+        if mid and mid != "TOTAL":
+            rows_by[str(mid)] = {
+                "basis": scr2.cell(r, 2).value,
+                "elec_delta_kwh": scr2.cell(r, 3).value,
+                "savings_kwh": scr2.cell(r, 4).value,
+            }
+    for mid in ("ECM-DOAS-HP", "ECM-AWHP-SURROGATE"):
+        assert mid in rows_by
+        assert rows_by[mid]["basis"] == "fuel_switch"
+        assert float(rows_by[mid]["savings_kwh"] or 0) >= 0
+    assert wb2["Compare"]["H2"].value == "ESCO_ONLY_NO_EP"
+    assert wb2["EPlus_Results"]["A2"].value == "note"
 
     base = extract_calibrated_baseline(scorecard, twin_run="geo_b100_x")
     assert base["model_site_eui"] == 77.8

--- a/vibe_code_apps_20/tests/test_notebook_builder.py
+++ b/vibe_code_apps_20/tests/test_notebook_builder.py
@@ -385,6 +385,26 @@ def test_calibrated_twin_sheet_from_scorecard(tmp_path: Path):
     assert base["model_site_eui"] == 77.8
     assert base["has_core"] is True
 
+    # Flat Liberty scorecard.json shape (model_* top-level + model_peer)
+    flat = {
+        "run_id": "geo_b100_6stack_shape_r56_sched_mild",
+        "model_kwh": 1462657.3,
+        "model_therms": 59060.4,
+        "model_site_eui": 77.8,
+        "bill_kwh": 1464449.0,
+        "bill_therms": 56845.2,
+        "g14_pass": True,
+        "elec": {"nmbe_pct": 0.122, "cvrmse_pct": 11.339},
+        "gas": {"nmbe_pct": -3.897, "cvrmse_pct": 12.976},
+        "model_peer": {"band": "above_p80", "vs_median_pct": 47.1},
+    }
+    flat_base = extract_calibrated_baseline(flat, twin_run=flat["run_id"])
+    assert flat_base["model_site_eui"] == 77.8
+    assert flat_base["model_kwh"] == 1462657.3
+    assert flat_base["g14_pass"] == "PASS"
+    assert flat_base["peer_band"] == "above_p80"
+    assert flat_base["nmbe_elec_pct"] == 0.122
+
     man = summarize_notebook(written["xlsx"])
     assert man["docs_url"].endswith("ESCO_CALCULATORS.md")
     assert man["honesty"]["docs"]["retrofit_cost_roi"].endswith("ESCO_RETROFIT_COST_ROI.md")

--- a/vibe_code_apps_20/tests/test_notebook_builder.py
+++ b/vibe_code_apps_20/tests/test_notebook_builder.py
@@ -433,6 +433,25 @@ def test_calibrated_twin_sheet_from_scorecard(tmp_path: Path):
     assert flat_base["peer_band"] == "above_p80"
     assert flat_base["nmbe_elec_pct"] == 0.122
 
+    # per_month observed bills must sum all months (not stop after month 1)
+    monthly_bills = {
+        "utility_bills": {
+            "per_month": [
+                {"observed_kwh": 100.0, "observed_therms": 10.0},
+                {"observed_kwh": 200.0, "observed_therms": 20.0},
+                {"observed_kwh": 50.0, "observed_therms": 5.0},
+            ]
+        }
+    }
+    monthly_base = extract_calibrated_baseline(monthly_bills)
+    assert monthly_base["bill_kwh"] == 350.0
+    assert monthly_base["bill_therms"] == 35.0
+
     man = summarize_notebook(written["xlsx"])
     assert man["docs_url"].endswith("ESCO_CALCULATORS.md")
     assert man["honesty"]["docs"]["retrofit_cost_roi"].endswith("ESCO_RETROFIT_COST_ROI.md")
+    # Honesty Compare rows must not leak as fake measures
+    assert all(
+        str(v.get("measure_id") or "").lower() not in ("(package)", "note")
+        for v in (man.get("compare") or [])
+    )

--- a/vibe_code_apps_20/tests/test_studio_app.py
+++ b/vibe_code_apps_20/tests/test_studio_app.py
@@ -140,10 +140,48 @@ def test_studio_twin_and_ecms_dry_path(tmp_path, monkeypatch):
     assert any("G36_airside" in o for o in opts)
     assert any("plant_chiller" in o for o in opts)
     assert any("ERV_IAQ_DOAS" in o for o in opts)
-    # No formula dump in Studio
-    assert not any("Formulas used" in str(getattr(el, "value", el)) for el in at.subheader)
-    assert any("Screening results" in str(getattr(el, "value", el)) for el in at.subheader)
+    # Results-only UI — no formula dump / formula-sheet primary surface
+    ui_blob = " ".join(
+        str(getattr(el, "value", el))
+        for group in (at.subheader, at.markdown, at.caption)
+        for el in group
+    )
+    assert "Formulas used" not in ui_blob
+    assert "Screening results" in ui_blob
+    assert "ESCO_Calcs" not in ui_blob
+    assert "ROI_Capital" not in ui_blob
     assert not at.exception
+
+    # Deep retrofit screening: fuel-switch rows must not present huge negative "savings_kwh"
+    deep = next(p for p in (tmp_path / "reports" / "notebooks").glob("*.xlsx") if "ERV_IAQ" in p.name)
+    from openpyxl import load_workbook
+
+    wb = load_workbook(deep, data_only=False)
+    assert wb.sheetnames[0] == "Cover"
+    assert wb.sheetnames[1] == "Screening_Results"
+    assert wb.active.title == "Screening_Results"
+    scr = wb["Screening_Results"]
+    headers = [scr.cell(1, c).value for c in range(1, 12)]
+    assert "elec_delta_kwh" in headers
+    assert "basis" in headers
+    i_mid = headers.index("measure_id") + 1
+    i_basis = headers.index("basis") + 1
+    i_delta = headers.index("elec_delta_kwh") + 1
+    i_sav = headers.index("savings_kwh") + 1
+    for r in range(2, (scr.max_row or 1) + 1):
+        mid = scr.cell(r, i_mid).value
+        if mid in ("ECM-DOAS-HP", "ECM-AWHP-SURROGATE"):
+            assert scr.cell(r, i_basis).value == "fuel_switch"
+            delta = float(scr.cell(r, i_delta).value or 0)
+            sav = float(scr.cell(r, i_sav).value or 0)
+            assert sav >= 0
+            if delta < 0:
+                assert sav == 0
+    assert wb["Compare"]["H2"].value == "ESCO_ONLY_NO_EP"
+    assert wb["Compare"]["I2"].value == "N/A"
+    assert "YELLOW" not in {
+        wb["Compare"].cell(r, 9).value for r in range(2, (wb["Compare"].max_row or 1) + 1)
+    }
 
 
 def test_turnkey_live_html_smoke():

--- a/vibe_code_apps_20/tests/test_studio_app.py
+++ b/vibe_code_apps_20/tests/test_studio_app.py
@@ -133,23 +133,16 @@ def test_studio_twin_and_ecms_dry_path(tmp_path, monkeypatch):
     assert not any("ecm_notebook_build" in k for k in btn_keys)
     assert not any("ecm_notebook_refresh_caches" in k for k in btn_keys)
 
-    # File dropdown lists on-disk filenames only
+    # File dropdown lists on-disk filenames only (human-readable stems)
     assert any("ecm_notebook_file" in str(getattr(s, "key", "") or "") for s in at.selectbox)
     sel = at.selectbox(key="ecm_notebook_file")
     opts = list(getattr(sel, "options", []) or [])
-    assert "schedules_economizer.xlsx" in opts
-    assert "plant_optimization.xlsx" in opts
-    assert "deep_retrofit.xlsx" in opts
-
-    assert any("ecm_dl_notebook_xlsx" in k for k in btn_keys) or any(
-        "Download" in str(getattr(b, "label", "") or "") for b in at.button
-    ) or any(
-        "ecm_dl_notebook_xlsx" in str(getattr(b, "key", "") or "") for b in getattr(at, "download_button", [])
-    )
-    # Formulas used section present
-    assert any("Formulas used" in str(getattr(el, "value", el)) for el in at.subheader) or any(
-        "Formulas used" in str(x) for x in at.markdown
-    )
+    assert any("G36_airside" in o for o in opts)
+    assert any("plant_chiller" in o for o in opts)
+    assert any("ERV_IAQ_DOAS" in o for o in opts)
+    # No formula dump in Studio
+    assert not any("Formulas used" in str(getattr(el, "value", el)) for el in at.subheader)
+    assert any("Screening results" in str(getattr(el, "value", el)) for el in at.subheader)
     assert not at.exception
 
 

--- a/vibe_code_apps_20/wattlab/notebooks/builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/builder.py
@@ -212,13 +212,24 @@ def extract_calibrated_baseline(
     bill_kwh = _first(report.get("bill_kwh"), score.get("bill_kwh"))
     bill_therms = _first(report.get("bill_therms"), score.get("bill_therms"))
     if bill_kwh is None or bill_therms is None:
+        # Aggregate all months — do not stop after the first observed value
+        sum_kwh = 0.0
+        sum_therms = 0.0
+        n_kwh = 0
+        n_therms = 0
         for row in bills.get("per_month") or []:
             if not isinstance(row, dict):
                 continue
-            if bill_kwh is None and row.get("observed_kwh") is not None:
-                bill_kwh = (bill_kwh or 0.0) + float(row["observed_kwh"])
-            if bill_therms is None and row.get("observed_therms") is not None:
-                bill_therms = (bill_therms or 0.0) + float(row["observed_therms"])
+            if row.get("observed_kwh") is not None:
+                sum_kwh += float(row["observed_kwh"])
+                n_kwh += 1
+            if row.get("observed_therms") is not None:
+                sum_therms += float(row["observed_therms"])
+                n_therms += 1
+        if bill_kwh is None and n_kwh:
+            bill_kwh = round(sum_kwh, 1)
+        if bill_therms is None and n_therms:
+            bill_therms = round(sum_therms, 1)
 
     peer_band = _first(
         report.get("peer_band"),
@@ -712,17 +723,28 @@ def build_notebook_workbook(
     for i, row in enumerate(econ_rows, start=2):
         mid = row["measure_id"]
         p = proxies.get(mid) or {}
-        if str(p.get("basis") or "") == "fuel_switch":
+        ep = ep_by.get(mid) or {}
+        has_ep = ep.get("kwh_saved") is not None or ep.get("therms_saved") is not None
+        if has_ep:
+            basis = "energyplus"
+            elec_delta = float(ep.get("kwh_saved") if ep.get("kwh_saved") is not None else row.get("kwh_saved") or 0)
+            therms = float(ep.get("therms_saved") if ep.get("therms_saved") is not None else row.get("therms_saved") or 0)
+        elif str(p.get("basis") or "") == "fuel_switch":
             basis = "fuel_switch"
+            elec_delta = float(p.get("elec_delta_kwh", row.get("kwh_saved") or 0) or 0)
+            therms = float(row.get("therms_saved") or 0)
         elif mid in FORMULA_ESCO_KWH or mid in FORMULA_ESCO_THERMS:
             basis = "excel_formula"
+            elec_delta = float(row.get("kwh_saved") or 0)
+            therms = float(row.get("therms_saved") or 0)
         else:
             basis = "python_proxy"
-        elec_delta = float(p.get("elec_delta_kwh", row.get("kwh_saved") or 0) or 0)
-        therms = float(row.get("therms_saved") or 0)
+            elec_delta = float(p.get("elec_delta_kwh", row.get("kwh_saved") or 0) or 0)
+            therms = float(row.get("therms_saved") or 0)
         cost = float(row.get("implementation_cost_usd") or 0)
         annual = float(row.get("annual_cost_saved_usd") or 0)
-        payback = (cost / annual) if annual else None
+        # Negative annual $ (fuel-switch at some rates) is not a meaningful payback
+        payback = (cost / annual) if annual > 0 else None
         # Never label negative elec Δ as "savings" — fuel_switch uses elec_delta_kwh
         savings_kwh = max(0.0, elec_delta) if basis == "fuel_switch" else elec_delta
         if basis == "fuel_switch":
@@ -730,6 +752,8 @@ def build_notebook_workbook(
                 "Fuel switch: elec_delta_kwh may be negative (HP load added); "
                 "therms = gas avoided; $/yr uses both. Not 'negative kWh savings'."
             )
+        elif basis == "energyplus":
+            notes = "Twin measure EnergyPlus delta (vs baseline). Prefer over ESCO proxy when present."
         else:
             notes = (
                 "Build-time screening numbers for Studio. "
@@ -1276,6 +1300,10 @@ def build_and_save_notebook(
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     stem = (file_stem or notebook_file_stem(pkg.id) or pkg.id).strip() or pkg.id
+    # Bare filename only — never allow path traversal via caller-supplied stem
+    stem = Path(stem).name.replace("\\", "_").replace("/", "_").strip() or pkg.id
+    if stem in (".", ".."):
+        stem = pkg.id
     xlsx = out_dir / f"{stem}.xlsx"
     wb = build_notebook_workbook(
         pkg,
@@ -1402,6 +1430,32 @@ def sync_notebook_from_twin(
                 updated += 1
         if updated == 0:
             note = "no matching measure rows for Twin savings"
+        elif "Compare" in wb.sheetnames and updated:
+            # Drop stale ESCO_ONLY_NO_EP honesty when E+ measure rows now exist
+            cmp = wb["Compare"]
+            if str(cmp["H2"].value or "") == "ESCO_ONLY_NO_EP":
+                for r in range(2, (cmp.max_row or 2) + 1):
+                    for c in range(1, 10):
+                        cmp.cell(r, c).value = None
+                # Rebuild lightweight per-measure Compare from EPlus + ESCO
+                esco_by: dict[str, tuple[Any, Any]] = {}
+                if "ESCO_Calcs" in wb.sheetnames:
+                    for r in range(2, (wb["ESCO_Calcs"].max_row or 1) + 1):
+                        mid = wb["ESCO_Calcs"].cell(r, 1).value
+                        if mid:
+                            esco_by[str(mid)] = (
+                                wb["ESCO_Calcs"].cell(r, 2).value,
+                                wb["ESCO_Calcs"].cell(r, 3).value,
+                            )
+                for i, (mid, ep) in enumerate(sorted(ep_by.items()), start=2):
+                    cmp.cell(i, 1).value = mid
+                    cmp.cell(i, 2).value = esco_by.get(mid, (None, None))[0]
+                    cmp.cell(i, 3).value = ep.get("kwh_saved")
+                    cmp.cell(i, 6).value = esco_by.get(mid, (None, None))[1]
+                    cmp.cell(i, 7).value = ep.get("therms_saved")
+                    cmp.cell(i, 8).value = "TWIN_SYNCED"
+                    cmp.cell(i, 9).value = "GREEN"
+                note = "ok — Compare refreshed after Twin E+ paste"
     if twin_label and "Cover" in wb.sheetnames:
         cover = wb["Cover"]
         for r in range(4, (cover.max_row or 4) + 1):
@@ -1499,14 +1553,19 @@ def summarize_notebook(
     if "Compare" in wb.sheetnames:
         ws = wb["Compare"]
         for row in ws.iter_rows(min_row=2, max_col=9, values_only=True):
-            if row[0]:
-                verdicts.append(
-                    {
-                        "measure_id": str(row[0]),
-                        "verdict": str(row[7] or ""),
-                        "light": str(row[8] or ""),
-                    }
-                )
+            mid = row[0]
+            if not mid:
+                continue
+            mid_s = str(mid).strip().lower()
+            if mid_s in ("(package)", "note", "notes", "honesty"):
+                continue
+            verdicts.append(
+                {
+                    "measure_id": str(row[0]),
+                    "verdict": str(row[7] or ""),
+                    "light": str(row[8] or ""),
+                }
+            )
     gate = None
     if "Guardrails" in wb.sheetnames:
         gate = wb["Guardrails"]["B2"].value

--- a/vibe_code_apps_20/wattlab/notebooks/builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/builder.py
@@ -124,23 +124,58 @@ def extract_calibrated_baseline(
     twin_run: str | None = None,
     property_type: str = "office",
 ) -> dict[str, Any]:
-    """Pull G14 / annual / peer fields from Twin scorecard or report (BUG-057)."""
+    """Pull G14 / annual / peer fields from Twin scorecard or report (BUG-057).
+
+    Accepts both nested Studio shapes (``annual`` / ``utility_bills``) and the
+    flat Liberty ``scorecard.json`` fields (``model_kwh``, ``model_site_eui``,
+    ``model_peer``, …) plus ``g14`` / ``g14_score.json`` NMBE blocks.
+    """
     report = report or {}
     annual = report.get("annual") if isinstance(report.get("annual"), dict) else {}
     bills = report.get("utility_bills") if isinstance(report.get("utility_bills"), dict) else {}
     g14_blob = report.get("g14") if isinstance(report.get("g14"), dict) else {}
+    score = report.get("scorecard") if isinstance(report.get("scorecard"), dict) else {}
+    peer = (
+        report.get("model_peer")
+        if isinstance(report.get("model_peer"), dict)
+        else score.get("model_peer") if isinstance(score.get("model_peer"), dict) else {}
+    )
+
     stats_e = bills.get("stats_electricity") or bills.get("stats") or {}
     stats_g = bills.get("stats_natural_gas") or bills.get("stats_gas") or {}
     if not isinstance(stats_e, dict):
         stats_e = {}
     if not isinstance(stats_g, dict):
         stats_g = {}
+    # Flat g14_score / report.g14.elec|gas
+    elec_g = g14_blob.get("elec") if isinstance(g14_blob.get("elec"), dict) else {}
+    gas_g = g14_blob.get("gas") if isinstance(g14_blob.get("gas"), dict) else {}
+    if not elec_g and isinstance(report.get("elec"), dict):
+        elec_g = report["elec"]
+    if not gas_g and isinstance(report.get("gas"), dict):
+        gas_g = report["gas"]
+    if not stats_e and elec_g:
+        stats_e = elec_g
+    if not stats_g and gas_g:
+        stats_g = gas_g
 
-    model_kwh = annual.get("electricity_kwh_year")
-    model_therms = (
-        annual.get("natural_gas_therm_year")
-        or annual.get("gas_therms_year")
-        or annual.get("natural_gas_therms_year")
+    def _first(*vals: Any) -> Any:
+        for v in vals:
+            if v is not None and v != "":
+                return v
+        return None
+
+    model_kwh = _first(
+        annual.get("electricity_kwh_year"),
+        report.get("model_kwh"),
+        score.get("model_kwh"),
+    )
+    model_therms = _first(
+        annual.get("natural_gas_therm_year"),
+        annual.get("gas_therms_year"),
+        annual.get("natural_gas_therms_year"),
+        report.get("model_therms"),
+        score.get("model_therms"),
     )
     if model_therms is None:
         monthly = annual.get("monthly") or []
@@ -151,25 +186,50 @@ def extract_calibrated_baseline(
         ]
         if vals:
             model_therms = round(sum(vals), 1)
-    site_eui = annual.get("site_eui_kbtu_ft2_year") or g14_blob.get("site_eui_kbtu_ft2_year")
-    g14_pass = (
-        bills.get("pass_fail")
-        or report.get("pass_fail")
-        or report.get("overall")
-        or g14_blob.get("pass_fail")
+    site_eui = _first(
+        annual.get("site_eui_kbtu_ft2_year"),
+        g14_blob.get("site_eui_kbtu_ft2_year"),
+        report.get("model_site_eui"),
+        score.get("model_site_eui"),
     )
-    bill_kwh = None
-    bill_therms = None
-    for row in bills.get("per_month") or []:
-        if not isinstance(row, dict):
-            continue
-        if row.get("observed_kwh") is not None:
-            bill_kwh = (bill_kwh or 0.0) + float(row["observed_kwh"])
-        if row.get("observed_therms") is not None:
-            bill_therms = (bill_therms or 0.0) + float(row["observed_therms"])
 
-    peer_band = report.get("peer_band") or g14_blob.get("peer_band")
-    peer_vs = report.get("peer_vs_median_pct") or g14_blob.get("peer_vs_median_pct")
+    g14_raw = _first(
+        bills.get("pass_fail"),
+        report.get("pass_fail"),
+        report.get("overall"),
+        g14_blob.get("pass_fail"),
+        g14_blob.get("g14_pass"),
+        report.get("g14_pass"),
+        score.get("pass_fail"),
+    )
+    if g14_raw is True:
+        g14_pass: Any = "PASS"
+    elif g14_raw is False:
+        g14_pass = "FAIL"
+    else:
+        g14_pass = g14_raw
+
+    bill_kwh = _first(report.get("bill_kwh"), score.get("bill_kwh"))
+    bill_therms = _first(report.get("bill_therms"), score.get("bill_therms"))
+    if bill_kwh is None or bill_therms is None:
+        for row in bills.get("per_month") or []:
+            if not isinstance(row, dict):
+                continue
+            if bill_kwh is None and row.get("observed_kwh") is not None:
+                bill_kwh = (bill_kwh or 0.0) + float(row["observed_kwh"])
+            if bill_therms is None and row.get("observed_therms") is not None:
+                bill_therms = (bill_therms or 0.0) + float(row["observed_therms"])
+
+    peer_band = _first(
+        report.get("peer_band"),
+        g14_blob.get("peer_band"),
+        peer.get("band"),
+    )
+    peer_vs = _first(
+        report.get("peer_vs_median_pct"),
+        g14_blob.get("peer_vs_median_pct"),
+        peer.get("vs_median_pct"),
+    )
     if peer_band is None and site_eui is not None:
         try:
             from wattlab.benchmarks.eui import compare_eui

--- a/vibe_code_apps_20/wattlab/notebooks/builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/builder.py
@@ -511,7 +511,8 @@ def build_notebook_workbook(
     rows = [
         ("Building", inputs.get("building")),
         ("Package id", pkg.id),
-        ("Package", pkg.label),
+        ("Package", getattr(pkg, "story", None) or pkg.label),
+        ("Catalog label", pkg.label),
         ("Honesty", pkg.honesty),
         ("Generated (UTC)", datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")),
         ("Catalog package", pkg.catalog_package),
@@ -668,9 +669,66 @@ def build_notebook_workbook(
         if ep:
             ep_ws[f"E{i}"] = f"Twin savings_by_measure{(' · ' + twin_note) if twin_note else ''}"
         else:
-            ep_ws[f"E{i}"] = "E+ measure not attached — baseline is Calibrated_Twin"
+            ep_ws[f"E{i}"] = ""
+    if ep_missing:
+        ep_ws["A" + str(len(ids) + 3)] = "note"
+        ep_ws["B" + str(len(ids) + 3)] = (
+            "No measure-level EnergyPlus savings attached — see Calibrated_Twin for G14 baseline. "
+            "Blank cells ≠ zero savings."
+        )
     ep_ws.column_dimensions["A"].width = 28
     ep_ws.column_dimensions["E"].width = 40
+
+    # --- Screening_Results (numbers for Studio — formulas stay on other sheets) ---
+    if "Screening_Results" in wb.sheetnames:
+        del wb["Screening_Results"]
+    # Insert after Calibrated_Twin when possible
+    scr = wb.create_sheet("Screening_Results", 2)
+    scr.append(
+        [
+            "measure_id",
+            "basis",
+            "savings_kwh",
+            "savings_therms",
+            "annual_cost_saved_usd",
+            "implementation_cost_usd",
+            "simple_payback_years",
+            "npv_usd",
+            "notes",
+        ]
+    )
+    _style_header(scr)
+    for i, row in enumerate(econ_rows, start=2):
+        mid = row["measure_id"]
+        basis = (
+            "excel_formula"
+            if mid in FORMULA_ESCO_KWH or mid in FORMULA_ESCO_THERMS
+            else "python_proxy"
+        )
+        cost = float(row.get("implementation_cost_usd") or 0)
+        annual = float(row.get("annual_cost_saved_usd") or 0)
+        payback = (cost / annual) if annual else None
+        scr[f"A{i}"] = mid
+        scr[f"B{i}"] = basis
+        scr[f"C{i}"] = round(float(row.get("kwh_saved") or 0), 1)
+        scr[f"D{i}"] = round(float(row.get("therms_saved") or 0), 1)
+        scr[f"E{i}"] = round(annual, 2)
+        scr[f"F{i}"] = round(cost, 2)
+        scr[f"G{i}"] = round(payback, 2) if payback is not None else ""
+        scr[f"H{i}"] = round(float(row.get("npv_usd") or 0), 2)
+        scr[f"I{i}"] = (
+            "Build-time screening numbers for Studio. Live Excel formulas are on ESCO_Calcs / ROI_Capital."
+        )
+    if econ_rows:
+        tot = len(econ_rows) + 2
+        scr[f"A{tot}"] = "TOTAL"
+        scr[f"E{tot}"] = f"=SUM(E2:E{len(econ_rows)+1})"
+        scr[f"F{tot}"] = f"=SUM(F2:F{len(econ_rows)+1})"
+        scr[f"H{tot}"] = f"=SUM(H2:H{len(econ_rows)+1})"
+        scr[f"A{tot}"].font = Font(bold=True)
+    scr.column_dimensions["A"].width = 28
+    scr.column_dimensions["B"].width = 14
+    scr.column_dimensions["I"].width = 56
 
     # --- Compare (formulas vs ESCO / E+ sheets) ---
     if "Compare" in wb.sheetnames:
@@ -1158,11 +1216,15 @@ def build_and_save_notebook(
     twin_run: str | None = None,
     write_manifest: bool = True,
     use_template: bool = True,
+    file_stem: str | None = None,
 ) -> dict[str, Path]:
+    from wattlab.notebooks.packages import notebook_file_stem
+
     pkg = get_notebook_package(package_id)
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    xlsx = out_dir / f"{pkg.id}.xlsx"
+    stem = (file_stem or notebook_file_stem(pkg.id) or pkg.id).strip() or pkg.id
+    xlsx = out_dir / f"{stem}.xlsx"
     wb = build_notebook_workbook(
         pkg,
         profile=profile,
@@ -1183,7 +1245,9 @@ def build_and_save_notebook(
             template_loaded=bool(getattr(wb, "_wattlab_template_loaded", False)),
             formula_backed=list(getattr(wb, "_wattlab_formula_backed", []) or []),
         )
-        mp = out_dir / f"{pkg.id}.notebook_manifest.json"
+        man["file_stem"] = stem
+        man["story"] = getattr(pkg, "story", "") or pkg.label
+        mp = out_dir / f"{stem}.notebook_manifest.json"
         mp.write_text(json.dumps(man, indent=2) + "\n", encoding="utf-8")
         written["manifest"] = mp
     return written
@@ -1312,7 +1376,8 @@ def validate_notebook(path: Path | str) -> dict[str, Any]:
     ep_rows = 0
     if "EPlus_Results" in wb.sheetnames:
         for row in wb["EPlus_Results"].iter_rows(min_row=2, max_col=3, values_only=True):
-            if not row[0]:
+            mid = row[0]
+            if not mid or str(mid).strip().lower() in ("note", "notes", "measure_id"):
                 continue
             ep_rows += 1
             if row[1] is not None or row[2] is not None:
@@ -1383,6 +1448,7 @@ def summarize_notebook(
     cover_building = None
     cover_twin = None
     cover_template = None
+    cover_pkg_id = None
     if "Cover" in wb.sheetnames:
         for row in wb["Cover"].iter_rows(min_row=4, max_col=2, values_only=True):
             key = str(row[0] or "").strip().lower()
@@ -1392,12 +1458,14 @@ def summarize_notebook(
                 cover_twin = row[1]
             elif key == "template":
                 cover_template = row[1]
-    # Prefer package from Cover / stem; load catalog label when possible
-    pkg_id = package.id if package else path.stem
+            elif key == "package id":
+                cover_pkg_id = row[1]
+    # Prefer package from Cover / arg; stem may be a human-readable file name
+    pkg_id = package.id if package else (str(cover_pkg_id) if cover_pkg_id else path.stem)
     pkg_label = package.label if package else None
     if package is None:
         try:
-            package = get_notebook_package(path.stem)
+            package = get_notebook_package(str(cover_pkg_id or path.stem))
             pkg_id = package.id
             pkg_label = package.label
         except Exception:

--- a/vibe_code_apps_20/wattlab/notebooks/builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/builder.py
@@ -647,7 +647,13 @@ def build_notebook_workbook(
             esco[f"C{i}"] = float(p.get("savings_therms") or 0)
             calcs = p.get("calculators")
             esco[f"D{i}"] = ",".join(calcs) if isinstance(calcs, list) else ""
-            esco[f"F{i}"] = "proxy (not Excel yet) — Python screening at build"
+            if str(p.get("basis") or "") == "fuel_switch":
+                esco[f"F{i}"] = (
+                    "fuel_switch proxy — B is elec Δ (negative = added HP load), "
+                    "C is gas therms avoided; see Screening_Results"
+                )
+            else:
+                esco[f"F{i}"] = "proxy (not Excel yet) — Python screening at build"
         esco[f"E{i}"] = f"=B{i}*inp_elec_rate+C{i}*inp_gas_rate"
     esco.column_dimensions["A"].width = 28
     esco.column_dimensions["D"].width = 28
@@ -660,34 +666,39 @@ def build_notebook_workbook(
     ep_ws = wb.create_sheet("EPlus_Results")
     ep_ws.append(["measure_id", "kwh_saved", "therms_saved", "peak_kw_delta", "source"])
     _style_header(ep_ws)
-    for i, mid in enumerate(ids, start=2):
-        ep = ep_by.get(mid) or {}
-        ep_ws[f"A{i}"] = mid
-        ep_ws[f"B{i}"] = ep.get("kwh_saved")
-        ep_ws[f"C{i}"] = ep.get("therms_saved")
-        ep_ws[f"D{i}"] = ep.get("peak_demand_kw_delta")
-        if ep:
-            ep_ws[f"E{i}"] = f"Twin savings_by_measure{(' · ' + twin_note) if twin_note else ''}"
-        else:
-            ep_ws[f"E{i}"] = ""
     if ep_missing:
-        ep_ws["A" + str(len(ids) + 3)] = "note"
-        ep_ws["B" + str(len(ids) + 3)] = (
+        # One honesty note — do not spam blank measure rows as the story
+        ep_ws["A2"] = "note"
+        ep_ws["B2"] = (
             "No measure-level EnergyPlus savings attached — see Calibrated_Twin for G14 baseline. "
-            "Blank cells ≠ zero savings."
+            "Blank ≠ zero. Screening numbers are on Screening_Results (ESCO proxies)."
         )
+        if twin_note:
+            ep_ws["E2"] = f"twin={twin_note}"
+    else:
+        for i, mid in enumerate(ids, start=2):
+            ep = ep_by.get(mid) or {}
+            ep_ws[f"A{i}"] = mid
+            ep_ws[f"B{i}"] = ep.get("kwh_saved")
+            ep_ws[f"C{i}"] = ep.get("therms_saved")
+            ep_ws[f"D{i}"] = ep.get("peak_demand_kw_delta")
+            if ep:
+                ep_ws[f"E{i}"] = f"Twin savings_by_measure{(' · ' + twin_note) if twin_note else ''}"
+            else:
+                ep_ws[f"E{i}"] = ""
     ep_ws.column_dimensions["A"].width = 28
     ep_ws.column_dimensions["E"].width = 40
 
     # --- Screening_Results (numbers for Studio — formulas stay on other sheets) ---
     if "Screening_Results" in wb.sheetnames:
         del wb["Screening_Results"]
-    # Insert after Calibrated_Twin when possible
-    scr = wb.create_sheet("Screening_Results", 2)
+    # First data sheet after Cover (Excel opens here; Studio mirrors these numbers)
+    scr = wb.create_sheet("Screening_Results", 1)
     scr.append(
         [
             "measure_id",
             "basis",
+            "elec_delta_kwh",
             "savings_kwh",
             "savings_therms",
             "annual_cost_saved_usd",
@@ -700,35 +711,52 @@ def build_notebook_workbook(
     _style_header(scr)
     for i, row in enumerate(econ_rows, start=2):
         mid = row["measure_id"]
-        basis = (
-            "excel_formula"
-            if mid in FORMULA_ESCO_KWH or mid in FORMULA_ESCO_THERMS
-            else "python_proxy"
-        )
+        p = proxies.get(mid) or {}
+        if str(p.get("basis") or "") == "fuel_switch":
+            basis = "fuel_switch"
+        elif mid in FORMULA_ESCO_KWH or mid in FORMULA_ESCO_THERMS:
+            basis = "excel_formula"
+        else:
+            basis = "python_proxy"
+        elec_delta = float(p.get("elec_delta_kwh", row.get("kwh_saved") or 0) or 0)
+        therms = float(row.get("therms_saved") or 0)
         cost = float(row.get("implementation_cost_usd") or 0)
         annual = float(row.get("annual_cost_saved_usd") or 0)
         payback = (cost / annual) if annual else None
+        # Never label negative elec Δ as "savings" — fuel_switch uses elec_delta_kwh
+        savings_kwh = max(0.0, elec_delta) if basis == "fuel_switch" else elec_delta
+        if basis == "fuel_switch":
+            notes = (
+                "Fuel switch: elec_delta_kwh may be negative (HP load added); "
+                "therms = gas avoided; $/yr uses both. Not 'negative kWh savings'."
+            )
+        else:
+            notes = (
+                "Build-time screening numbers for Studio. "
+                "Live Excel formulas are on ESCO_Calcs / ROI_Capital."
+            )
         scr[f"A{i}"] = mid
         scr[f"B{i}"] = basis
-        scr[f"C{i}"] = round(float(row.get("kwh_saved") or 0), 1)
-        scr[f"D{i}"] = round(float(row.get("therms_saved") or 0), 1)
-        scr[f"E{i}"] = round(annual, 2)
-        scr[f"F{i}"] = round(cost, 2)
-        scr[f"G{i}"] = round(payback, 2) if payback is not None else ""
-        scr[f"H{i}"] = round(float(row.get("npv_usd") or 0), 2)
-        scr[f"I{i}"] = (
-            "Build-time screening numbers for Studio. Live Excel formulas are on ESCO_Calcs / ROI_Capital."
-        )
+        scr[f"C{i}"] = round(elec_delta, 1)
+        scr[f"D{i}"] = round(savings_kwh, 1)
+        scr[f"E{i}"] = round(therms, 1)
+        scr[f"F{i}"] = round(annual, 2)
+        scr[f"G{i}"] = round(cost, 2)
+        scr[f"H{i}"] = round(payback, 2) if payback is not None else ""
+        scr[f"I{i}"] = round(float(row.get("npv_usd") or 0), 2)
+        scr[f"J{i}"] = notes
     if econ_rows:
         tot = len(econ_rows) + 2
+        last = len(econ_rows) + 1
         scr[f"A{tot}"] = "TOTAL"
-        scr[f"E{tot}"] = f"=SUM(E2:E{len(econ_rows)+1})"
-        scr[f"F{tot}"] = f"=SUM(F2:F{len(econ_rows)+1})"
-        scr[f"H{tot}"] = f"=SUM(H2:H{len(econ_rows)+1})"
+        scr[f"F{tot}"] = f"=SUM(F2:F{last})"
+        scr[f"G{tot}"] = f"=SUM(G2:G{last})"
+        scr[f"I{tot}"] = f"=SUM(I2:I{last})"
         scr[f"A{tot}"].font = Font(bold=True)
     scr.column_dimensions["A"].width = 28
     scr.column_dimensions["B"].width = 14
-    scr.column_dimensions["I"].width = 56
+    scr.column_dimensions["C"].width = 16
+    scr.column_dimensions["J"].width = 64
 
     # --- Compare (formulas vs ESCO / E+ sheets) ---
     if "Compare" in wb.sheetnames:
@@ -748,26 +776,37 @@ def build_notebook_workbook(
         ]
     )
     _style_header(cmp_ws)
-    for i, row in enumerate(compare_rows, start=2):
-        cmp_ws[f"A{i}"] = row["measure_id"]
-        cmp_ws[f"B{i}"] = f"=ESCO_Calcs!B{i}"
-        cmp_ws[f"C{i}"] = f"=EPlus_Results!B{i}"
-        cmp_ws[f"D{i}"] = f'=IF(OR(C{i}="",C{i}=0),"",C{i}-B{i})'
-        cmp_ws[f"E{i}"] = f'=IF(OR(B{i}=0,C{i}=""),"",C{i}/B{i})'
-        cmp_ws[f"F{i}"] = f"=ESCO_Calcs!C{i}"
-        cmp_ws[f"G{i}"] = f"=EPlus_Results!C{i}"
-        cmp_ws[f"H{i}"] = row["verdict"]
-        has_ep = row["ep_kwh"] is not None or row["ep_therms"] is not None
-        v = str(row["verdict"] or "").upper()
-        if not has_ep:
-            light = "YELLOW"
-        elif v == "IN_LINE":
-            light = "GREEN"
-        elif "REASONABLE" in v or "INSUFFICIENT" in v:
-            light = "YELLOW"
-        else:
-            light = "RED"
-        cmp_ws[f"I{i}"] = light
+    if ep_missing:
+        # One honesty row — avoid YELLOW INSUFFICIENT_EVIDENCE spam per measure
+        cmp_ws["A2"] = "(package)"
+        cmp_ws["H2"] = "ESCO_ONLY_NO_EP"
+        cmp_ws["I2"] = "N/A"
+        cmp_ws["A3"] = "note"
+        cmp_ws["B3"] = (
+            "No measure-level EnergyPlus cascade — Calibrated_Twin is G14 baseline only. "
+            "Use Screening_Results for ESCO / proxy numbers (not Compare traffic lights)."
+        )
+    else:
+        for i, row in enumerate(compare_rows, start=2):
+            cmp_ws[f"A{i}"] = row["measure_id"]
+            cmp_ws[f"B{i}"] = f"=ESCO_Calcs!B{i}"
+            cmp_ws[f"C{i}"] = f"=EPlus_Results!B{i}"
+            cmp_ws[f"D{i}"] = f'=IF(OR(C{i}="",C{i}=0),"",C{i}-B{i})'
+            cmp_ws[f"E{i}"] = f'=IF(OR(B{i}=0,C{i}=""),"",C{i}/B{i})'
+            cmp_ws[f"F{i}"] = f"=ESCO_Calcs!C{i}"
+            cmp_ws[f"G{i}"] = f"=EPlus_Results!C{i}"
+            cmp_ws[f"H{i}"] = row["verdict"]
+            has_ep = row["ep_kwh"] is not None or row["ep_therms"] is not None
+            v = str(row["verdict"] or "").upper()
+            if not has_ep:
+                light = "YELLOW"
+            elif v == "IN_LINE":
+                light = "GREEN"
+            elif "REASONABLE" in v or "INSUFFICIENT" in v:
+                light = "YELLOW"
+            else:
+                light = "RED"
+            cmp_ws[f"I{i}"] = light
     cmp_ws.column_dimensions["A"].width = 28
 
     # --- ROI_Capital ---
@@ -898,6 +937,19 @@ def build_notebook_workbook(
 
     wb.properties.title = f"WattLab notebook · {pkg.id}"
     wb.properties.creator = "WattLab"
+    # Prefer Screening_Results immediately after Cover (numbers first when Excel opens)
+    if "Screening_Results" in wb.sheetnames and "Cover" in wb.sheetnames:
+        idx = wb.sheetnames.index("Screening_Results")
+        target = wb.sheetnames.index("Cover") + 1
+        if idx != target:
+            wb.move_sheet("Screening_Results", offset=target - idx)
+    if "Calibrated_Twin" in wb.sheetnames and "Screening_Results" in wb.sheetnames:
+        idx = wb.sheetnames.index("Calibrated_Twin")
+        target = wb.sheetnames.index("Screening_Results") + 1
+        if idx != target:
+            wb.move_sheet("Calibrated_Twin", offset=target - idx)
+    if "Screening_Results" in wb.sheetnames:
+        wb.active = wb["Screening_Results"]
     # Stash for summarize
     wb._wattlab_template_loaded = template_loaded  # type: ignore[attr-defined]
     wb._wattlab_formula_backed = list(formula_backed)  # type: ignore[attr-defined]
@@ -1321,18 +1373,35 @@ def sync_notebook_from_twin(
         note = "EPlus_Results sheet missing"
     else:
         ws = wb["EPlus_Results"]
+        # Existing measure rows (skip honesty "note")
+        measure_rows: list[tuple[int, str]] = []
         for r in range(2, (ws.max_row or 1) + 1):
             mid = ws.cell(r, 1).value
-            if not mid:
-                continue
-            ep = ep_by.get(str(mid)) or {}
-            if not ep:
-                continue
-            ws.cell(r, 2).value = ep.get("kwh_saved")
-            ws.cell(r, 3).value = ep.get("therms_saved")
-            ws.cell(r, 4).value = ep.get("peak_demand_kw_delta")
-            ws.cell(r, 5).value = f"Twin sync · {twin_label or 'report'}"
-            updated += 1
+            if mid and str(mid).strip().lower() not in ("note", "notes"):
+                measure_rows.append((r, str(mid)))
+        if not measure_rows:
+            # Honesty-only sheet → expand into measure rows from Twin paste
+            for c in range(1, 6):
+                ws.cell(2, c).value = None
+            for i, (mid, ep) in enumerate(sorted(ep_by.items()), start=2):
+                ws.cell(i, 1).value = mid
+                ws.cell(i, 2).value = ep.get("kwh_saved")
+                ws.cell(i, 3).value = ep.get("therms_saved")
+                ws.cell(i, 4).value = ep.get("peak_demand_kw_delta")
+                ws.cell(i, 5).value = f"Twin sync · {twin_label or 'report'}"
+                updated += 1
+        else:
+            for r, mid in measure_rows:
+                ep = ep_by.get(mid) or {}
+                if not ep:
+                    continue
+                ws.cell(r, 2).value = ep.get("kwh_saved")
+                ws.cell(r, 3).value = ep.get("therms_saved")
+                ws.cell(r, 4).value = ep.get("peak_demand_kw_delta")
+                ws.cell(r, 5).value = f"Twin sync · {twin_label or 'report'}"
+                updated += 1
+        if updated == 0:
+            note = "no matching measure rows for Twin savings"
     if twin_label and "Cover" in wb.sheetnames:
         cover = wb["Cover"]
         for r in range(4, (cover.max_row or 4) + 1):
@@ -1382,10 +1451,11 @@ def validate_notebook(path: Path | str) -> dict[str, Any]:
             ep_rows += 1
             if row[1] is not None or row[2] is not None:
                 ep_filled += 1
-    if ep_rows and ep_filled == 0:
+    # BUG-034: warn when E+ sheet has no measure savings (honesty-only or blank rows)
+    if "EPlus_Results" in wb.sheetnames and ep_filled == 0:
         warnings.append(
-            "EPlus_Results empty (no savings_by_measure) — Compare lights will be YELLOW; "
-            "pick a Twin ECM run with measure savings"
+            "EPlus_Results empty (no savings_by_measure) — Calibrated_Twin is baseline; "
+            "Compare = ESCO_ONLY_NO_EP; Screening_Results has ESCO numbers"
         )
     # Honesty: cost B should reference H when still formula-linked
     if "ROI_Capital" in wb.sheetnames:

--- a/vibe_code_apps_20/wattlab/notebooks/packages.py
+++ b/vibe_code_apps_20/wattlab/notebooks/packages.py
@@ -7,33 +7,44 @@ from dataclasses import dataclass
 from wattlab.ecm.packages import PACKAGES, resolve_package
 
 # Liberty-style screening ladder. Each id → one downloadable workbook.
+# ``file_stem`` = human-readable .xlsx name (narrative acts, not catalog jargon).
 NOTEBOOK_PACKAGES: dict[str, dict] = {
     "controls_first": {
         "label": "1 · Controls-first (no capital RCx)",
+        "file_stem": "01_controls_first_rcx",
+        "story": "Controls-first RCx / schedules / sensors",
         "rank": 1,
         "catalog_package": "no-capital-rcx",
         "honesty": "screening — schedules / sensors / standby+DCV",
     },
     "schedules_economizer": {
         "label": "2 · Schedules + airside resets",
+        "file_stem": "01_G36_airside_trim_respond",
+        "story": "G36 trim-and-respond — SAT/DSP, schedules, standby+DCV, chiller lockout",
         "rank": 2,
         "catalog_package": "controls-only",
         "honesty": "screening — controls package before plant capital",
     },
     "plant_optimization": {
         "label": "3 · Plant optimization",
+        "file_stem": "02_plant_chiller_boiler",
+        "story": "Plant — chiller lockout (out of the 40s), CHW/CW/HW reset, pumps / boilers",
         "rank": 3,
         "catalog_package": "plant-optimization",
         "honesty": "screening — CHW/HW/CW resets + pump VFD",
     },
     "esco_top15": {
         "label": "4 · ESCO Top-15 HVAC",
+        "file_stem": "04_esco_top15_hvac",
+        "story": "Full ESCO Top-15 HVAC screening ladder",
         "rank": 4,
         "catalog_package": "esco-top15",
         "honesty": "screening — full ESCO Top-15 map (see Docs sheet)",
     },
     "deep_retrofit": {
         "label": "5 · Deep retrofit (DOAS + HP)",
+        "file_stem": "03_ERV_IAQ_DOAS_heat_pump",
+        "story": "ERV / IAQ + DOAS heat-pump capital what-if",
         "rank": 5,
         "catalog_package": "deep-doas-heat-pump",
         "honesty": "what-if — radical capital; not investment-grade",
@@ -44,6 +55,7 @@ NOTEBOOK_PACKAGES: dict[str, dict] = {
 REQUIRED_SHEETS = (
     "Cover",
     "Calibrated_Twin",
+    "Screening_Results",
     "Inputs",
     "ESCO_Calcs",
     "EPlus_Results",
@@ -88,6 +100,8 @@ class NotebookPackage:
     catalog_package: str
     honesty: str
     measure_ids: tuple[str, ...]
+    file_stem: str = ""
+    story: str = ""
 
 
 def list_notebook_packages() -> list[NotebookPackage]:
@@ -105,9 +119,22 @@ def list_notebook_packages() -> list[NotebookPackage]:
                 catalog_package=str(meta["catalog_package"]),
                 honesty=str(meta["honesty"]),
                 measure_ids=tuple(ids),
+                file_stem=str(meta.get("file_stem") or pid),
+                story=str(meta.get("story") or meta.get("label") or pid),
             )
         )
     return out
+
+
+def notebook_file_stem(package_id: str) -> str:
+    """Human-readable workbook stem for ``reports/notebooks/{stem}.xlsx``."""
+    meta = NOTEBOOK_PACKAGES.get(package_id) or {}
+    return str(meta.get("file_stem") or package_id)
+
+
+def notebook_story(package_id: str) -> str:
+    meta = NOTEBOOK_PACKAGES.get(package_id) or {}
+    return str(meta.get("story") or meta.get("label") or package_id)
 
 
 def get_notebook_package(package_id: str) -> NotebookPackage:

--- a/vibe_code_apps_20/wattlab/notebooks/packages.py
+++ b/vibe_code_apps_20/wattlab/notebooks/packages.py
@@ -54,8 +54,8 @@ NOTEBOOK_PACKAGES: dict[str, dict] = {
 
 REQUIRED_SHEETS = (
     "Cover",
-    "Calibrated_Twin",
     "Screening_Results",
+    "Calibrated_Twin",
     "Inputs",
     "ESCO_Calcs",
     "EPlus_Results",

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -1,4 +1,7 @@
-"""ECMs — file viewer for agent-owned Excel notebooks (BUG-051–056)."""
+"""ECMs — file viewer: on-disk .xlsx → screening results → download.
+
+Formulas live in the workbook for Excel; Studio shows numbers only.
+"""
 
 from __future__ import annotations
 
@@ -12,18 +15,13 @@ import streamlit as st
 
 from wattlab.studio.workspace import reports_dir
 
-# Preferred tab order when sheets exist in the workbook
-_PREFERRED_SHEETS = (
+# Results-first tabs (skip formula-heavy sheets in the default UI)
+_RESULTS_SHEETS = (
+    "Screening_Results",
     "Calibrated_Twin",
-    "Cover",
     "Inputs",
-    "ESCO_Calcs",
-    "EPlus_Results",
-    "Compare",
-    "ROI_Capital",
+    "Guardrails",
 )
-
-_FORMULA_CAP = 200
 
 
 def _list_notebook_files(out_dir: Path) -> list[Path]:
@@ -44,74 +42,54 @@ def _sheet_names(path: Path) -> list[str]:
         return []
 
 
-def _ordered_sheets(present: list[str]) -> list[str]:
-    ordered: list[str] = []
-    for name in _PREFERRED_SHEETS:
-        if name in present:
-            ordered.append(name)
-    for name in present:
-        if name not in ordered:
-            ordered.append(name)
-    return ordered
-
-
-def _preview_sheet_frame(path: Path, sheet: str, *, mode: str) -> pd.DataFrame | None:
-    """Readonly Values or Formulas preview (never blank formula cells)."""
+def _preview_values(path: Path, sheet: str) -> pd.DataFrame | None:
+    """Readonly numeric/text preview — never show formula strings as the main view."""
     from wattlab.notebooks.builder import preview_sheet_rows
 
-    if mode == "values":
-        formula_rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=False)
-        value_rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=True)
-        if not formula_rows:
-            return None
-        header = formula_rows[0]
-        body: list[list[Any]] = []
-        for i, frow in enumerate(formula_rows[1:]):
-            vrow = value_rows[i + 1] if value_rows and i + 1 < len(value_rows) else []
-            merged: list[Any] = []
-            for j, cell in enumerate(frow):
-                if isinstance(cell, str) and cell.startswith("="):
-                    vc = vrow[j] if j < len(vrow) else None
-                    merged.append(vc if vc is not None else cell)
-                else:
-                    merged.append(cell)
-            body.append(merged)
-        return pd.DataFrame(body, columns=header)
-
-    rows = preview_sheet_rows(path, sheet, max_rows=50, data_only=False)
-    if not rows:
+    formula_rows = preview_sheet_rows(path, sheet, max_rows=60, data_only=False)
+    value_rows = preview_sheet_rows(path, sheet, max_rows=60, data_only=True)
+    if not formula_rows:
         return None
-    return pd.DataFrame(rows[1:], columns=rows[0])
+    header = [str(c) if c is not None else "" for c in formula_rows[0]]
+    body: list[list[Any]] = []
+    for i, frow in enumerate(formula_rows[1:]):
+        vrow = value_rows[i + 1] if value_rows and i + 1 < len(value_rows) else []
+        merged: list[Any] = []
+        for j, cell in enumerate(frow):
+            if isinstance(cell, str) and cell.startswith("="):
+                vc = vrow[j] if j < len(vrow) else None
+                # Prefer cached/static value; blank if Excel-only formula (openpyxl can't calc)
+                merged.append(vc if vc is not None else "—")
+            else:
+                merged.append(cell)
+        body.append(merged)
+    return pd.DataFrame(body, columns=header)
 
 
 def _cover_subtitle(path: Path) -> str:
-    """Building · twin · mtime from Cover / sidecar when available."""
     parts: list[str] = []
     try:
         from openpyxl import load_workbook
 
         wb = load_workbook(path, read_only=True, data_only=False)
         if "Cover" in wb.sheetnames:
-            cover = {str(r[0]).strip().lower(): r[1] for r in wb["Cover"].iter_rows(min_row=4, max_col=2, values_only=True) if r[0]}
-            building = cover.get("building")
+            cover = {
+                str(r[0]).strip().lower(): r[1]
+                for r in wb["Cover"].iter_rows(min_row=4, max_col=2, values_only=True)
+                if r[0]
+            }
+            if cover.get("building"):
+                parts.append(str(cover["building"]))
             twin = cover.get("twin run")
-            if building:
-                parts.append(str(building))
-            if twin and str(twin) not in ("(none — E+ optional)",):
+            if twin and str(twin) not in ("(none — E+ optional)", "(none)"):
                 parts.append(f"twin={twin}")
+            if cover.get("g14 pass") is not None:
+                parts.append(f"G14={cover['g14 pass']}")
+            if cover.get("model site eui") is not None:
+                parts.append(f"EUI={cover['model site eui']}")
         wb.close()
     except Exception:
         pass
-    man = path.parent / f"{path.stem}.notebook_manifest.json"
-    if man.is_file() and not parts:
-        try:
-            data = json.loads(man.read_text(encoding="utf-8"))
-            if data.get("building"):
-                parts.append(str(data["building"]))
-            if data.get("twin_run"):
-                parts.append(f"twin={data['twin_run']}")
-        except (OSError, json.JSONDecodeError, TypeError):
-            pass
     try:
         mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
         parts.append(f"mtime {mtime.strftime('%Y-%m-%d %H:%MZ')}")
@@ -120,69 +98,69 @@ def _cover_subtitle(path: Path) -> str:
     return " · ".join(parts) if parts else ""
 
 
-def _load_formula_cells(path: Path) -> dict[str, dict[str, str]]:
-    """Prefer manifest formula_cells; fall back to show_formulas."""
-    man = path.parent / f"{path.stem}.notebook_manifest.json"
-    if man.is_file():
-        try:
-            data = json.loads(man.read_text(encoding="utf-8"))
-            cells = data.get("formula_cells")
-            if isinstance(cells, dict) and cells:
-                return {str(k): dict(v) for k, v in cells.items() if isinstance(v, dict)}
-        except (OSError, json.JSONDecodeError, TypeError):
-            pass
-    from wattlab.notebooks.builder import show_formulas
+def _screening_frame(path: Path) -> pd.DataFrame | None:
+    """Prefer Screening_Results sheet; else build from ROI caches."""
+    present = _sheet_names(path)
+    if "Screening_Results" in present:
+        return _preview_values(path, "Screening_Results")
+    # Fallback: ROI measure id + numeric npv_usd_at_build + static kwh when present
+    from wattlab.notebooks.builder import preview_sheet_rows
 
+    rows = preview_sheet_rows(path, "ROI_Capital", max_rows=40, data_only=False)
+    if not rows or len(rows) < 2:
+        return None
+    header = [str(c) for c in rows[0]]
     try:
-        dumped = show_formulas(path)
-        sheets = dumped.get("sheets") or {}
-        return {str(k): dict(v) for k, v in sheets.items() if isinstance(v, dict)}
-    except Exception:
-        return {}
-
-
-def _render_formulas_used(path: Path) -> None:
-    st.subheader("Formulas used")
-    cells_by_sheet = _load_formula_cells(path)
-    if not cells_by_sheet:
-        st.caption("No formula map in manifest — download the workbook or run `wattlab notebook show-formulas`.")
-        return
-    total = 0
-    lines: list[str] = []
-    for sheet in _ordered_sheets(list(cells_by_sheet.keys())):
-        mapping = cells_by_sheet.get(sheet) or {}
-        if not mapping:
+        i_npv = header.index("npv_usd_at_build")
+    except ValueError:
+        i_npv = 8 if len(header) > 8 else -1
+    out_rows = []
+    for row in rows[1:]:
+        mid = row[0] if row else None
+        if not mid or str(mid).upper() == "TOTAL" or str(mid) == "Honesty":
             continue
-        lines.append(f"**{sheet}**")
-        for addr in sorted(mapping.keys(), key=lambda a: (len(a), a)):
-            if total >= _FORMULA_CAP:
-                break
-            formula = mapping[addr]
-            lines.append(f"`{addr}` = `{formula}`")
-            total += 1
-        if total >= _FORMULA_CAP:
-            break
-    st.markdown("\n\n".join(lines) if lines else "_No formulas found._")
-    if total >= _FORMULA_CAP:
-        st.caption(f"Showing first {_FORMULA_CAP} formula cells — see download for full workbook.")
-    else:
-        st.caption(f"{total} formula cells.")
+        kwh = row[2] if len(row) > 2 else None
+        therms = row[3] if len(row) > 3 else None
+        if isinstance(kwh, str) and kwh.startswith("="):
+            kwh = "—"
+        if isinstance(therms, str) and therms.startswith("="):
+            therms = "—"
+        npv = row[i_npv] if i_npv >= 0 and i_npv < len(row) else None
+        out_rows.append(
+            {
+                "measure_id": mid,
+                "kwh_saved": kwh,
+                "therms_saved": therms,
+                "npv_usd_at_build": npv,
+            }
+        )
+    return pd.DataFrame(out_rows) if out_rows else None
+
+
+def _calibrated_metrics(path: Path) -> dict[str, Any]:
+    df = _preview_values(path, "Calibrated_Twin")
+    if df is None or df.empty or df.shape[1] < 2:
+        return {}
+    out: dict[str, Any] = {}
+    for _, row in df.iterrows():
+        key = str(row.iloc[0] or "").strip()
+        if key:
+            out[key] = row.iloc[1]
+    return out
 
 
 def render() -> None:
     st.header("ECMs — engineering notebooks")
     st.caption(
-        "Agent owns the file under `reports/notebooks/`. "
-        "Pick a workbook → readonly preview → formulas → download. "
-        "Use **Reload from disk** (or hard-refresh the browser) after a CLI write."
+        "Pick an on-disk workbook → **screening results** (numbers) → download. "
+        "Excel formulas stay in the `.xlsx` for Excel — not shown here. "
+        "**Reload from disk** after an agent CLI write."
     )
     st.markdown(
         "[ESCO calculators](https://github.com/bbartling/py-bacnet-stacks-playground/blob/develop/"
         "vibe_code_apps_20/vibe20_agent_spec/docs/ESCO_CALCULATORS.md) · "
         "[Retrofit cost / ROI](https://github.com/bbartling/py-bacnet-stacks-playground/blob/develop/"
-        "vibe_code_apps_20/vibe20_agent_spec/docs/ESCO_RETROFIT_COST_ROI.md) · "
-        "[Spreadsheet map](https://github.com/bbartling/py-bacnet-stacks-playground/blob/develop/"
-        "vibe_code_apps_20/docs/ESCO_SPREADSHEET_CALCS.md)"
+        "vibe_code_apps_20/vibe20_agent_spec/docs/ESCO_RETROFIT_COST_ROI.md)"
     )
 
     out_dir = reports_dir() / "notebooks"
@@ -201,22 +179,34 @@ def render() -> None:
 
     if not files:
         st.info(
-            f"No `.xlsx` files under `{out_dir}` yet. "
-            "Agent: `wattlab notebook agent-build --package … --out reports/notebooks/`."
+            f"No `.xlsx` under `{out_dir}` yet. "
+            "Agent: `wattlab notebook agent-build` or `/data/tools/agent_build_ecm_packages.py`."
         )
         return
 
     names = [p.name for p in files]
     by_name = {p.name: p for p in files}
-    stored = st.session_state.get("ecm_notebook_file")
-    if stored not in names:
+
+    def _label(name: str) -> str:
+        man = out_dir / f"{Path(name).stem}.notebook_manifest.json"
+        story = ""
+        if man.is_file():
+            try:
+                data = json.loads(man.read_text(encoding="utf-8"))
+                story = str(data.get("story") or data.get("package_label") or "")
+            except (OSError, json.JSONDecodeError, TypeError):
+                story = ""
+        return f"{name} — {story}" if story else name
+
+    if st.session_state.get("ecm_notebook_file") not in names:
         st.session_state["ecm_notebook_file"] = names[0]
 
     pick_name = st.selectbox(
         "Notebook file",
         names,
+        format_func=_label,
         key="ecm_notebook_file",
-        help="On-disk workbooks only — catalog packages without a file do not appear.",
+        help="On-disk workbooks only — names follow the ECM narrative acts.",
     )
     path = by_name[pick_name]
     st.session_state["studio_notebook_path"] = str(path)
@@ -224,32 +214,51 @@ def render() -> None:
     if subtitle:
         st.caption(subtitle)
 
-    mode = st.radio(
-        "Preview",
-        options=["values", "formulas"],
-        format_func=lambda k: "Values" if k == "values" else "Formulas",
-        horizontal=True,
-        key="ecm_notebook_preview_mode",
-    )
+    # --- Baseline metrics ---
+    cal = _calibrated_metrics(path)
+    if cal:
+        c1, c2, c3, c4 = st.columns(4)
+        with c1:
+            st.metric("G14", str(cal.get("g14_pass") or "—"))
+        with c2:
+            st.metric("Model site EUI", str(cal.get("model_site_eui") or "—"))
+        with c3:
+            st.metric("Model kWh/yr", f"{cal.get('model_kwh'):,.0f}" if isinstance(cal.get("model_kwh"), (int, float)) else str(cal.get("model_kwh") or "—"))
+        with c4:
+            st.metric("Peer band", str(cal.get("peer_band") or "—"))
+        st.caption(
+            "Calibrated Twin baseline (fuel match). "
+            "Measure-level EnergyPlus savings are optional — blank E+ ≠ zero; see download."
+        )
 
-    present = _sheet_names(path)
-    sheets = _ordered_sheets(present)
-    if not sheets:
-        st.warning("Workbook has no sheets (or could not be opened).")
+    # --- Screening results (numbers) ---
+    st.subheader("Screening results")
+    screen = _screening_frame(path)
+    if screen is None or screen.empty:
+        st.warning("No screening numbers in this workbook yet — rebuild with tip agent-build.")
     else:
-        tabs = st.tabs(sheets)
-        for tab, sheet in zip(tabs, sheets):
-            with tab:
-                df = _preview_sheet_frame(path, sheet, mode=mode)
-                if df is None or df.empty:
-                    st.caption(f"Sheet `{sheet}` empty or unreadable.")
-                else:
-                    # Arrow-safe: stringify mixed formula/number columns
-                    safe = df.copy()
-                    safe.columns = [str(c) if c is not None else "" for c in safe.columns]
-                    st.dataframe(safe.astype(str), width="stretch", hide_index=True)
+        safe = screen.copy()
+        safe.columns = [str(c) if c is not None else "" for c in safe.columns]
+        st.dataframe(safe.astype(str), width="stretch", hide_index=True)
+        st.caption(
+            "Build-time screening (ESCO / Inputs). Open the downloaded `.xlsx` for live Excel formulas."
+        )
 
-    _render_formulas_used(path)
+    # Optional extra value sheets (no formula dump)
+    present = _sheet_names(path)
+    extra = [s for s in _RESULTS_SHEETS if s in present and s not in ("Screening_Results", "Calibrated_Twin")]
+    if extra:
+        with st.expander("More sheets (values)", expanded=False):
+            tabs = st.tabs(extra)
+            for tab, sheet in zip(tabs, extra):
+                with tab:
+                    df = _preview_values(path, sheet)
+                    if df is None or df.empty:
+                        st.caption(f"`{sheet}` empty.")
+                    else:
+                        safe = df.copy()
+                        safe.columns = [str(c) if c is not None else "" for c in safe.columns]
+                        st.dataframe(safe.astype(str), width="stretch", hide_index=True)
 
     st.download_button(
         "Download .xlsx",

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -219,13 +219,20 @@ def render() -> None:
     if cal:
         c1, c2, c3, c4 = st.columns(4)
         with c1:
-            st.metric("G14", str(cal.get("g14_pass") or "—"))
+            g14 = cal.get("g14_pass")
+            st.metric("G14", "—" if g14 is None else str(g14))
         with c2:
-            st.metric("Model site EUI", str(cal.get("model_site_eui") or "—"))
+            eui = cal.get("model_site_eui")
+            st.metric("Model site EUI", "—" if eui is None else str(eui))
         with c3:
-            st.metric("Model kWh/yr", f"{cal.get('model_kwh'):,.0f}" if isinstance(cal.get("model_kwh"), (int, float)) else str(cal.get("model_kwh") or "—"))
+            mk = cal.get("model_kwh")
+            st.metric(
+                "Model kWh/yr",
+                f"{mk:,.0f}" if isinstance(mk, (int, float)) else ("—" if mk is None else str(mk)),
+            )
         with c4:
-            st.metric("Peer band", str(cal.get("peer_band") or "—"))
+            peer = cal.get("peer_band")
+            st.metric("Peer band", "—" if peer is None else str(peer))
         st.caption(
             "Calibrated Twin baseline (fuel match). "
             "Measure-level EnergyPlus savings are optional — blank E+ ≠ zero; see download."

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -239,10 +239,22 @@ def render() -> None:
     else:
         safe = screen.copy()
         safe.columns = [str(c) if c is not None else "" for c in safe.columns]
-        st.dataframe(safe.astype(str), width="stretch", hide_index=True)
-        st.caption(
-            "Build-time screening (ESCO / Inputs). Open the downloaded `.xlsx` for live Excel formulas."
+        # Hard guard: never render Excel formula soup as the primary table
+        as_text = safe.astype(str)
+        has_formula = any(
+            isinstance(v, str) and str(v).startswith("=")
+            for col in as_text.columns
+            for v in as_text[col].tolist()
         )
+        if has_formula:
+            st.error(
+                "This workbook still has formula cells on Screening_Results — rebuild with tip agent-build."
+            )
+        else:
+            st.dataframe(as_text, width="stretch", hide_index=True)
+            st.caption(
+                "Build-time screening (ESCO / Inputs). Open the downloaded `.xlsx` for live Excel formulas."
+            )
 
     # Optional extra value sheets (no formula dump)
     present = _sheet_names(path)

--- a/vibe_code_apps_20/wattlab/studio/proxies.py
+++ b/vibe_code_apps_20/wattlab/studio/proxies.py
@@ -420,6 +420,7 @@ def estimate_proxy_savings(profile: dict[str, Any], measure_ids: list[str]) -> d
                 }
             elif mid == "ECM-DOAS-HP" or "DOAS-HP" in mid:
                 # Mega package: ERV ventilation recovery + heat-pump electrification.
+                # HP returns negative savings_kwh (elec added) — keep as elec_delta, not "savings".
                 erv = _erv_proxy(
                     get, oa_cfm=oa_cfm, exhaust_cfm=oa_cfm, kw_per_ton=kw_per_ton, bins=bins, schedule=existing
                 )
@@ -430,9 +431,13 @@ def estimate_proxy_savings(profile: dict[str, Any], measure_ids: list[str]) -> d
                         "proposed_cop": 2.8,
                     }
                 )
+                hp_kwh = float(hp["savings_kwh"])
                 out[mid] = {
-                    "savings_kwh": round(erv["savings_kwh"] + float(hp["savings_kwh"]), 1),
+                    "savings_kwh": round(float(erv["savings_kwh"]) + hp_kwh, 1),
+                    "elec_delta_kwh": round(float(erv["savings_kwh"]) + hp_kwh, 1),
                     "savings_therms": round(erv["savings_therms"] + float(hp["savings_therms"]), 1),
+                    "basis": "fuel_switch",
+                    "calculators": ["erv_bins", "heat_pump_electrification"],
                 }
             elif "AWHP" in mid:
                 hp = get("heat_pump_electrification")(
@@ -442,9 +447,13 @@ def estimate_proxy_savings(profile: dict[str, Any], measure_ids: list[str]) -> d
                         "proposed_cop": 2.8,
                     }
                 )
+                hp_kwh = float(hp["savings_kwh"])
                 out[mid] = {
-                    "savings_kwh": round(float(hp["savings_kwh"]), 1),
+                    "savings_kwh": round(hp_kwh, 1),
+                    "elec_delta_kwh": round(hp_kwh, 1),
                     "savings_therms": round(float(hp["savings_therms"]), 1),
+                    "basis": "fuel_switch",
+                    "calculators": ["heat_pump_electrification"],
                 }
             elif "BOILER-TUNE" in mid:
                 res = get("boiler_efficiency_improvement")(


### PR DESCRIPTION
## Summary
- **Results-only Studio ECMs:** dropdown of narrative workbooks → Calibrated Twin metrics → **Screening results** numbers → download. No “Formulas used” dump; no primary `ESCO_Calcs` / `Compare` / `ROI_Capital` formula grids (formulas stay in the `.xlsx` for Excel).
- **Narrative filenames:** `01_G36_airside_trim_respond`, `02_plant_chiller_boiler`, `03_ERV_IAQ_DOAS_heat_pump` (+ story labels from manifest).
- **`Screening_Results` first** (active sheet after Cover) with build-time numbers: `basis`, `elec_delta_kwh`, `savings_kwh`, therms, $/yr, NPV.
- **Fuel-switch honesty:** DOAS-HP / AWHP expose signed `elec_delta_kwh` + `basis=fuel_switch`; never label negative kWh as “savings”.
- **Soft Twin honesty:** when no measure cascade, `EPlus_Results` / `Compare` are one `ESCO_ONLY_NO_EP` note — not YELLOW `INSUFFICIENT_EVIDENCE` spam. Calibrated Twin (G14 r56 / EUI 77.8) remains baseline ≠ measure E+.
- **Flat scorecard fields:** `extract_calibrated_baseline` reads Liberty `model_*` / `model_peer` / g14.elec stats.

## Test plan
- [x] `pytest tests/test_notebook_builder.py tests/test_studio_app.py::test_studio_twin_and_ecms_dry_path`
- [x] Rebuild Liberty 3-pack against `geo_b100_6stack_shape_r56_sched_mild`; Screening_Results active; DOAS/AWHP `savings_kwh=0` with negative `elec_delta_kwh`
- [ ] CI green (vibe20 tests + vibe20-ghcr)
- [ ] CodeRabbit / Fable 5 / Sol: spreadsheet honesty (screening ≠ calibrated measure E+)
- [ ] After merge: tip GHCR on :8520 **without bind-mount**; hard-refresh ECMs → narrative dropdown + numeric Screening results only

## Out of scope
BUG-048 FanAvailSched / BUG-049 zero cascade — soft Twin baseline only.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, human-readable workbook names and package descriptions.
  * Introduced a dedicated **Screening Results** worksheet with measure savings, costs, payback, and baseline information.
  * Updated the Studio workbook viewer to prioritize screening results and key calibrated metrics.
  * Added support for heat-pump fuel-switching results and electrical impact details.

* **Improvements**
  * Improved workbook handling when EnergyPlus results are unavailable, including clearer ESCO-only disclosures.
  * Enhanced compatibility with multiple calibration report formats.
  * Refined workbook sheet ordering, previews, and downloadable manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->