### PR TITLE
fix(ops): BUG-061 docker update scripts keep /data bind

### DIFF
--- a/vibe_code_apps_19/docs/DOCKER.md
+++ b/vibe_code_apps_19/docs/DOCKER.md
@@ -25,6 +25,10 @@ Foreground `docker run` (no `-d`) dies when you close the terminal. A **running*
 # Windows: .\scripts\docker_update_vibe19.ps1
 ```
 
+By default the script bind-mounts `$HOME/wattlab_workspace` → `/data` when that
+host directory exists (BUG-061). Override with `DATA_MOUNT=/path:/data` or
+`DATA_MOUNT=none` for zip-only demos without a shared workspace.
+
 Or by hand — prefer **`:latest`** (same tip as `:develop` while default branch is `develop`):
 
 1. **`docker pull ghcr.io/bbartling/vibe19:latest`**
@@ -42,15 +46,19 @@ Or by hand — prefer **`:latest`** (same tip as `:develop` while default branch
 | `-d` | Detached — process stays up after the shell closes |
 | `--restart unless-stopped` | Restart on crash or host/Docker reboot until you `docker stop` |
 | `-p HOST:8501` | Map a free host port to Streamlit inside the container |
+| `-v $HOME/wattlab_workspace:/data` | Shared agent workspace (AFDD / dumps / vibe20) |
 | `--name vibe19` | Stable name for stop / start / logs |
 | Do **not** pass `--rm` | `--rm` deletes the container on stop (fine for one-shot tests only) |
 
 **Linux / macOS / Raspberry Pi (64-bit):**
 
 ```bash
+mkdir -p "$HOME/wattlab_workspace"
 docker pull ghcr.io/bbartling/vibe19:latest
 docker stop vibe19 2>/dev/null; docker rm vibe19 2>/dev/null
-docker run -d --restart unless-stopped -p 8502:8501 --name vibe19 \
+docker run -d --restart unless-stopped -p 8502:8501 \
+  -v "$HOME/wattlab_workspace:/data" \
+  --name vibe19 \
   ghcr.io/bbartling/vibe19:latest
 # open http://localhost:8502  (or http://<pi-ip>:8502)
 ```

--- a/vibe_code_apps_19/scripts/docker_update_vibe19.ps1
+++ b/vibe_code_apps_19/scripts/docker_update_vibe19.ps1
@@ -1,28 +1,59 @@
 # Easy button: pull newest vibe19 image and recreate the long-running container.
+# BUG-061: default bind $HOME/wattlab_workspace -> /data (set DataMount=none to skip).
 # Usage:
 #   .\scripts\docker_update_vibe19.ps1
 #   .\scripts\docker_update_vibe19.ps1 -Tag develop
 #   .\scripts\docker_update_vibe19.ps1 -Tag latest -HostPort 8501
+#   .\scripts\docker_update_vibe19.ps1 -DataMount "C:\Users\ben\wattlab_workspace:/data"
 param(
     [string]$Tag = "latest",
     [string]$Name = "vibe19",
-    [int]$HostPort = 8502
+    [int]$HostPort = 8502,
+    [string]$DataMount = ""
 )
 
 $ErrorActionPreference = "Stop"
 $Image = "ghcr.io/bbartling/vibe19:$Tag"
+$DefaultHostWs = if ($env:WATTLAB_HOST_WORKSPACE) { $env:WATTLAB_HOST_WORKSPACE } else {
+    Join-Path $HOME "wattlab_workspace"
+}
+
+if (-not $DataMount) {
+    if ($env:DATA_MOUNT) {
+        $DataMount = $env:DATA_MOUNT
+    } elseif (Test-Path -LiteralPath $DefaultHostWs) {
+        $DataMount = "${DefaultHostWs}:/data"
+    }
+}
+if ($DataMount -in @("none", "off", "0")) {
+    $DataMount = ""
+}
 
 Write-Host "==> Pulling $Image"
 docker pull $Image
 if ($LASTEXITCODE -ne 0) { throw "docker pull failed" }
 
 Write-Host "==> Recreating container '$Name' on host port $HostPort"
+if ($DataMount) {
+    Write-Host "    bind: $DataMount"
+} else {
+    Write-Host "    bind: (none)"
+}
+
 docker stop $Name 2>$null | Out-Null
 docker rm $Name 2>$null | Out-Null
-docker run -d --restart unless-stopped `
-    -p "${HostPort}:8501" `
-    --name $Name `
-    $Image
+
+$runArgs = @(
+    "-d", "--restart", "unless-stopped",
+    "-p", "${HostPort}:8501",
+    "--name", $Name
+)
+if ($DataMount) {
+    $runArgs += @("-v", $DataMount)
+}
+$runArgs += $Image
+
+docker run @runArgs
 if ($LASTEXITCODE -ne 0) { throw "docker run failed" }
 
 Write-Host "==> Running:"

--- a/vibe_code_apps_19/scripts/docker_update_vibe19.sh
+++ b/vibe_code_apps_19/scripts/docker_update_vibe19.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 # Easy button: pull newest vibe19 image and recreate the long-running container.
+#
+# Default bind (BUG-061): $HOME/wattlab_workspace → /data so AFDD / Eng Findings /
+# shared vibe20 agent paths survive recreate. Override or disable with env:
+#   DATA_MOUNT="$HOME/wattlab_workspace:/data"   # default when host dir exists
+#   DATA_MOUNT=none                             # skip volume (zip-only demos)
+#   HOST_PORT=8502 CONTAINER_NAME=vibe19
+#
 # Usage:
 #   ./scripts/docker_update_vibe19.sh           # :latest (tip of develop)
 #   ./scripts/docker_update_vibe19.sh develop   # same tip, branch tag
@@ -10,19 +17,48 @@ TAG="${1:-latest}"
 NAME="${CONTAINER_NAME:-vibe19}"
 HOST_PORT="${HOST_PORT:-8502}"
 IMAGE="ghcr.io/bbartling/vibe19:${TAG}"
+DEFAULT_HOST_WS="${WATTLAB_HOST_WORKSPACE:-${HOME}/wattlab_workspace}"
+
+# Resolve DATA_MOUNT: explicit env wins; else default host workspace if present.
+if [[ -z "${DATA_MOUNT+x}" ]]; then
+  if [[ -d "${DEFAULT_HOST_WS}" ]]; then
+    DATA_MOUNT="${DEFAULT_HOST_WS}:/data"
+  else
+    DATA_MOUNT=""
+  fi
+elif [[ "${DATA_MOUNT}" == "none" || "${DATA_MOUNT}" == "off" || "${DATA_MOUNT}" == "0" ]]; then
+  DATA_MOUNT=""
+fi
 
 echo "==> Pulling ${IMAGE}"
 docker pull "${IMAGE}"
 
 echo "==> Recreating container '${NAME}' on host port ${HOST_PORT}"
+if [[ -n "${DATA_MOUNT}" ]]; then
+  echo "    bind: ${DATA_MOUNT}"
+else
+  echo "    bind: (none — set DATA_MOUNT or create ${DEFAULT_HOST_WS})"
+fi
+
 docker stop "${NAME}" 2>/dev/null || true
 docker rm "${NAME}" 2>/dev/null || true
-docker run -d --restart unless-stopped \
-  -p "${HOST_PORT}:8501" \
-  --name "${NAME}" \
-  "${IMAGE}"
+
+RUN_ARGS=(
+  -d --restart unless-stopped
+  -p "${HOST_PORT}:8501"
+  --name "${NAME}"
+)
+if [[ -n "${DATA_MOUNT}" ]]; then
+  RUN_ARGS+=(-v "${DATA_MOUNT}")
+fi
+
+docker run "${RUN_ARGS[@]}" "${IMAGE}"
 
 echo "==> Running:"
 docker ps --filter "name=^/${NAME}$"
 echo "Open http://localhost:${HOST_PORT}  (or http://<host-ip>:${HOST_PORT})"
+if [[ -n "${DATA_MOUNT}" ]]; then
+  echo "Workspace: ${DATA_MOUNT}"
+  docker inspect "${NAME}" --format '{{range .Mounts}}{{.Source}} -> {{.Destination}}{{println}}{{end}}'
+fi
 echo "Note: a running container never auto-updates — re-run this script after GHCR builds."

--- a/vibe_code_apps_20/scripts/docker_update_vibe20.sh
+++ b/vibe_code_apps_20/scripts/docker_update_vibe20.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Easy button: pull newest vibe20 image and recreate Studio with /data + docker.sock.
+#
+# Defaults (BUG-061 class for vibe20):
+#   -v $HOME/wattlab_workspace:/data
+#   -v /var/run/docker.sock:/var/run/docker.sock
+#   WATTLAB_STUDIO_WORKSPACE=/data
+#   WATTLAB_HOST_WORKSPACE=<host path of /data bind>
+#
+#   DATA_MOUNT=none SOCK_MOUNT=none  # disable binds
+#   HOST_PORT=8520 CONTAINER_NAME=vibe20
+set -euo pipefail
+
+TAG="${1:-latest}"
+NAME="${CONTAINER_NAME:-vibe20}"
+HOST_PORT="${HOST_PORT:-8520}"
+IMAGE="ghcr.io/bbartling/vibe20:${TAG}"
+DEFAULT_HOST_WS="${WATTLAB_HOST_WORKSPACE:-${HOME}/wattlab_workspace}"
+
+if [[ -z "${DATA_MOUNT+x}" ]]; then
+  if [[ -d "${DEFAULT_HOST_WS}" ]]; then
+    DATA_MOUNT="${DEFAULT_HOST_WS}:/data"
+  else
+    mkdir -p "${DEFAULT_HOST_WS}"
+    DATA_MOUNT="${DEFAULT_HOST_WS}:/data"
+  fi
+elif [[ "${DATA_MOUNT}" == "none" || "${DATA_MOUNT}" == "off" || "${DATA_MOUNT}" == "0" ]]; then
+  DATA_MOUNT=""
+fi
+
+if [[ -z "${SOCK_MOUNT+x}" ]]; then
+  if [[ -S /var/run/docker.sock ]]; then
+    SOCK_MOUNT="/var/run/docker.sock:/var/run/docker.sock"
+  else
+    SOCK_MOUNT=""
+  fi
+elif [[ "${SOCK_MOUNT}" == "none" || "${SOCK_MOUNT}" == "off" || "${SOCK_MOUNT}" == "0" ]]; then
+  SOCK_MOUNT=""
+fi
+
+HOST_WS_ENV="${DEFAULT_HOST_WS}"
+if [[ -n "${DATA_MOUNT}" && "${DATA_MOUNT}" == *:* ]]; then
+  HOST_WS_ENV="${DATA_MOUNT%%:*}"
+fi
+
+echo "==> Pulling ${IMAGE}"
+docker pull "${IMAGE}"
+
+echo "==> Recreating container '${NAME}' on host port ${HOST_PORT}"
+echo "    data: ${DATA_MOUNT:-none}"
+echo "    sock: ${SOCK_MOUNT:-none}"
+
+docker stop "${NAME}" 2>/dev/null || true
+docker rm "${NAME}" 2>/dev/null || true
+
+RUN_ARGS=(
+  -d --restart unless-stopped
+  -p "${HOST_PORT}:8501"
+  --name "${NAME}"
+  -e WATTLAB_STUDIO_WORKSPACE=/data
+  -e WATTLAB_HOST_WORKSPACE="${HOST_WS_ENV}"
+  -e WATTLAB_ROOT=/app
+)
+if [[ -n "${DATA_MOUNT}" ]]; then
+  RUN_ARGS+=(-v "${DATA_MOUNT}")
+fi
+if [[ -n "${SOCK_MOUNT}" ]]; then
+  RUN_ARGS+=(-v "${SOCK_MOUNT}")
+fi
+
+docker run "${RUN_ARGS[@]}" "${IMAGE}"
+
+echo "==> Running:"
+docker ps --filter "name=^/${NAME}$"
+echo "Open http://localhost:${HOST_PORT}"
+docker inspect "${NAME}" --format '{{range .Mounts}}{{.Source}} -> {{.Destination}}{{println}}{{end}}'
+echo "Note: a running container never auto-updates — re-run this script after GHCR builds."


### PR DESCRIPTION
## Summary
- **BUG-061:** `docker_update_vibe19.sh` / `.ps1` bind `$HOME/wattlab_workspace:/data` by default
- Add `docker_update_vibe20.sh` with `/data` + docker.sock + `WATTLAB_*` envs
- Document `DATA_MOUNT` / `DATA_MOUNT=none` in `docs/DOCKER.md`

## Test plan
- [ ] `DATA_MOUNT=none ./scripts/docker_update_vibe19.sh` still works
- [ ] Default recreate shows `/data` in `docker inspect` mounts
- [ ] CodeRabbit + CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable workspace and Docker socket mounts for the Vibe 19 and Vibe 20 containers.
  - Added options to disable mounts when needed, including support for zip-only demonstrations.
  - Added automatic workspace detection and clearer container mount status reporting.
  - Added a Vibe 20 update utility with configurable image tag, container name, and ports.

- **Documentation**
  - Expanded Docker setup instructions for Linux, macOS, and Raspberry Pi, including shared workspace mapping and stable container naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->