### PR TITLE
chore: BUG-041 include pytest in vibe19/vibe20 GHCR images

### DIFF
--- a/vibe_code_apps_19/Dockerfile
+++ b/vibe_code_apps_19/Dockerfile
@@ -61,6 +61,11 @@ RUN pip install --no-cache-dir -r requirements.txt \
  && python -c "import docx, kaleido, matplotlib; print('engineering-report extras ok')" \
  && python /tmp/docker_kaleido_smoke.py
 
+# In-container test runner (BUG-041): pytest is not a runtime/cloud dependency,
+# so it stays out of requirements.txt and is installed Docker-only. Lets
+# AppTests run ``python -m pytest`` inside the GHCR image.
+RUN pip install --no-cache-dir "pytest>=8"
+
 # Includes .streamlit/config.toml (maxUploadSize=500) — do not lower OPENFDD_MAX_* here.
 COPY . .
 

--- a/vibe_code_apps_19/README.md
+++ b/vibe_code_apps_19/README.md
@@ -150,6 +150,17 @@ python -m pytest -q
 .\scripts\run_tests_local.ps1
 ```
 
+The GHCR image installs `pytest` (Docker-only; it stays out of
+`requirements.txt` / Streamlit Cloud), so AppTests can also run inside the
+container (BUG-041):
+
+```bash
+docker exec vibe19 python -m pytest -q
+```
+
+Host-venv runs are still fine — `pytest` there comes from
+`requirements-dev` / your local install.
+
 ## Docs
 
 | Doc | Topic |

--- a/vibe_code_apps_20/Dockerfile
+++ b/vibe_code_apps_20/Dockerfile
@@ -44,7 +44,9 @@ COPY . .
 # Editable install so ``import wattlab`` resolves to /app/wattlab (single tree).
 # open-fdd (PyPI) supplies shared ECM engineering calculators via
 # wattlab.engineering.openfdd_ecm — pin comes from pyproject.toml.
-RUN pip install --no-cache-dir -e ".[studio]"
+# apptest extra adds pytest>=8 (no playwright) so AppTests can run
+# ``python -m pytest`` inside the GHCR image (BUG-041).
+RUN pip install --no-cache-dir -e ".[studio,apptest]"
 
 EXPOSE 8501
 

--- a/vibe_code_apps_20/README.md
+++ b/vibe_code_apps_20/README.md
@@ -78,6 +78,18 @@ python -m pytest tests/test_studio_app.py -q
 python scripts/browser_smoke_vibe20.py --url http://localhost:8520 --screenshots .artifacts/browser/native
 ```
 
+### AppTests in the container (BUG-041)
+
+The GHCR image installs the lightweight `apptest` extra (`pytest>=8`, no
+playwright), so AppTests can run `python -m pytest` inside the container:
+
+```bash
+docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 python -m pytest -q
+```
+
+Running tests from a host venv still works — install with
+`pip install -e ".[studio,apptest]"` (or `.[dev]` for the full toolchain).
+
 ## Related docs
 
 | Doc | For |

--- a/vibe_code_apps_20/pyproject.toml
+++ b/vibe_code_apps_20/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 studio = ["streamlit>=1.37", "plotly>=5.20", "matplotlib>=3.8", "openpyxl>=3.1", "python-docx>=1.1"]
 excel = ["openpyxl>=3.1"]
 docx = ["python-docx>=1.1"]
+# Lightweight in-container test runner (BUG-041): pytest only, no playwright/ruff,
+# so ``python -m pytest`` works inside the GHCR image without the heavy dev extra.
+apptest = ["pytest>=8"]
 dev = ["pytest>=8.0", "ruff>=0.5", "playwright>=1.40"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- **BUG-041:** vibe20 `apptest` extra (pytest only) installed in Docker; vibe19 Dockerfile installs pytest
- README notes: run `python -m pytest` in-container; host venv still valid

## Test plan
- [ ] CI + CodeRabbit
- [ ] After GHCR publish: `docker exec … python -m pytest --version`


Made with [Cursor](https://cursor.com)