### PR TITLE
feat(vibe20): F2 delegate 8 Open-FDD ECM twins (keep 18 local)

### DIFF
--- a/vibe_code_apps_20/docs/OPENFDD_ECM_TWINS.md
+++ b/vibe_code_apps_20/docs/OPENFDD_ECM_TWINS.md
@@ -1,0 +1,30 @@
+# Open-FDD ECM twins vs local-only WattLab calculators
+
+Registry names stay stable (`wattlab.bench.registry`). As of Open-FDD **4.1.x**,
+only these **8** calculators have name-matched Open-FDD implementations and are
+**delegated** through `wattlab.engineering.openfdd_ecm`:
+
+| WattLab `@register` name | Open-FDD surface |
+|---|---|
+| `fan_affinity` | `open_fdd.ecm_engineering.calculate` |
+| `schedule_reduction` | same |
+| `outside_air_sensible` | same (WattLab default fuel=`electric`) |
+| `kw_per_ton_improvement` | same |
+| `boiler_efficiency_improvement` | same |
+| `scheduling_fan_bins` | `bin_methods` via adapter |
+| `scheduling_cooling_bins` | same |
+| `scheduling_heating_bins` | same |
+
+## Intentional local-only keepers (no Open-FDD equivalent in 4.1.x)
+
+Do **not** delete or silently map these to similarly named proxies:
+
+`demand_control_ventilation`, `economizer_proxy`, `pump_vfd`, `temperature_reset_bins`,
+`eui`, `simple_payback`, `heat_pump_electrification`, `oad_unoccupied_closed`,
+`dcv_bins`, `static_pressure_reset`, `dat_reset_bins`, `hydronic_reset_bins`,
+`chw_reset`, `condenser_water_reset`, `pneumatic_compressor`, `dewpoint_economizer`,
+`erv_bins`, `toilet_exhaust_erv_bins`
+
+(`economizer_proxy` ≠ `economizer_runtime_cap`; `chw_reset` ≠ `chws_reset_proxy`; etc.)
+
+Parity evidence: `tests/test_openfdd_ecm_parity.py` + golden `tests/test_esco_golden.py`.

--- a/vibe_code_apps_20/wattlab/bench/algorithms.py
+++ b/vibe_code_apps_20/wattlab/bench/algorithms.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 from math import isfinite
 from typing import Any
+
+from wattlab.engineering import openfdd_ecm as _ofdd
+
 from .registry import register
 
 def _req(d: dict[str, Any], key: str) -> float:
@@ -16,55 +19,24 @@ def _result(**kwargs: Any) -> dict[str, Any]:
 
 @register("fan_affinity")
 def fan_affinity(i: dict[str, Any]) -> dict[str, Any]:
-    design_kw = _req(i, "design_kw")
-    baseline_speed = _req(i, "baseline_speed_fraction")
-    proposed_speed = _req(i, "proposed_speed_fraction")
-    hours = _req(i, "hours")
-    exponent = float(i.get("power_exponent", 3.0))
-    baseline_kwh = design_kw * baseline_speed**exponent * hours
-    proposed_kwh = design_kw * proposed_speed**exponent * hours
-    return _result(
-        baseline_kwh=baseline_kwh,
-        proposed_kwh=proposed_kwh,
-        savings_kwh=baseline_kwh-proposed_kwh,
-        savings_fraction=(baseline_kwh-proposed_kwh)/baseline_kwh if baseline_kwh else 0.0,
-        assumptions={"power_exponent": exponent},
-    )
+    """Delegate to Open-FDD; preserve WattLab savings_fraction key."""
+    out = dict(_ofdd.calculate("fan_affinity", dict(i)))
+    baseline = float(out.get("baseline_kwh") or 0.0)
+    savings = float(out.get("savings_kwh") or 0.0)
+    out.setdefault("savings_fraction", (savings / baseline) if baseline else 0.0)
+    out.setdefault("assumptions", {"power_exponent": float(i.get("power_exponent", 3.0))})
+    return out
 
 @register("schedule_reduction")
 def schedule_reduction(i: dict[str, Any]) -> dict[str, Any]:
-    kw = _req(i, "equipment_kw")
-    baseline_hours = _req(i, "baseline_annual_hours")
-    proposed_hours = _req(i, "proposed_annual_hours")
-    load_fraction = float(i.get("average_load_fraction", 1.0))
-    baseline_kwh = kw * baseline_hours * load_fraction
-    proposed_kwh = kw * proposed_hours * load_fraction
-    return _result(
-        baseline_kwh=baseline_kwh,
-        proposed_kwh=proposed_kwh,
-        savings_kwh=baseline_kwh-proposed_kwh,
-        reduced_hours=baseline_hours-proposed_hours,
-    )
+    return dict(_ofdd.calculate("schedule_reduction", dict(i)))
 
 @register("outside_air_sensible")
 def outside_air_sensible(i: dict[str, Any]) -> dict[str, Any]:
-    cfm = _req(i, "outside_air_cfm")
-    delta_t_f = _req(i, "average_delta_t_f")
-    hours = _req(i, "hours")
-    efficiency = float(i.get("system_efficiency", 1.0))
-    fuel = str(i.get("fuel", "electric")).lower()
-    load_btu = 1.08 * cfm * delta_t_f * hours
-    if efficiency <= 0:
-        raise ValueError("system_efficiency must be > 0")
-    input_btu = load_btu / efficiency
-    out = {"load_btu": load_btu, "input_btu": input_btu}
-    if fuel == "electric":
-        out["savings_kwh"] = input_btu / 3412.142
-    elif fuel == "natural_gas":
-        out["savings_therms"] = input_btu / 100000.0
-    else:
-        raise ValueError("fuel must be electric or natural_gas")
-    return out
+    # WattLab default fuel is electric; Open-FDD defaults to natural_gas.
+    payload = dict(i)
+    payload.setdefault("fuel", "electric")
+    return dict(_ofdd.calculate("outside_air_sensible", payload))
 
 @register("demand_control_ventilation")
 def demand_control_ventilation(i: dict[str, Any]) -> dict[str, Any]:
@@ -94,14 +66,7 @@ def economizer_proxy(i: dict[str, Any]) -> dict[str, Any]:
 
 @register("kw_per_ton_improvement")
 def kw_per_ton_improvement(i: dict[str, Any]) -> dict[str, Any]:
-    ton_hours = _req(i, "annual_ton_hours")
-    baseline = _req(i, "baseline_kw_per_ton")
-    proposed = _req(i, "proposed_kw_per_ton")
-    return _result(
-        baseline_kwh=ton_hours*baseline,
-        proposed_kwh=ton_hours*proposed,
-        savings_kwh=ton_hours*(baseline-proposed),
-    )
+    return dict(_ofdd.calculate("kw_per_ton_improvement", dict(i)))
 
 @register("pump_vfd")
 def pump_vfd(i: dict[str, Any]) -> dict[str, Any]:
@@ -157,27 +122,19 @@ def simple_payback(i: dict[str, Any]) -> dict[str, Any]:
 
 @register("boiler_efficiency_improvement")
 def boiler_efficiency_improvement(i: dict[str, Any]) -> dict[str, Any]:
-    """Screening gas savings from raising boiler thermal efficiency.
-
-    ``annual_heating_mmbtu`` is delivered (output) load. Input fuel falls as
-    efficiency rises: therms = MMBtu × 10 / η.
-    """
-    load_mmbtu = _req(i, "annual_heating_mmbtu")
+    """Screening gas savings from raising boiler thermal efficiency (Open-FDD)."""
     baseline = _req(i, "baseline_efficiency")
     proposed = _req(i, "proposed_efficiency")
     if baseline <= 0 or proposed <= 0:
         raise ValueError("efficiencies must be > 0")
     if proposed < baseline:
         raise ValueError("proposed_efficiency must be >= baseline_efficiency")
-    baseline_therms = load_mmbtu * 10.0 / baseline
-    proposed_therms = load_mmbtu * 10.0 / proposed
-    return _result(
-        baseline_therms=baseline_therms,
-        proposed_therms=proposed_therms,
-        savings_therms=baseline_therms - proposed_therms,
-        savings_fraction=(baseline_therms - proposed_therms) / baseline_therms if baseline_therms else 0.0,
-        assumptions={"load_is_delivered_mmbtu": True},
-    )
+    out = dict(_ofdd.calculate("boiler_efficiency_improvement", dict(i)))
+    bt = float(out.get("baseline_therms") or 0.0)
+    st = float(out.get("savings_therms") or 0.0)
+    out.setdefault("savings_fraction", (st / bt) if bt else 0.0)
+    out.setdefault("assumptions", {"load_is_delivered_mmbtu": True})
+    return out
 
 
 @register("heat_pump_electrification")

--- a/vibe_code_apps_20/wattlab/bench/esco.py
+++ b/vibe_code_apps_20/wattlab/bench/esco.py
@@ -36,6 +36,8 @@ from wattlab.weather.bins import (
     parse_bins_input,
 )
 
+from wattlab.engineering import openfdd_ecm as _ofdd
+
 from .registry import register
 
 MMBTU_PER_THERM = 0.1
@@ -73,124 +75,20 @@ def _vent_heating_kbtu_per_hr(oa_cfm: float, bin_temp: float, balance_point: flo
 
 @register("scheduling_fan_bins")
 def scheduling_fan_bins(i: dict[str, Any]) -> dict[str, Any]:
-    """CV/VV Scheduling — fan power saved by tightening the operating schedule.
-
-    Inputs: ``fan_kw_total`` (SF+RF), ``existing_schedule``/``proposed_schedule``
-    (``{"shifts": [h1,h2,h3], "days_per_week": d, "override_allowance": a}``),
-    ``bins``.
-    """
-    fan_kw = float(i["fan_kw_total"]) if "fan_kw_total" in i else sum(
-        float(u.get("fan_kw", 0.0)) for u in i.get("units", [])
-    )
-    if fan_kw <= 0:
-        raise ValueError("fan_kw_total (or units[].fan_kw) must be > 0")
-    existing = _schedule(i, "existing_schedule")
-    proposed = _schedule(i, "proposed_schedule")
-    bins = _bins(i)
-    reduction = hours_reduction_fraction(existing, proposed)
-
-    baseline_kwh = 0.0
-    details = []
-    for row in bins.rows:
-        op_hours = existing.total_operating_hours(row.shift_hours)
-        existing_kwh = fan_kw * op_hours
-        baseline_kwh += existing_kwh
-        details.append({
-            "temp": row.temp,
-            "operating_hours": op_hours,
-            "existing_kwh": existing_kwh,
-            "saved_kwh": existing_kwh * reduction,
-        })
-    savings = baseline_kwh * reduction
-    return {
-        "baseline_kwh": baseline_kwh,
-        "proposed_kwh": baseline_kwh - savings,
-        "savings_kwh": savings,
-        "hours_reduction_fraction": reduction,
-        "bins": details,
-    }
+    """CV/VV Scheduling — fan power (Open-FDD bin method)."""
+    return dict(_ofdd.scheduling_fan_bins(i))
 
 
 @register("scheduling_cooling_bins")
 def scheduling_cooling_bins(i: dict[str, Any]) -> dict[str, Any]:
-    """CV/VV Scheduling — ventilation cooling saved during avoided run hours.
-
-    Inputs: ``oa_cfm_total``, ``kw_per_ton``, ``supply_enthalpy`` (default 23.2
-    Btu/lb at 55 F supply), ``existing_schedule``, ``proposed_schedule``, ``bins``.
-    """
-    oa_cfm = float(i["oa_cfm_total"])
-    kw_per_ton = float(i["kw_per_ton"])
-    supply_h = float(i.get("supply_enthalpy", 23.2))
-    existing = _schedule(i, "existing_schedule")
-    proposed = _schedule(i, "proposed_schedule")
-    bins = _bins(i)
-    reduction = hours_reduction_fraction(existing, proposed)
-
-    baseline_kwh = 0.0
-    details = []
-    for row in bins.rows:
-        op_hours = existing.total_operating_hours(row.shift_hours)
-        ton_hr = _vent_cooling_ton_per_hr(oa_cfm, row.oa_enthalpy, supply_h)
-        existing_kwh = ton_hr * op_hours * kw_per_ton
-        baseline_kwh += existing_kwh
-        details.append({
-            "temp": row.temp,
-            "operating_hours": op_hours,
-            "vent_cooling_ton_hr": ton_hr,
-            "existing_kwh": existing_kwh,
-            "saved_kwh": existing_kwh * reduction,
-        })
-    savings = baseline_kwh * reduction
-    return {
-        "baseline_kwh": baseline_kwh,
-        "proposed_kwh": baseline_kwh - savings,
-        "savings_kwh": savings,
-        "hours_reduction_fraction": reduction,
-        "bins": details,
-    }
+    """CV/VV Scheduling — ventilation cooling (Open-FDD bin method)."""
+    return dict(_ofdd.scheduling_cooling_bins(i))
 
 
 @register("scheduling_heating_bins")
 def scheduling_heating_bins(i: dict[str, Any]) -> dict[str, Any]:
-    """CV/VV Scheduling — ventilation heating saved during avoided run hours.
-
-    Inputs: ``oa_cfm_total``, ``balance_point_f`` (default 55),
-    ``boiler_efficiency`` (default 0.8), ``existing_schedule``,
-    ``proposed_schedule``, ``bins``. Outputs MMBtu and therms.
-    """
-    oa_cfm = float(i["oa_cfm_total"])
-    balance_point = float(i.get("balance_point_f", 55.0))
-    efficiency = float(i.get("boiler_efficiency", 0.8))
-    if efficiency <= 0:
-        raise ValueError("boiler_efficiency must be > 0")
-    existing = _schedule(i, "existing_schedule")
-    proposed = _schedule(i, "proposed_schedule")
-    bins = _bins(i)
-    reduction = hours_reduction_fraction(existing, proposed)
-
-    baseline_mmbtu = 0.0
-    details = []
-    for row in bins.rows:
-        op_hours = existing.total_operating_hours(row.shift_hours)
-        load_kbtu_h = _vent_heating_kbtu_per_hr(oa_cfm, row.temp, balance_point)
-        input_mmbtu = load_kbtu_h * op_hours / efficiency / 1000.0
-        baseline_mmbtu += input_mmbtu
-        details.append({
-            "temp": row.temp,
-            "operating_hours": op_hours,
-            "vent_heat_kbtu_hr": load_kbtu_h,
-            "existing_mmbtu": input_mmbtu,
-            "saved_mmbtu": input_mmbtu * reduction,
-        })
-    savings = baseline_mmbtu * reduction
-    return {
-        "baseline_mmbtu": baseline_mmbtu,
-        "proposed_mmbtu": baseline_mmbtu - savings,
-        "savings_mmbtu": savings,
-        "savings_therms": savings / MMBTU_PER_THERM,
-        "hours_reduction_fraction": reduction,
-        "bins": details,
-    }
+    """CV/VV Scheduling — ventilation heating (Open-FDD bin method)."""
+    return dict(_ofdd.scheduling_heating_bins(i))
 
 
 # ---------------------------------------------------------------------------

--- a/vibe_code_apps_20/wattlab/engineering/openfdd_ecm.py
+++ b/vibe_code_apps_20/wattlab/engineering/openfdd_ecm.py
@@ -143,31 +143,116 @@ def scheduling_fan_bins(inputs: Mapping[str, Any]) -> dict[str, Any]:
     fan_kw = float(inputs["fan_kw_total"]) if "fan_kw_total" in inputs else sum(
         float(u.get("fan_kw", 0.0)) for u in inputs.get("units", [])
     )
-    return ofdd_bin_methods.scheduling_fan_bins(
+    out = ofdd_bin_methods.scheduling_fan_bins(
         fan_kw_total=fan_kw,
         existing_schedule=to_ofdd_schedule(inputs["existing_schedule"]),
         proposed_schedule=to_ofdd_schedule(inputs["proposed_schedule"]),
         bins=to_ofdd_bins(inputs["bins"]),
     )
+    return _normalize_scheduling_fan_result(out)
 
 
 def scheduling_cooling_bins(inputs: Mapping[str, Any]) -> dict[str, Any]:
-    return ofdd_bin_methods.scheduling_cooling_bins(
-        oa_cfm_total=float(inputs["oa_cfm_total"]),
-        kw_per_ton=float(inputs["kw_per_ton"]),
+    supply_h = float(inputs.get("supply_enthalpy", inputs.get("supply_enthalpy_btu_lb", 23.2)))
+    oa_cfm = float(inputs["oa_cfm_total"])
+    kw_per_ton = float(inputs["kw_per_ton"])
+    out = ofdd_bin_methods.scheduling_cooling_bins(
+        oa_cfm_total=oa_cfm,
+        kw_per_ton=kw_per_ton,
         existing_schedule=to_ofdd_schedule(inputs["existing_schedule"]),
         proposed_schedule=to_ofdd_schedule(inputs["proposed_schedule"]),
         bins=to_ofdd_bins(inputs["bins"]),
-        supply_enthalpy_btu_lb=float(inputs.get("supply_enthalpy", inputs.get("supply_enthalpy_btu_lb", 23.2))),
+        supply_enthalpy_btu_lb=supply_h,
     )
+    return _normalize_scheduling_cooling_result(out, oa_cfm=oa_cfm, supply_h=supply_h, kw_per_ton=kw_per_ton, inputs=inputs)
 
 
 def scheduling_heating_bins(inputs: Mapping[str, Any]) -> dict[str, Any]:
-    return ofdd_bin_methods.scheduling_heating_bins(
-        oa_cfm_total=float(inputs["oa_cfm_total"]),
+    oa_cfm = float(inputs["oa_cfm_total"])
+    balance = float(inputs.get("balance_point_f", 55.0))
+    out = ofdd_bin_methods.scheduling_heating_bins(
+        oa_cfm_total=oa_cfm,
         boiler_efficiency=float(inputs.get("boiler_efficiency", 0.8)),
         existing_schedule=to_ofdd_schedule(inputs["existing_schedule"]),
         proposed_schedule=to_ofdd_schedule(inputs["proposed_schedule"]),
         bins=to_ofdd_bins(inputs["bins"]),
-        balance_point_f=float(inputs.get("balance_point_f", 55.0)),
+        balance_point_f=balance,
     )
+    return _normalize_scheduling_heating_result(out, oa_cfm=oa_cfm, balance_point_f=balance, inputs=inputs)
+
+
+def _normalize_scheduling_fan_result(out: dict[str, Any]) -> dict[str, Any]:
+    details = []
+    for row in out.get("bins") or []:
+        details.append({
+            "temp": row.get("temp", row.get("temp_f")),
+            "operating_hours": row.get("operating_hours"),
+            "existing_kwh": row.get("existing_kwh", row.get("baseline_kwh")),
+            "saved_kwh": row.get("saved_kwh"),
+        })
+    out = dict(out)
+    out["bins"] = details
+    return out
+
+
+def _normalize_scheduling_cooling_result(
+    out: dict[str, Any],
+    *,
+    oa_cfm: float,
+    supply_h: float,
+    kw_per_ton: float,
+    inputs: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Remap Open-FDD detail keys + reconstruct vent_cooling_ton_hr for WattLab goldens."""
+    ofdd_bins = to_ofdd_bins(inputs["bins"])
+    existing = to_ofdd_schedule(inputs["existing_schedule"])
+    reduction = float(out.get("hours_reduction_fraction") or ofdd_hours_reduction_fraction(
+        existing, to_ofdd_schedule(inputs["proposed_schedule"])
+    ))
+    details = []
+    for row in ofdd_bins.rows:
+        op_hours = existing.total_operating_hours(row.shift_hours)
+        oa_h = row.oa_enthalpy
+        ton_hr = 0.0 if oa_h is None or oa_h < supply_h else oa_cfm * (oa_h - supply_h) * 4.5 / 12000.0
+        existing_kwh = ton_hr * op_hours * kw_per_ton
+        details.append({
+            "temp": row.temp_f,
+            "operating_hours": op_hours,
+            "vent_cooling_ton_hr": ton_hr,
+            "existing_kwh": existing_kwh,
+            "saved_kwh": existing_kwh * reduction,
+        })
+    out = dict(out)
+    out["bins"] = details
+    out.setdefault("hours_reduction_fraction", reduction)
+    return out
+
+
+def _normalize_scheduling_heating_result(
+    out: dict[str, Any],
+    *,
+    oa_cfm: float,
+    balance_point_f: float,
+    inputs: Mapping[str, Any],
+) -> dict[str, Any]:
+    ofdd_bins = to_ofdd_bins(inputs["bins"])
+    existing = to_ofdd_schedule(inputs["existing_schedule"])
+    proposed = to_ofdd_schedule(inputs["proposed_schedule"])
+    reduction = float(out.get("hours_reduction_fraction") or ofdd_hours_reduction_fraction(existing, proposed))
+    efficiency = float(inputs.get("boiler_efficiency", 0.8))
+    details = []
+    for row in ofdd_bins.rows:
+        op_hours = existing.total_operating_hours(row.shift_hours)
+        load_kbtu_h = 0.0 if balance_point_f < row.temp_f else (balance_point_f - row.temp_f) * oa_cfm * 1.08 / 1000.0
+        existing_mmbtu = load_kbtu_h * op_hours / efficiency / 1000.0
+        details.append({
+            "temp": row.temp_f,
+            "operating_hours": op_hours,
+            "vent_heat_kbtu_hr": load_kbtu_h,
+            "existing_mmbtu": existing_mmbtu,
+            "saved_mmbtu": existing_mmbtu * reduction,
+        })
+    out = dict(out)
+    out["bins"] = details
+    out.setdefault("hours_reduction_fraction", reduction)
+    return out


### PR DESCRIPTION
## Summary
- Delegate the **8** parity-proven calculators to `wattlab.engineering.openfdd_ecm`
- Keep `@register` names and WattLab bin detail keys (golden-compatible)
- Document intentional local-only keepers in `docs/OPENFDD_ECM_TWINS.md`
- Registry length unchanged (26)

## Test plan
- [x] `pytest tests/test_openfdd_ecm_parity.py tests/test_esco_golden.py tests/test_bench_algorithms.py -q` (31 passed)


Made with [Cursor](https://cursor.com)