### PR TITLE
feat(vibe20): Open-FDD ECM adapter + parity (no delete yet)

### DIFF
--- a/vibe_code_apps_20/AGENTS.md
+++ b/vibe_code_apps_20/AGENTS.md
@@ -4,6 +4,12 @@
 
 **Product:** OpenFDD WattLab — AI helper that turns **Open-FDD / Vibe App 19** findings into auditable **EnergyPlus** ECM energy screens (Dockerized via LBNL EnergyPlus-MCP).
 
+**ECM math SoT:** Generic spreadsheet/ESCO calculators live on PyPI `open-fdd` (`open_fdd.ecm_engineering`). Call them through `wattlab.engineering.openfdd_ecm` — do not invent a second affinity/bin/finance stack. EnergyPlus, IDF, Studio, catalog IDs, and EP-vs-engineering presentation stay in WattLab.
+
+```text
+Open-FDD evidence → Open-FDD ECM engineering → Vibe 20 EnergyPlus → engineering vs EP cross-check
+```
+
 **Quick link (vibe19 historian zips):** [`../vibe_code_apps_19/docs/PACKAGE_SPEC.md`](../vibe_code_apps_19/docs/PACKAGE_SPEC.md) — `openfdd_package_v1` layout before bridging / calibrating.
 
 ## Mission

--- a/vibe_code_apps_20/Dockerfile
+++ b/vibe_code_apps_20/Dockerfile
@@ -42,6 +42,8 @@ COPY --from=dockercli /usr/local/bin/docker /usr/local/bin/docker
 
 COPY . .
 # Editable install so ``import wattlab`` resolves to /app/wattlab (single tree).
+# open-fdd (PyPI) supplies shared ECM engineering calculators via
+# wattlab.engineering.openfdd_ecm — pin comes from pyproject.toml.
 RUN pip install --no-cache-dir -e ".[studio]"
 
 EXPOSE 8501

--- a/vibe_code_apps_20/pyproject.toml
+++ b/vibe_code_apps_20/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
   "numpy>=1.24",
   "pydantic>=2.7",
   "PyYAML>=6.0",
+  # Generic ECM / spreadsheet engineering math (fan affinity, bins, finance helpers).
+  # Local wattlab.bench duplicates remain until parity tests pass, then delete.
+  "open-fdd>=4.0.0,<5",
 ]
 
 [project.optional-dependencies]

--- a/vibe_code_apps_20/tests/test_openfdd_ecm_parity.py
+++ b/vibe_code_apps_20/tests/test_openfdd_ecm_parity.py
@@ -1,0 +1,186 @@
+"""Parity: WattLab local ECM math vs Open-FDD ``open_fdd.ecm_engineering``.
+
+Do not delete ``wattlab.bench`` duplicates until these pass. Core numeric
+outputs must match; detail-row key names may differ (``temp`` vs ``temp_f``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wattlab.bench import runner  # noqa: F401  — registers algorithms + esco
+from wattlab.bench.registry import get as wattlab_get
+from wattlab.engineering import openfdd_ecm as adapter
+from wattlab.weather.bins import OperatingSchedule, washington_dc_noaa
+
+
+def _sched(shifts=(8.0, 8.0, 4.0), days=5.0, override=0.0) -> dict:
+    return {"shifts": list(shifts), "days_per_week": days, "override_allowance": override}
+
+
+# ---------------------------------------------------------------------------
+# Registry algorithms (dict-in)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "name,inputs,keys",
+    [
+        (
+            "fan_affinity",
+            {
+                "design_kw": 10.0,
+                "baseline_speed_fraction": 1.0,
+                "proposed_speed_fraction": 0.8,
+                "hours": 1000.0,
+                "power_exponent": 3.0,
+            },
+            ("baseline_kwh", "proposed_kwh", "savings_kwh"),
+        ),
+        (
+            "schedule_reduction",
+            {
+                "equipment_kw": 10.0,
+                "baseline_annual_hours": 2000.0,
+                "proposed_annual_hours": 1500.0,
+                "average_load_fraction": 1.0,
+            },
+            ("baseline_kwh", "proposed_kwh", "savings_kwh", "reduced_hours"),
+        ),
+        (
+            "boiler_efficiency_improvement",
+            {
+                "annual_heating_mmbtu": 1000.0,
+                "baseline_efficiency": 0.80,
+                "proposed_efficiency": 0.90,
+            },
+            ("baseline_therms", "proposed_therms", "savings_therms"),
+        ),
+        (
+            "kw_per_ton_improvement",
+            {
+                "annual_ton_hours": 50000.0,
+                "baseline_kw_per_ton": 0.85,
+                "proposed_kw_per_ton": 0.70,
+            },
+            ("baseline_kwh", "proposed_kwh", "savings_kwh"),
+        ),
+        (
+            "outside_air_sensible",
+            {
+                "outside_air_cfm": 2000.0,
+                "average_delta_t_f": 15.0,
+                "hours": 2000.0,
+                "system_efficiency": 0.8,
+                "fuel": "natural_gas",
+            },
+            ("load_btu", "input_btu", "savings_therms"),
+        ),
+    ],
+)
+def test_algorithm_parity(name, inputs, keys):
+    local = wattlab_get(name)(dict(inputs))
+    remote = adapter.calculate(name, dict(inputs))
+    for key in keys:
+        assert local[key] == pytest.approx(remote[key], rel=1e-9, abs=1e-6), key
+
+
+def test_finance_simple_payback_parity():
+    assert adapter.ofdd_simple_payback(10000.0, 2500.0) == pytest.approx(4.0)
+    assert adapter.ofdd_simple_payback(10000.0, 0.0) is None
+
+
+def test_finance_npv_parity_vs_wattlab_escalated():
+    """Open-FDD npv(cost, annual, years, rate, escalation) ↔ WattLab cash-flow NPV."""
+    from wattlab.finance import escalated_cash_flows, npv as wattlab_npv
+
+    cost, annual, years, rate, esc = 20000.0, 4000.0, 15, 0.05, 0.0
+    ofdd = adapter.ofdd_npv(cost, annual, years=years, discount_rate=rate, escalation=esc)
+    flows = escalated_cash_flows(annual, years, escalation_rate=esc)
+    local = wattlab_npv(flows, rate, cost)
+    assert ofdd == pytest.approx(local, rel=1e-9, abs=1e-6)
+
+
+def test_psychrometrics_parity():
+    from wattlab.weather.bins import sat_enthalpy_btu_lb
+
+    for twb in (73.5, 63.1, 53.4, 25.9, 8.4):
+        assert sat_enthalpy_btu_lb(twb) == pytest.approx(
+            adapter.ofdd_sat_enthalpy_btu_lb(twb), rel=1e-9, abs=1e-9
+        )
+
+
+def test_engineering_crosscheck_helper():
+    out = adapter.engineering_crosscheck(100.0, 110.0)
+    assert out["agreement_ratio"] == pytest.approx(1.1)
+    assert out["verdict"] == "REASONABLE_SCREENING_ALIGNMENT"
+
+
+# ---------------------------------------------------------------------------
+# Bin methods (scheduling fan / cooling / heating)
+# ---------------------------------------------------------------------------
+
+def _bin_inputs() -> dict:
+    bins = washington_dc_noaa()
+    # Use explicit enthalpies so OA cooling matches between local MCWB curve and Open-FDD
+    records = []
+    for r in bins.rows:
+        records.append({
+            "temp": r.temp,
+            "shift_hours": list(r.shift_hours),
+            "mcwb": r.mcwb,
+            "enthalpy": r.oa_enthalpy,
+        })
+    return {
+        "fan_kw_total": 25.0,
+        "oa_cfm_total": 8000.0,
+        "kw_per_ton": 0.8,
+        "boiler_efficiency": 0.8,
+        "balance_point_f": 55.0,
+        "supply_enthalpy": 23.2,
+        "existing_schedule": _sched((8, 8, 4), 5.0),
+        "proposed_schedule": _sched((0, 8, 2), 5.0, override=0.1),
+        "bins": records,
+    }
+
+
+def test_scheduling_fan_bins_parity():
+    i = _bin_inputs()
+    local = wattlab_get("scheduling_fan_bins")(i)
+    remote = adapter.scheduling_fan_bins(i)
+    for key in ("baseline_kwh", "proposed_kwh", "savings_kwh", "hours_reduction_fraction"):
+        assert local[key] == pytest.approx(remote[key], rel=1e-9, abs=1e-6), key
+
+
+def test_scheduling_cooling_bins_parity():
+    i = _bin_inputs()
+    local = wattlab_get("scheduling_cooling_bins")(i)
+    remote = adapter.scheduling_cooling_bins(i)
+    for key in ("baseline_kwh", "proposed_kwh", "savings_kwh"):
+        assert local[key] == pytest.approx(remote[key], rel=1e-9, abs=1e-4), key
+
+
+def test_scheduling_heating_bins_parity():
+    i = _bin_inputs()
+    local = wattlab_get("scheduling_heating_bins")(i)
+    remote = adapter.scheduling_heating_bins(i)
+    for key in ("baseline_mmbtu", "proposed_mmbtu", "savings_mmbtu", "savings_therms"):
+        assert local[key] == pytest.approx(remote[key], rel=1e-9, abs=1e-6), key
+
+
+def test_hours_reduction_fraction_parity():
+    existing = OperatingSchedule.from_dict(_sched((8, 8, 4), 5))
+    proposed = OperatingSchedule.from_dict(_sched((0, 8, 2), 5, 0.1))
+    from wattlab.weather.bins import hours_reduction_fraction as local_hr
+
+    assert local_hr(existing, proposed) == pytest.approx(
+        adapter.ofdd_hours_reduction_fraction(
+            adapter.to_ofdd_schedule(_sched((8, 8, 4), 5)),
+            adapter.to_ofdd_schedule(_sched((0, 8, 2), 5, 0.1)),
+        )
+    )
+
+
+def test_list_calculators_nonempty():
+    names = adapter.list_calculators()
+    assert "fan_affinity" in names
+    assert "boiler_efficiency_improvement" in names

--- a/vibe_code_apps_20/wattlab/engineering/__init__.py
+++ b/vibe_code_apps_20/wattlab/engineering/__init__.py
@@ -1,0 +1,16 @@
+"""Engineering adapters — thin bridges to Open-FDD / other shared libs.
+
+Generic ECM spreadsheet math lives on PyPI ``open-fdd``
+(``open_fdd.ecm_engineering``). WattLab keeps EnergyPlus / Studio / catalog
+IDs here and calls Open-FDD through :mod:`wattlab.engineering.openfdd_ecm`.
+"""
+
+from __future__ import annotations
+
+from .openfdd_ecm import calculate, list_calculators, openfdd_available
+
+__all__ = [
+    "calculate",
+    "list_calculators",
+    "openfdd_available",
+]

--- a/vibe_code_apps_20/wattlab/engineering/openfdd_ecm.py
+++ b/vibe_code_apps_20/wattlab/engineering/openfdd_ecm.py
@@ -1,0 +1,173 @@
+"""Thin adapter: WattLab → ``open_fdd.ecm_engineering`` (PyPI ``open-fdd``).
+
+Architecture target:
+
+```text
+Open-FDD evidence
+      |
+      +--> Open-FDD ECM engineering calculator/workbook
+      |
+      +--> Vibe 20 EnergyPlus model
+                 |
+                 +--> engineering vs EnergyPlus cross-check
+```
+
+This module is the temporary bridge while ``wattlab.bench.algorithms`` /
+``wattlab.bench.esco`` / generic weather-bin helpers are migrated and deleted
+only after parity tests pass. Do **not** move EnergyPlus-specific code into
+Open-FDD. Keep WattLab ECM IDs / ``catalog.yaml`` stable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+# ---------------------------------------------------------------------------
+# Import surface (fail loudly if package missing — Dockerfile must install it)
+# ---------------------------------------------------------------------------
+
+from open_fdd.ecm_engineering import (  # noqa: F401
+    ECMJob,
+    OpenFDDECMWorkbook,
+    calculate as _ofdd_calculate,
+    create_workbook,
+    crosscheck as engineering_crosscheck,
+    list_calculators as _ofdd_list_calculators,
+    npv as ofdd_npv,
+    simple_payback as ofdd_simple_payback,
+)
+from open_fdd.ecm_engineering import bin_methods as ofdd_bin_methods
+from open_fdd.ecm_engineering import weather as ofdd_weather
+from open_fdd.ecm_engineering.weather import (
+    OperatingSchedule as OfddOperatingSchedule,
+    WeatherBins as OfddWeatherBins,
+    hours_reduction_fraction as ofdd_hours_reduction_fraction,
+    saturated_enthalpy_btu_lb as ofdd_sat_enthalpy_btu_lb,
+)
+
+__all__ = [
+    "ECMJob",
+    "OpenFDDECMWorkbook",
+    "OfddOperatingSchedule",
+    "OfddWeatherBins",
+    "calculate",
+    "create_workbook",
+    "engineering_crosscheck",
+    "list_calculators",
+    "ofdd_hours_reduction_fraction",
+    "ofdd_npv",
+    "ofdd_sat_enthalpy_btu_lb",
+    "ofdd_simple_payback",
+    "openfdd_available",
+    "scheduling_cooling_bins",
+    "scheduling_fan_bins",
+    "scheduling_heating_bins",
+    "to_ofdd_bins",
+    "to_ofdd_schedule",
+]
+
+
+def openfdd_available() -> bool:
+    """True when the Open-FDD ECM package is importable (always after image build)."""
+    return True
+
+
+def list_calculators() -> list[str]:
+    return _ofdd_list_calculators()
+
+
+def calculate(name: str, inputs: dict[str, Any]) -> dict[str, Any]:
+    """Run a registered Open-FDD calculator by name (dict-in / dict-out)."""
+    return _ofdd_calculate(name, inputs)
+
+
+# ---------------------------------------------------------------------------
+# WattLab weather ↔ Open-FDD weather
+# ---------------------------------------------------------------------------
+
+def to_ofdd_schedule(data: Mapping[str, Any] | OfddOperatingSchedule) -> OfddOperatingSchedule:
+    if isinstance(data, OfddOperatingSchedule):
+        return data
+    return OfddOperatingSchedule.from_dict(dict(data))
+
+
+def to_ofdd_bins(
+    bins: Any,
+    *,
+    source: str = "",
+) -> OfddWeatherBins:
+    """Convert WattLab ``WeatherBins`` / record list / Open-FDD bins → Open-FDD.
+
+    WattLab rows use ``temp`` / ``mcwb`` / ``enthalpy``.
+    Open-FDD rows use ``temp_f`` / ``wetbulb_f`` / ``enthalpy_btu_lb``.
+    """
+    if isinstance(bins, OfddWeatherBins):
+        return bins
+
+    rows: Sequence[Mapping[str, Any]]
+    if hasattr(bins, "to_records"):
+        rows = bins.to_records()
+        source = source or str(getattr(bins, "source", "") or "")
+    elif isinstance(bins, Mapping) and "rows" in bins:
+        rows = list(bins["rows"])  # type: ignore[arg-type]
+        source = source or str(bins.get("source", "") or "")
+    elif isinstance(bins, Sequence):
+        rows = bins  # type: ignore[assignment]
+    else:
+        raise TypeError(f"unsupported bins type: {type(bins)!r}")
+
+    ofdd_rows: list[dict[str, Any]] = []
+    for r in rows:
+        temp = r.get("temp_f", r.get("temp"))
+        if temp is None:
+            raise ValueError("bin row missing temp / temp_f")
+        row: dict[str, Any] = {"temp_f": float(temp)}
+        if "shift_hours" in r:
+            row["shift_hours"] = list(r["shift_hours"])
+        elif "hours" in r:
+            row["hours"] = float(r["hours"])
+        else:
+            raise ValueError("bin row needs shift_hours or hours")
+        wb = r.get("wetbulb_f", r.get("mcwb"))
+        if wb is not None:
+            row["wetbulb_f"] = float(wb)
+        enh = r.get("enthalpy_btu_lb", r.get("enthalpy"))
+        if enh is not None:
+            row["enthalpy_btu_lb"] = float(enh)
+        ofdd_rows.append(row)
+    return OfddWeatherBins.from_rows(ofdd_rows, source=source)
+
+
+def scheduling_fan_bins(inputs: Mapping[str, Any]) -> dict[str, Any]:
+    """Open-FDD ``scheduling_fan_bins`` with WattLab-shaped schedule/bins inputs."""
+    fan_kw = float(inputs["fan_kw_total"]) if "fan_kw_total" in inputs else sum(
+        float(u.get("fan_kw", 0.0)) for u in inputs.get("units", [])
+    )
+    return ofdd_bin_methods.scheduling_fan_bins(
+        fan_kw_total=fan_kw,
+        existing_schedule=to_ofdd_schedule(inputs["existing_schedule"]),
+        proposed_schedule=to_ofdd_schedule(inputs["proposed_schedule"]),
+        bins=to_ofdd_bins(inputs["bins"]),
+    )
+
+
+def scheduling_cooling_bins(inputs: Mapping[str, Any]) -> dict[str, Any]:
+    return ofdd_bin_methods.scheduling_cooling_bins(
+        oa_cfm_total=float(inputs["oa_cfm_total"]),
+        kw_per_ton=float(inputs["kw_per_ton"]),
+        existing_schedule=to_ofdd_schedule(inputs["existing_schedule"]),
+        proposed_schedule=to_ofdd_schedule(inputs["proposed_schedule"]),
+        bins=to_ofdd_bins(inputs["bins"]),
+        supply_enthalpy_btu_lb=float(inputs.get("supply_enthalpy", inputs.get("supply_enthalpy_btu_lb", 23.2))),
+    )
+
+
+def scheduling_heating_bins(inputs: Mapping[str, Any]) -> dict[str, Any]:
+    return ofdd_bin_methods.scheduling_heating_bins(
+        oa_cfm_total=float(inputs["oa_cfm_total"]),
+        boiler_efficiency=float(inputs.get("boiler_efficiency", 0.8)),
+        existing_schedule=to_ofdd_schedule(inputs["existing_schedule"]),
+        proposed_schedule=to_ofdd_schedule(inputs["proposed_schedule"]),
+        bins=to_ofdd_bins(inputs["bins"]),
+        balance_point_f=float(inputs.get("balance_point_f", 55.0)),
+    )


### PR DESCRIPTION
## Summary
- Depend on PyPI `open-fdd` for shared ECM engineering math
- Add `wattlab/engineering/openfdd_ecm.py` adapter (algorithms, scheduling bins, finance helpers, weather convert)
- Add parity tests vs local `wattlab.bench` / weather / finance — **old code kept** until later delete pass
- Document architecture in `AGENTS.md`; Dockerfile picks up dep via editable install

## Test plan
- [x] `pytest tests/test_openfdd_ecm_parity.py tests/test_esco_golden.py tests/test_bench_algorithms.py -q` (31 passed)
- [ ] Follow-up: migrate Studio/proxies callers to adapter; delete `wattlab.bench.algorithms` / reusable esco only after parity
- [ ] GHCR rebuild + Streamlit smoke (with vibe19) after consumer PRs land


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared engineering calculators for energy conservation measures, including finance, psychrometrics, scheduling, and weather-bin analyses.
  * Added support for listing available calculators and checking calculator availability.
  * Added conversion support for schedules and weather-bin data.

* **Bug Fixes**
  * Improved consistency between WattLab engineering calculations and shared calculator results.

* **Tests**
  * Added parity tests covering calculator outputs, finance metrics, psychrometrics, scheduling, and engineering cross-checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->