### PR TITLE
fix(vibe20): BUG-062 honesty.openfdd delegated when adapter used

### DIFF
--- a/vibe_code_apps_20/tests/test_notebook_builder.py
+++ b/vibe_code_apps_20/tests/test_notebook_builder.py
@@ -14,6 +14,7 @@ from wattlab.notebooks.builder import (
     agent_build_notebook,
     build_and_save_notebook,
     extract_calibrated_baseline,
+    openfdd_honesty,
     prefill_notebook_inputs,
     preview_sheet_rows,
     read_notebook_inputs,
@@ -148,7 +149,36 @@ def test_summarize_resolves_package_and_ep_coverage(tmp_path: Path):
     assert man["package_label"]
     assert man["ep_coverage"]["filled_rows"] == 0
     assert man["honesty"]["template_file"] in ("loaded", "scaffold_only")
-    assert man["honesty"]["openfdd"] == "not_used"
+    # BUG-062: honesty reflects reality — "delegated" (+ version/calculators)
+    # when the Open-FDD ECM adapter is available, else "not_used".
+    assert man["honesty"]["openfdd"] in ("delegated", "not_used")
+    if man["honesty"]["openfdd"] == "delegated":
+        assert "openfdd_version" in man["honesty"]
+        assert isinstance(man["honesty"]["openfdd_calculators"], list)
+
+
+def test_openfdd_honesty_helper(monkeypatch):
+    """BUG-062: helper reports delegation honestly, never fabricates it."""
+    info = openfdd_honesty()
+    assert info["openfdd"] in ("delegated", "not_used")
+    if info["openfdd"] == "delegated":
+        assert "openfdd_version" in info
+        assert isinstance(info["openfdd_calculators"], list)
+
+    # With the adapter installed, forcing "unavailable" must downgrade to
+    # not_used rather than claim a delegation that did not happen.
+    pytest.importorskip("open_fdd")
+    from wattlab.engineering import openfdd_ecm
+
+    monkeypatch.setattr(openfdd_ecm, "openfdd_available", lambda: False)
+    assert openfdd_honesty() == {"openfdd": "not_used"}
+
+    # When delegating, calculators are truncated to max_calculators.
+    monkeypatch.setattr(openfdd_ecm, "openfdd_available", lambda: True)
+    monkeypatch.setattr(openfdd_ecm, "list_calculators", lambda: ["a", "b", "c", "d"])
+    trunc = openfdd_honesty(max_calculators=2)
+    assert trunc["openfdd"] == "delegated"
+    assert trunc["openfdd_calculators"] == ["a", "b"]
 
 
 def test_cli_prefill_elec_rate(tmp_path: Path):

--- a/vibe_code_apps_20/wattlab/notebooks/builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/builder.py
@@ -1781,6 +1781,42 @@ def validate_notebook(path: Path | str) -> dict[str, Any]:
     }
 
 
+def openfdd_honesty(*, max_calculators: int = 12) -> dict[str, Any]:
+    """BUG-062: honest Open-FDD ECM delegation status for the manifest.
+
+    Returns ``{"openfdd": "delegated", ...}`` with ``openfdd_version`` and a
+    (possibly truncated) ``openfdd_calculators`` list when the Open-FDD ECM
+    adapter is importable *and* reports available. Returns
+    ``{"openfdd": "not_used"}`` only when the package is missing or the adapter
+    is otherwise unavailable — never claim delegation that did not happen.
+    """
+    try:
+        from wattlab.engineering import openfdd_ecm
+
+        available = bool(openfdd_ecm.openfdd_available())
+    except Exception:
+        return {"openfdd": "not_used"}
+    if not available:
+        return {"openfdd": "not_used"}
+
+    info: dict[str, Any] = {"openfdd": "delegated"}
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            info["openfdd_version"] = version("open-fdd")
+        except PackageNotFoundError:
+            info["openfdd_version"] = None
+    except Exception:
+        info["openfdd_version"] = None
+    try:
+        calculators = list(openfdd_ecm.list_calculators())
+        info["openfdd_calculators"] = calculators[:max_calculators]
+    except Exception:
+        info["openfdd_calculators"] = []
+    return info
+
+
 def summarize_notebook(
     path: Path | str,
     *,
@@ -1912,7 +1948,7 @@ def summarize_notebook(
             "roi_cost_npv": "excel_formulas_from_inputs",
             "roi_vs_calibrated": "screening_roi_not_calibrated_g14_roi",
             "template_file": "loaded" if tpl_loaded else "scaffold_only",
-            "openfdd": "not_used",
+            **openfdd_honesty(),
             "docs": {
                 "esco_calculators": ESCO_CALCULATORS_URL,
                 "retrofit_cost_roi": ESCO_RETROFIT_ROI_URL,
@@ -1969,6 +2005,7 @@ __all__ = [
     "default_template_path",
     "extract_calibrated_baseline",
     "list_notebook_packages",
+    "openfdd_honesty",
     "prefill_notebook_inputs",
     "preview_sheet_rows",
     "read_notebook_inputs",


### PR DESCRIPTION
## Summary
- **BUG-062:** notebook manifest `honesty.openfdd` reports `delegated` + version + calculators when Open-FDD ECM adapter is available; `not_used` only when missing

## Test plan
- [x] `pytest vibe_code_apps_20/tests/test_notebook_builder.py`
- [ ] CI + CodeRabbit


Made with [Cursor](https://cursor.com)