### PR TITLE
fix(vibe20): BUG-064 SAT-RESET Compare no false RED without cascade

### DIFF
--- a/vibe_code_apps_20/tests/test_g36_notebook.py
+++ b/vibe_code_apps_20/tests/test_g36_notebook.py
@@ -8,7 +8,7 @@ import openpyxl
 import pytest
 
 from wattlab.notebooks.builder import build_and_save_notebook, validate_notebook
-from wattlab.notebooks.g36_builder import G36_MEASURES
+from wattlab.notebooks.g36_builder import G36_MEASURES, _crosscheck_light
 from wattlab.notebooks.packages import G36_SHEET_ORDER, get_notebook_package, list_notebook_packages
 
 
@@ -114,3 +114,71 @@ def test_g36_with_twin_vs_baseline(tmp_path: Path):
     assert wb["Twin_Measures"]["B2"].value == 50000.0
     assert wb["Crosscheck"]["C5"].value == "=Twin_Measures!B2"
     assert wb["Crosscheck"]["I5"].value != "ESCO_ONLY_NO_EP"
+
+
+def test_crosscheck_light_zero_ep_is_yellow_not_red():
+    """BUG-064: stubbed / zero EP savings must not fake a RED input mismatch."""
+    # No twin attached at all → ESCO_ONLY.
+    assert _crosscheck_light(72_800.0, None) == ("ESCO_ONLY_NO_EP", "N/A")
+    # ESCO > 0 but EP ~0 (cascade pending) → YELLOW, not RED.
+    assert _crosscheck_light(72_800.0, 0.0) == ("INSUFFICIENT_EVIDENCE", "YELLOW")
+    # Both ~0 → still YELLOW insufficient evidence.
+    assert _crosscheck_light(0.0, 0.0) == ("INSUFFICIENT_EVIDENCE", "YELLOW")
+    # ESCO ~0 but EP has real savings → genuine RED input inconsistency.
+    assert _crosscheck_light(0.0, 20_000.0) == ("INVESTIGATE_INPUTS", "RED")
+    # In-line ratio stays GREEN; wild ratio stays RED.
+    assert _crosscheck_light(72_800.0, 70_000.0) == ("IN_LINE", "GREEN")
+    assert _crosscheck_light(72_800.0, 5_000.0) == ("INVESTIGATE_INPUTS", "RED")
+
+
+def test_g36_zero_ep_savings_are_yellow_not_red(tmp_path: Path):
+    """BUG-064: an attached-but-stubbed twin (all kwh_saved=0) → YELLOW rows, no RED note."""
+    report = {
+        "run_id": "stub_zero",
+        "savings_by_measure": [
+            {"measure_id": mid, "vs_baseline": {"kwh_saved": 0.0, "therms_saved": 0.0}}
+            for mid in G36_MEASURES
+        ],
+    }
+    written = build_and_save_notebook(
+        "g36_airside_controls",
+        tmp_path,
+        profile={"floor_area_ft2": 140_000, "fan_hp": 80, "cooling_tons": 400},
+        report=report,
+        twin_run="stub_zero",
+    )
+    wb = openpyxl.load_workbook(written["xlsx"], data_only=False)
+    xc = wb["Crosscheck"]
+    for r in range(5, 8):
+        assert xc.cell(r, 9).value == "INSUFFICIENT_EVIDENCE"
+        assert xc.cell(r, 10).value == "YELLOW"
+    # No RED driver note when nothing is RED.
+    assert xc["A9"].value != "note"
+
+
+def test_g36_red_ratio_adds_sat_driver_note(tmp_path: Path):
+    """BUG-064: a genuine bad SAT ratio lands RED and names SAT driver cells."""
+    # ESCO SAT ≈ 400 * 0.65 * 3500 * 0.08 = 72,800 kWh; tiny EP → ratio < 0.25 → RED.
+    report = {
+        "run_id": "sat_bad_ratio",
+        "savings_by_measure": [
+            {"measure_id": "ECM-DSP-RESET", "vs_baseline": {"kwh_saved": 50_000.0}},
+            {"measure_id": "ECM-SAT-RESET", "vs_baseline": {"kwh_saved": 5_000.0}},
+            {"measure_id": "ECM-CHILLER-LOCKOUT", "vs_baseline": {"kwh_saved": 200_000.0}},
+        ],
+    }
+    written = build_and_save_notebook(
+        "g36_airside_controls",
+        tmp_path,
+        profile={"floor_area_ft2": 140_000, "fan_hp": 80, "cooling_tons": 400},
+        report=report,
+        twin_run="sat_bad_ratio",
+    )
+    wb = openpyxl.load_workbook(written["xlsx"], data_only=False)
+    xc = wb["Crosscheck"]
+    # SAT is row 6 (index 1) — RED for the bad ratio.
+    assert xc.cell(6, 10).value == "RED"
+    assert xc["A9"].value == "note"
+    note = str(xc["B9"].value)
+    for driver in ("sat_hours", "sat_frac", "cooling_tons", "kw_per_ton"):
+        assert driver in note

--- a/vibe_code_apps_20/wattlab/notebooks/g36_builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/g36_builder.py
@@ -73,11 +73,28 @@ def _ep_by_measure(report: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
 
 
 def _crosscheck_light(esco_kwh: float, ep_kwh: float | None) -> tuple[str, str]:
+    """Compare ESCO engineering savings against EnergyPlus twin savings.
+
+    BUG-064: a stubbed / not-yet-cascaded EnergyPlus result (``ep_kwh`` absent
+    or ~0) must never masquerade as a RED input inconsistency:
+
+    * ``ep_kwh is None`` → ESCO_ONLY (no twin attached).
+    * ``ep_kwh ≈ 0`` while ESCO > 0 → INSUFFICIENT_EVIDENCE / YELLOW — the twin
+      cascade is pending, so there is no evidence to contradict ESCO yet.
+    * ``ESCO ≈ 0`` while ``ep_kwh`` has meaningful savings → RED
+      INVESTIGATE_INPUTS (a genuine input inconsistency).
+    * both present and non-trivial → ratio bands (GREEN / YELLOW / RED).
+    """
     if ep_kwh is None:
         return "ESCO_ONLY_NO_EP", "N/A"
-    if abs(esco_kwh) < 1e-6 and abs(ep_kwh) < 1e-6:
+    esco_zero = abs(esco_kwh) < 1e-6
+    ep_zero = abs(ep_kwh) < 1e-6
+    if ep_zero:
+        # No twin savings yet (cascade pending or stubbed) — not a real
+        # disagreement, regardless of whether ESCO is zero or positive.
         return "INSUFFICIENT_EVIDENCE", "YELLOW"
-    if abs(esco_kwh) < 1e-6:
+    if esco_zero:
+        # Twin shows real savings but ESCO shows ~none → true input mismatch.
         return "INVESTIGATE_INPUTS", "RED"
     ratio = ep_kwh / esco_kwh
     if 0.5 <= ratio <= 1.5:
@@ -85,6 +102,15 @@ def _crosscheck_light(esco_kwh: float, ep_kwh: float | None) -> tuple[str, str]:
     if 0.25 <= ratio <= 2.5:
         return "REASONABLE_BAND", "YELLOW"
     return "INVESTIGATE_INPUTS", "RED"
+
+
+# Inputs/Baseline driver cells that dominate each ESCO measure — surfaced in the
+# Crosscheck note when a row lands RED so the engineer knows what to inspect.
+_MEASURE_DRIVERS: dict[str, str] = {
+    "ECM-DSP-RESET": "fan_hp, fan_hours, fan_speed_old, fan_speed_new",
+    "ECM-SAT-RESET": "sat_hours, sat_frac, cooling_tons, kw_per_ton",
+    "ECM-CHILLER-LOCKOUT": "cooling_tons, kw_per_ton, lockout_hours, lockout_oat_f",
+}
 
 
 def build_g36_workbook(
@@ -417,6 +443,7 @@ def build_g36_workbook(
         xc.cell(4, col, h)
     _style_header(xc, 4)
 
+    red_measures: list[str] = []
     for j, mid in enumerate(G36_MEASURES):
         r = 5 + j
         refs = CALC_RESULT_CELLS[mid]
@@ -424,6 +451,8 @@ def build_g36_workbook(
         ep_kwh = ep.get("kwh_saved")
         ep_therms = ep.get("therms_saved")
         verdict, light = _crosscheck_light(esco[mid]["kwh"], None if ep_kwh is None else float(ep_kwh))
+        if not ep_missing and light == "RED":
+            red_measures.append(mid)
         xc.cell(r, 1, mid)
         xc.cell(r, 2, f"={refs['kwh']}")
         if ep_missing:
@@ -444,6 +473,16 @@ def build_g36_workbook(
     if ep_missing:
         xc["A9"] = "note"
         xc["B9"] = "Twin cascade pending — ESCO columns still live from Calc_*. Run cascade-from-twin to fill ep_*."
+    elif red_measures:
+        drivers = " | ".join(
+            f"{mid} → check Inputs/Baseline drivers: {_MEASURE_DRIVERS.get(mid, 'inputs')}"
+            for mid in red_measures
+        )
+        xc["A9"] = "note"
+        xc["B9"] = (
+            "RED = ESCO vs Twin disagree (bad ratio or ESCO~0 with Twin savings). "
+            + drivers
+        )
 
     for col, w in zip("ABCDEFGHIJ", (26, 12, 12, 12, 14, 12, 12, 12, 28, 10), strict=False):
         xc.column_dimensions[col].width = w


### PR DESCRIPTION
## Summary
- **BUG-064:** stub/zero EP savings no longer force RED `INVESTIGATE_INPUTS` when ESCO > 0 (YELLOW insufficient / cascade pending)
- RED retained for true ESCO≈0 vs meaningful EP; Crosscheck note lists SAT driver inputs

## Test plan
- [x] `pytest vibe_code_apps_20/tests/test_g36_notebook.py`
- [ ] CI + CodeRabbit


Made with [Cursor](https://cursor.com)