### PR TITLE
fix(vibe20): G14 chart per-building dial history (not mtime soup)

### DIFF
--- a/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
+++ b/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
@@ -233,6 +233,11 @@ def test_g14_chart_scopes_to_building_family(tmp_path: Path):
     mixed_ids = {r["run_id"] for r in mixed}
     assert "geo_b50_i32_freecool_julHW" in mixed_ids
     assert "geo_b100_6stack_shape_r56_sched_mild" in mixed_ids
+    # "all" sentinel must not filter to prefix="all" (empty)
+    assert len(iter_g14_history(runs, limit=80, building_family="all")) == len(mixed)
+    from wattlab.studio.g14_history import discover_building_families
+
+    assert discover_building_families(runs) == ["geo_b100", "geo_b50"]
 
 
 def test_build_dial_knobs_rows(tmp_path: Path):

--- a/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
+++ b/vibe_code_apps_20/tests/test_twin_g14_model_summary.py
@@ -7,9 +7,11 @@ from pathlib import Path
 
 from wattlab.studio.g14_history import (
     assign_run_numbers,
+    building_family_from_run_id,
     g14_epoch_figure,
     iter_g14_history,
     pick_best_g14_run,
+    run_id_short_stem,
 )
 from wattlab.studio.idf_geometry import parse_idf_geometry
 from wattlab.studio.model_summary import build_dial_knobs_rows, build_model_summary
@@ -110,6 +112,127 @@ def test_iter_g14_history_and_epoch(tmp_path: Path):
     legend_names = [getattr(t, "name", "") or "" for t in fig.data]
     assert any("G14 |NMBE| gate" in n for n in legend_names)
     assert any("G14 CV(RMSE) gate" in n for n in legend_names)
+
+
+def _write_g14_run(
+    runs: Path,
+    run_id: str,
+    *,
+    day: int,
+    nmbe: float,
+    cvrmse: float,
+    pass_fail: str,
+) -> None:
+    d = runs / run_id
+    d.mkdir(parents=True)
+    (d / "run_manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "status": "ok",
+                "started_at": f"2026-07-{day:02d}T12:00:00Z",
+                "finished_at": f"2026-07-{day:02d}T12:30:00Z",
+                "hypothesis": run_id,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (d / "calibration_scorecard.json").write_text(
+        json.dumps(
+            {
+                "utility_bills": {
+                    "pass_fail": pass_fail,
+                    "stats_electricity": {"nmbe_pct": nmbe, "cvrmse_pct": cvrmse},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_building_family_helpers():
+    assert building_family_from_run_id("geo_b100_6stack_shape_r56_sched_mild") == "geo_b100"
+    assert building_family_from_run_id("geo_b50_i32_freecool_julHW") == "geo_b50"
+    assert run_id_short_stem("geo_b100_6stack_shape_r56_sched_mild") == "r56"
+    assert run_id_short_stem("geo_b50_i32_freecool_julHW") == "i32"
+
+
+def test_g14_chart_scopes_to_building_family(tmp_path: Path):
+    """B100 filter must never plot B50 points; best PASS is r56-like, not B50 i32."""
+    runs = tmp_path / "runs"
+    # Newer B50 FAIL (would look like “late iter” in mixed mtime soup)
+    _write_g14_run(
+        runs,
+        "geo_b50_i32_freecool_julHW",
+        day=20,
+        nmbe=2.0,
+        cvrmse=19.5,
+        pass_fail="FAIL",
+    )
+    _write_g14_run(
+        runs,
+        "geo_b50_i31_earlier",
+        day=18,
+        nmbe=4.0,
+        cvrmse=18.0,
+        pass_fail="FAIL",
+    )
+    # Older B100 PASS (true best for B100)
+    _write_g14_run(
+        runs,
+        "geo_b100_6stack_shape_r56_sched_mild",
+        day=10,
+        nmbe=1.5,
+        cvrmse=8.0,
+        pass_fail="PASS",
+    )
+    _write_g14_run(
+        runs,
+        "geo_b100_6stack_shape_r55_prior",
+        day=8,
+        nmbe=6.0,
+        cvrmse=16.0,
+        pass_fail="FAIL",
+    )
+
+    b100 = assign_run_numbers(
+        iter_g14_history(runs, limit=80, building_family="geo_b100")
+    )
+    ids = [r["run_id"] for r in b100]
+    assert ids == [
+        "geo_b100_6stack_shape_r55_prior",
+        "geo_b100_6stack_shape_r56_sched_mild",
+    ]
+    assert all(str(r["run_id"]).startswith("geo_b100") for r in b100)
+    assert "geo_b50_i32_freecool_julHW" not in ids
+    best = pick_best_g14_run(b100)
+    assert best is not None
+    assert best["run_id"] == "geo_b100_6stack_shape_r56_sched_mild"
+    assert best["pass_fail"] == "PASS"
+
+    fig = g14_epoch_figure(b100, building_family="geo_b100")
+    customdatas = []
+    for t in fig.data:
+        cd = getattr(t, "customdata", None)
+        if cd is not None:
+            customdatas.extend([str(x) for x in cd if x])
+    hover_blob = " ".join(
+        str(getattr(t, "text", "") or "")
+        + " "
+        + " ".join(str(x) for x in (getattr(t, "customdata", None) or []))
+        for t in fig.data
+    )
+    assert "geo_b100_6stack_shape_r56_sched_mild" in hover_blob
+    assert "geo_b50_i32" not in hover_blob
+    assert "geo_b50" not in hover_blob
+    legend_names = [getattr(t, "name", "") or "" for t in fig.data]
+    assert any(n == "G14 PASS" for n in legend_names)
+
+    # Mixed / unfiltered still returns both families (explicit All path)
+    mixed = iter_g14_history(runs, limit=80)
+    mixed_ids = {r["run_id"] for r in mixed}
+    assert "geo_b50_i32_freecool_julHW" in mixed_ids
+    assert "geo_b100_6stack_shape_r56_sched_mild" in mixed_ids
 
 
 def test_build_dial_knobs_rows(tmp_path: Path):

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_LOOP.md
@@ -172,6 +172,11 @@ Always publish `model.idf` and dial/geo meta into `runs/<id>/`. Twin panes follo
 “model reference/default” — never claim ASHRAE 90.1 compliance from defaults alone.
 ECMs default the baseline Twin run to best G14 (`pick_best_g14_run`); override via
 `studio_ecm_baseline_run`.
+Studio **Calibration iterations (G14)** scopes the table + epoch chart to the
+active Twin building family (`geo_b100_*` vs `geo_b50_*`, from `CURRENT_RUN` /
+Building filter). Iteration index is **per-building dial history**, not a global
+mtime mix across campus. Hover shows full `run_id`; best callout is
+`pick_best_g14_run` within the filter.
 
 ## Docker turnkey (Studio + EnergyPlus MCP image)
 

--- a/vibe_code_apps_20/wattlab/studio/ep_viz.py
+++ b/vibe_code_apps_20/wattlab/studio/ep_viz.py
@@ -360,15 +360,29 @@ def read_run_progress(run_dir: Path) -> dict[str, Any]:
     return out
 
 
-def list_iteration_runs(runs_root: Path, limit: int = 20) -> list[dict[str, Any]]:
+def list_iteration_runs(
+    runs_root: Path,
+    limit: int = 20,
+    *,
+    prefix: str | None = None,
+) -> list[dict[str, Any]]:
+    """List newest published ``runs/<id>/`` dirs (mtime descending).
+
+    When ``prefix`` is set (e.g. ``geo_b100``), only run ids whose directory name
+    starts with that prefix are returned — scan continues until ``limit`` matches
+    or dirs are exhausted (so B50 dial spam does not crowd out B100 history).
+    """
     from wattlab.energyplus.timeseries import find_eplusout_csv
 
     root = Path(runs_root)
     if not root.is_dir():
         return []
+    want = (prefix or "").strip().lower() or None
     rows: list[dict[str, Any]] = []
     for d in sorted(root.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
         if not d.is_dir() or d.name.startswith("_"):
+            continue
+        if want and not d.name.lower().startswith(want):
             continue
         info = read_run_progress(d)
         info["dir"] = str(d)

--- a/vibe_code_apps_20/wattlab/studio/g14_history.py
+++ b/vibe_code_apps_20/wattlab/studio/g14_history.py
@@ -1,8 +1,14 @@
-"""G14 calibration history across published Twin runs (epoch / loss-style chart)."""
+"""G14 calibration history across published Twin runs (epoch / loss-style chart).
+
+Iteration index is **per-building dial history** (e.g. ``geo_b100_*``), not a
+global mtime soup mixing B50 and B100. Operators must never read “Iteration N”
+as campus-wide training epoch without a building filter.
+"""
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +17,78 @@ from wattlab.studio.ep_viz import list_iteration_runs, read_run_progress
 
 G14_NMBE_GATE = 5.0
 G14_CVRMSE_GATE = 15.0
+
+# Default scan window when filtering by building family (many B50 dials exist).
+DEFAULT_G14_HISTORY_LIMIT = 80
+# When scanning for family discovery / “all matching prefix”, allow a wide window.
+G14_HISTORY_SCAN_MAX = 500
+
+_BUILDING_FAMILY_RE = re.compile(r"^(geo_b\d+)", re.IGNORECASE)
+_SHORT_STEM_RE = re.compile(r"(?:^|_)(r\d+|i\d+)(?:_|$)", re.IGNORECASE)
+
+
+def building_family_from_run_id(run_id: str | None) -> str | None:
+    """Extract building dial family from a run id.
+
+    Examples::
+        geo_b100_6stack_shape_r56_sched_mild → geo_b100
+        geo_b50_i32_freecool_julHW → geo_b50
+    """
+    if not run_id:
+        return None
+    rid = str(run_id).strip()
+    m = _BUILDING_FAMILY_RE.match(rid)
+    if m:
+        return m.group(1).lower()
+    parts = rid.split("_")
+    if len(parts) >= 2 and parts[0].lower() == "geo" and parts[1].lower().startswith("b"):
+        return f"{parts[0]}_{parts[1]}".lower()
+    return None
+
+
+def run_id_short_stem(run_id: str | None) -> str:
+    """Short dial stem for axis ticks (``r56``, ``i32``); else truncated run_id."""
+    if not run_id:
+        return "?"
+    rid = str(run_id)
+    m = _SHORT_STEM_RE.search(rid)
+    if m:
+        return m.group(1).lower()
+    fam = building_family_from_run_id(rid)
+    if fam and rid.lower().startswith(fam):
+        rest = rid[len(fam) :].lstrip("_")
+        return (rest[:16] if rest else fam) or rid[-12:]
+    return rid[-12:]
+
+
+def discover_building_families(runs_root: Path | str, *, limit: int = G14_HISTORY_SCAN_MAX) -> list[str]:
+    """Sorted unique ``geo_bNN`` families present under ``runs/``."""
+    found: set[str] = set()
+    for h in list_iteration_runs(Path(runs_root), limit=limit):
+        fam = building_family_from_run_id(h.get("run_id") or Path(str(h.get("dir") or "")).name)
+        if fam:
+            found.add(fam)
+    return sorted(found)
+
+
+def filter_rows_by_building_family(
+    rows: list[dict[str, Any]],
+    family: str | None,
+) -> list[dict[str, Any]]:
+    """Keep rows whose run_id matches ``family`` (e.g. ``geo_b100``).
+
+    ``family`` None / empty / ``all`` → no filter (mixed campus — avoid for charts).
+    """
+    if not family or str(family).strip().lower() in {"all", "*", "(all)"}:
+        return list(rows)
+    want = str(family).strip().lower()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        rid = r.get("run_id") or (Path(str(r["dir"])).name if r.get("dir") else None)
+        fam = building_family_from_run_id(str(rid) if rid else None)
+        if fam == want:
+            out.append(r)
+    return out
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -32,7 +110,6 @@ def _g14_from_scorecard(data: dict[str, Any]) -> dict[str, Any]:
         stats_e = {}
     if not isinstance(stats_g, dict):
         stats_g = {}
-    # Some stamps put nmbe at top level
     out = {
         "nmbe_elec_pct": stats_e.get("nmbe_pct", data.get("nmbe_elec_pct")),
         "cvrmse_elec_pct": stats_e.get("cvrmse_pct", data.get("cvrmse_elec_pct")),
@@ -60,16 +137,32 @@ def extract_run_g14(run_dir: Path | str | None) -> dict[str, Any]:
     return {}
 
 
-def iter_g14_history(runs_root: Path | str, *, limit: int = 30) -> list[dict[str, Any]]:
-    """Return chronological G14 rows for published runs (oldest → newest)."""
+def iter_g14_history(
+    runs_root: Path | str,
+    *,
+    limit: int = DEFAULT_G14_HISTORY_LIMIT,
+    building_family: str | None = None,
+    prefix: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return chronological G14 rows for published runs (oldest → newest).
+
+    When ``building_family`` or ``prefix`` is set (e.g. ``geo_b100``), only matching
+    run ids are kept and iteration renumbering is per-family dial history.
+    """
+    fam = (building_family or prefix or "").strip() or None
+    # Scan widely when filtering so older B100 runs are not crowded out by B50 dials.
+    scan_limit = max(limit, G14_HISTORY_SCAN_MAX) if fam else limit
     rows: list[dict[str, Any]] = []
-    for h in list_iteration_runs(Path(runs_root), limit=limit):
+    for h in list_iteration_runs(Path(runs_root), limit=scan_limit, prefix=fam):
         d = Path(str(h["dir"])) if h.get("dir") else None
+        rid = h.get("run_id") or (d.name if d else None)
         g14 = extract_run_g14(d)
         prog = read_run_progress(d) if d else {}
         rows.append(
             {
-                "run_id": h.get("run_id"),
+                "run_id": rid,
+                "building_family": building_family_from_run_id(str(rid) if rid else None),
+                "short_stem": run_id_short_stem(str(rid) if rid else None),
                 "dir": str(d) if d else None,
                 "started_at": h.get("started_at") or prog.get("started_at"),
                 "finished_at": h.get("finished_at") or prog.get("finished_at"),
@@ -82,6 +175,9 @@ def iter_g14_history(runs_root: Path | str, *, limit: int = 30) -> list[dict[str
             }
         )
 
+    if fam:
+        rows = filter_rows_by_building_family(rows, fam)
+
     def _sort_key(r: dict[str, Any]) -> tuple:
         ts = r.get("started_at") or ""
         if ts:
@@ -90,11 +186,14 @@ def iter_g14_history(runs_root: Path | str, *, limit: int = 30) -> list[dict[str
         return (1, float(mt) if mt is not None else 0.0, str(r.get("run_id") or ""))
 
     rows.sort(key=_sort_key)
+    # Cap after filter+sort so chart stays readable
+    if len(rows) > limit:
+        rows = rows[-limit:]
     return rows
 
 
 def assign_run_numbers(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Add chronological ``run`` 1…N (oldest → newest). Mutates copies."""
+    """Add chronological ``run`` 1…N (oldest → newest) within the filtered set."""
     out: list[dict[str, Any]] = []
     for i, r in enumerate(rows, start=1):
         out.append({**r, "run": i})
@@ -134,8 +233,9 @@ def _is_g14_pass(row: dict[str, Any]) -> bool:
 
 
 def pick_best_g14_run(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
-    """Choose best published Twin run for ECM baseline.
+    """Choose best published Twin run for ECM baseline **within the given rows**.
 
+    Callers must pass building-filtered rows; this never mixes B50 with B100.
     Prefer G14 PASS; else minimize |NMBE|+CVRMSE (elec, plus gas when present).
     """
     if not rows:
@@ -154,8 +254,17 @@ def pick_best_g14_run(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
     return min(candidates, key=_g14_error_score)
 
 
-def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
-    """Plot |NMBE| and CV(RMSE) vs iteration index (training-loss style)."""
+def g14_epoch_figure(
+    rows: list[dict[str, Any]],
+    *,
+    height: int = 440,
+    building_family: str | None = None,
+):
+    """Plot |NMBE| and CV(RMSE) vs per-building iteration index.
+
+    X-axis ticks use short stems (``r56``, ``i32``); hover shows full ``run_id``
+    and building family. G14 PASS points get star markers + annotation.
+    """
     import plotly.graph_objects as go
 
     usable = [
@@ -163,10 +272,17 @@ def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
         for r in rows
         if r.get("nmbe_elec_pct") is not None or r.get("cvrmse_elec_pct") is not None
     ]
+    fam_label = building_family or (
+        usable[0].get("building_family") if usable else None
+    )
+    title_suffix = f" · {fam_label}" if fam_label else ""
     fig = go.Figure()
     if not usable:
         fig.add_annotation(
-            text="No per-run G14 scorecards yet — publish calibration_scorecard.json with each Twin run.",
+            text=(
+                "No per-run G14 scorecards for this building filter — "
+                "publish calibration_scorecard.json with each Twin run."
+            ),
             xref="paper",
             yref="paper",
             x=0.5,
@@ -175,20 +291,27 @@ def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
         )
         return plotly_layout_clean(
             fig,
-            title="G14 calibration across iterations",
+            title=f"G14 calibration across iterations{title_suffix}",
             height=height,
             yaxis_title="% error",
         )
 
-    xs = list(range(1, len(usable) + 1))
-    hover = [
-        f"{r.get('run_id')}<br>{r.get('started_at') or ''}<br>{(r.get('hypothesis') or '')[:80]}"
-        for r in usable
-    ]
+    numbered = usable if all("run" in r for r in usable) else assign_run_numbers(list(usable))
+    xs = [int(r.get("run") or i) for i, r in enumerate(numbered, start=1)]
+    ticktext = [str(r.get("short_stem") or run_id_short_stem(r.get("run_id"))) for r in numbered]
+    hover = []
+    for r in numbered:
+        rid = r.get("run_id") or "?"
+        bf = r.get("building_family") or building_family_from_run_id(str(rid)) or "?"
+        g14 = str(r.get("pass_fail") or "—")
+        hover.append(
+            f"<b>{rid}</b><br>building={bf}<br>G14={g14}<br>"
+            f"{r.get('started_at') or ''}<br>{(r.get('hypothesis') or '')[:80]}"
+        )
 
     def _abs_series(key: str) -> list[float | None]:
         out: list[float | None] = []
-        for r in usable:
+        for r in numbered:
             v = r.get(key)
             try:
                 out.append(abs(float(v)) if v is not None else None)
@@ -202,7 +325,8 @@ def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
         mode="lines+markers",
         name="|NMBE| elec %",
         text=hover,
-        hovertemplate="iter %{x}<br>%{text}<br>|NMBE| %{y:.2f}%<extra></extra>",
+        customdata=[r.get("run_id") for r in numbered],
+        hovertemplate="%{text}<br>iter %{x}<br>|NMBE| %{y:.2f}%<extra></extra>",
         line=dict(color="#1f77b4", width=2),
     )
     fig.add_scatter(
@@ -211,32 +335,77 @@ def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
         mode="lines+markers",
         name="CV(RMSE) elec %",
         text=hover,
-        hovertemplate="iter %{x}<br>%{text}<br>CVRMSE %{y:.2f}%<extra></extra>",
+        customdata=[r.get("run_id") for r in numbered],
+        hovertemplate="%{text}<br>iter %{x}<br>CVRMSE %{y:.2f}%<extra></extra>",
         line=dict(color="#ff7f0e", width=2),
     )
-    if any(r.get("nmbe_gas_pct") is not None for r in usable):
+    if any(r.get("nmbe_gas_pct") is not None for r in numbered):
         fig.add_scatter(
             x=xs,
             y=_abs_series("nmbe_gas_pct"),
             mode="lines+markers",
             name="|NMBE| gas %",
             text=hover,
-            hovertemplate="iter %{x}<br>%{text}<br>|NMBE| gas %{y:.2f}%<extra></extra>",
+            hovertemplate="%{text}<br>iter %{x}<br>|NMBE| gas %{y:.2f}%<extra></extra>",
             line=dict(color="#2ca02c", width=2, dash="dot"),
         )
-    if any(r.get("cvrmse_gas_pct") is not None for r in usable):
+    if any(r.get("cvrmse_gas_pct") is not None for r in numbered):
         fig.add_scatter(
             x=xs,
             y=_abs_series("cvrmse_gas_pct"),
             mode="lines+markers",
             name="CV(RMSE) gas %",
             text=hover,
-            hovertemplate="iter %{x}<br>%{text}<br>CVRMSE gas %{y:.2f}%<extra></extra>",
+            hovertemplate="%{text}<br>iter %{x}<br>CVRMSE gas %{y:.2f}%<extra></extra>",
             line=dict(color="#9467bd", width=2, dash="dot"),
         )
 
-    # ASHRAE G14 monthly gates — as legend traces (add_hline annotations alone
-    # do not appear in the Plotly legend and look like anonymous dashboard lines).
+    # Highlight G14 PASS points on CVRMSE series (most visible “success” metric)
+    pass_x: list[int] = []
+    pass_y: list[float] = []
+    pass_text: list[str] = []
+    for r, x in zip(numbered, xs, strict=False):
+        if not _is_g14_pass(r):
+            continue
+        try:
+            y = abs(float(r["cvrmse_elec_pct"])) if r.get("cvrmse_elec_pct") is not None else None
+        except (TypeError, ValueError):
+            y = None
+        if y is None:
+            try:
+                y = abs(float(r["nmbe_elec_pct"])) if r.get("nmbe_elec_pct") is not None else None
+            except (TypeError, ValueError):
+                y = None
+        if y is None:
+            continue
+        pass_x.append(int(x))
+        pass_y.append(y)
+        pass_text.append(str(r.get("run_id") or ""))
+    if pass_x:
+        fig.add_scatter(
+            x=pass_x,
+            y=pass_y,
+            mode="markers+text",
+            name="G14 PASS",
+            text=["PASS"] * len(pass_x),
+            textposition="top center",
+            marker=dict(symbol="star", size=14, color="#2ca02c", line=dict(width=1, color="#145214")),
+            customdata=pass_text,
+            hovertemplate="<b>%{customdata}</b><br>G14 PASS<br>iter %{x}<extra></extra>",
+        )
+
+    best = pick_best_g14_run(numbered)
+    if best and best.get("run") is not None:
+        fig.add_annotation(
+            x=int(best["run"]),
+            y=0,
+            yref="y domain",
+            text=f"best: {best.get('run_id')}",
+            showarrow=False,
+            yanchor="bottom",
+            font=dict(size=11),
+        )
+
     x0, x1 = xs[0], xs[-1]
     fig.add_scatter(
         x=[x0, x1],
@@ -259,10 +428,10 @@ def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
 
     plotly_layout_clean(
         fig,
-        title="G14 calibration across iterations (lower is better)",
+        title=f"G14 calibration across iterations{title_suffix} (per-building dial history)",
         height=height,
         yaxis_title="% error",
-        xaxis_title="Iteration (oldest → newest)",
+        xaxis_title="Iteration (oldest → newest) · tick = dial stem (hover = full run_id)",
     )
     fig.update_layout(
         legend=dict(
@@ -274,6 +443,12 @@ def g14_epoch_figure(rows: list[dict[str, Any]], *, height: int = 440):
             x=0,
         ),
     )
-    fig.update_xaxes(dtick=1, showgrid=True, gridcolor="rgba(0,0,0,0.06)")
+    fig.update_xaxes(
+        tickmode="array",
+        tickvals=xs,
+        ticktext=ticktext,
+        showgrid=True,
+        gridcolor="rgba(0,0,0,0.06)",
+    )
     fig.update_yaxes(rangemode="tozero", showgrid=True, gridcolor="rgba(0,0,0,0.08)")
     return fig

--- a/vibe_code_apps_20/wattlab/studio/g14_history.py
+++ b/vibe_code_apps_20/wattlab/studio/g14_history.py
@@ -62,12 +62,28 @@ def run_id_short_stem(run_id: str | None) -> str:
 
 
 def discover_building_families(runs_root: Path | str, *, limit: int = G14_HISTORY_SCAN_MAX) -> list[str]:
-    """Sorted unique ``geo_bNN`` families present under ``runs/``."""
+    """Sorted unique ``geo_bNN`` families present under ``runs/``.
+
+    Directory-name scan only (no scorecard / eplusout I/O).
+    """
+    root = Path(runs_root)
+    if not root.is_dir():
+        return []
     found: set[str] = set()
-    for h in list_iteration_runs(Path(runs_root), limit=limit):
-        fam = building_family_from_run_id(h.get("run_id") or Path(str(h.get("dir") or "")).name)
+    n = 0
+    try:
+        dirs = sorted(root.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True)
+    except OSError:
+        return []
+    for d in dirs:
+        if not d.is_dir() or d.name.startswith("_"):
+            continue
+        fam = building_family_from_run_id(d.name)
         if fam:
             found.add(fam)
+        n += 1
+        if n >= limit:
+            break
     return sorted(found)
 
 
@@ -89,6 +105,16 @@ def filter_rows_by_building_family(
         if fam == want:
             out.append(r)
     return out
+
+
+def _normalize_building_family(family: str | None) -> str | None:
+    """Return a concrete family prefix, or None for no filter (incl. all sentinels)."""
+    if not family:
+        return None
+    s = str(family).strip()
+    if not s or s.lower() in {"all", "*", "(all)"}:
+        return None
+    return s
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -149,7 +175,7 @@ def iter_g14_history(
     When ``building_family`` or ``prefix`` is set (e.g. ``geo_b100``), only matching
     run ids are kept and iteration renumbering is per-family dial history.
     """
-    fam = (building_family or prefix or "").strip() or None
+    fam = _normalize_building_family(building_family or prefix)
     # Scan widely when filtering so older B100 runs are not crowded out by B50 dials.
     scan_limit = max(limit, G14_HISTORY_SCAN_MAX) if fam else limit
     rows: list[dict[str, Any]] = []
@@ -297,6 +323,8 @@ def g14_epoch_figure(
         )
 
     numbered = usable if all("run" in r for r in usable) else assign_run_numbers(list(usable))
+    # Same pool as caption / pick_best: only rows with elec metrics (usable).
+    best = pick_best_g14_run(numbered)
     xs = [int(r.get("run") or i) for i, r in enumerate(numbered, start=1)]
     ticktext = [str(r.get("short_stem") or run_id_short_stem(r.get("run_id"))) for r in numbered]
     hover = []
@@ -394,7 +422,6 @@ def g14_epoch_figure(
             hovertemplate="<b>%{customdata}</b><br>G14 PASS<br>iter %{x}<extra></extra>",
         )
 
-    best = pick_best_g14_run(numbered)
     if best and best.get("run") is not None:
         fig.add_annotation(
             x=int(best["run"]),

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -946,7 +946,22 @@ def render() -> None:
                 )
 
         try:
-            hist_rows = assign_run_numbers(iter_g14_history(runs_dir(), limit=20))
+            from wattlab.studio.g14_history import (
+                DEFAULT_G14_HISTORY_LIMIT,
+                building_family_from_run_id,
+            )
+
+            _active_for_hist = _resolve_active_run()
+            _fam_hist = building_family_from_run_id(
+                _active_for_hist.name if _active_for_hist else None
+            )
+            hist_rows = assign_run_numbers(
+                iter_g14_history(
+                    runs_dir(),
+                    limit=DEFAULT_G14_HISTORY_LIMIT,
+                    building_family=_fam_hist,
+                )
+            )
         except Exception:
             hist_rows = []
         if len(hist_rows) >= 2:
@@ -1113,9 +1128,18 @@ def render() -> None:
         st.subheader("Iteration history (agent + Studio)")
         st.caption(
             "Each published `runs/<id>/` after agent/CLI EnergyPlus. "
-            "Timestamps from `run_manifest.json`. G14 columns need `calibration_scorecard.json` per run."
+            "Timestamps from `run_manifest.json`. G14 columns need `calibration_scorecard.json` per run. "
+            "**Iteration index is per-building dial history** (e.g. geo_b100_*), not a global mtime mix of B50+B100."
         )
-        from wattlab.studio.g14_history import assign_run_numbers, g14_epoch_figure, iter_g14_history
+        from wattlab.studio.g14_history import (
+            DEFAULT_G14_HISTORY_LIMIT,
+            assign_run_numbers,
+            building_family_from_run_id,
+            discover_building_families,
+            g14_epoch_figure,
+            iter_g14_history,
+            pick_best_g14_run,
+        )
         from wattlab.studio.model_summary import (
             build_assumption_rows,
             build_dial_knobs_rows,
@@ -1123,8 +1147,44 @@ def render() -> None:
             render_model_summary_panel,
         )
 
-        hist = list_iteration_runs(runs_dir(), limit=30)
-        if not hist:
+        active_now = _resolve_active_run()
+        active_fam = building_family_from_run_id(active_now.name if active_now else None)
+        families = discover_building_families(runs_dir())
+        filter_opts: list[str] = []
+        if active_fam:
+            filter_opts.append(active_fam)
+        for fam in families:
+            if fam not in filter_opts:
+                filter_opts.append(fam)
+        filter_opts.append("All")
+        # Default = active building family (not All). Persist via widget key.
+        if "twin_g14_building_filter" not in st.session_state:
+            st.session_state["twin_g14_building_filter"] = filter_opts[0]
+        elif st.session_state["twin_g14_building_filter"] not in filter_opts:
+            st.session_state["twin_g14_building_filter"] = filter_opts[0]
+        chosen_filter = st.selectbox(
+            "Building filter",
+            options=filter_opts,
+            key="twin_g14_building_filter",
+            help=(
+                "Scopes table + G14 chart to one building family. "
+                "Default follows CURRENT_RUN / active Twin run. "
+                "All mixes campus runs — do not read as one training curve."
+            ),
+        )
+        fam_filter = None if chosen_filter == "All" else chosen_filter
+        if chosen_filter == "All":
+            st.warning(
+                "Building filter = All mixes geo_b50_* and geo_b100_* (etc.). "
+                "Iteration numbers are **not** a single training curve — use a building filter for dial history."
+            )
+
+        hist = list_iteration_runs(
+            runs_dir(),
+            limit=DEFAULT_G14_HISTORY_LIMIT,
+            prefix=fam_filter,
+        )
+        if not hist and fam_filter is None:
             manifests = sorted(ARTIFACTS.glob("wattlab_*/run_manifest.json"), reverse=True)[:10]
             for mp in manifests:
                 try:
@@ -1144,10 +1204,23 @@ def render() -> None:
                 except Exception:
                     continue
         if not hist:
-            st.caption("No prior runs in workspace runs/.")
+            st.caption(
+                f"No prior runs in workspace runs/ for filter `{chosen_filter}`."
+                if fam_filter
+                else "No prior runs in workspace runs/."
+            )
         else:
-            st.metric("Published iterations shown", len(hist))
-            g14_rows = assign_run_numbers(iter_g14_history(runs_dir(), limit=30))
+            st.metric(
+                f"Published iterations shown ({chosen_filter})",
+                len(hist),
+            )
+            g14_rows = assign_run_numbers(
+                iter_g14_history(
+                    runs_dir(),
+                    limit=DEFAULT_G14_HISTORY_LIMIT,
+                    building_family=fam_filter,
+                )
+            )
             g14_by_dir = {str(r.get("dir")): r for r in g14_rows if r.get("dir")}
 
             def _hist_sort_key(h: dict[str, Any]) -> tuple:
@@ -1163,10 +1236,13 @@ def render() -> None:
             for i, h in enumerate(hist_chrono, start=1):
                 dkey = str(h.get("dir") or "")
                 g = g14_by_dir.get(dkey) or {}
+                rid = h.get("run_id") or (Path(dkey).name if dkey else None)
                 row = {
                     "run": g.get("run") or i,
                     "started_at": h.get("started_at") or g.get("started_at"),
-                    "run_id": h.get("run_id"),
+                    "run_id": rid,
+                    "building": g.get("building_family")
+                    or building_family_from_run_id(str(rid) if rid else None),
                     "hypothesis": h.get("hypothesis"),
                     "weather": h.get("weather_mode"),
                     "status": h.get("status"),
@@ -1200,6 +1276,7 @@ def render() -> None:
                     "run",
                     "started_at",
                     "run_id",
+                    "building",
                     "hypothesis",
                     "status",
                     "eplusout",
@@ -1222,23 +1299,31 @@ def render() -> None:
                 hide_index=True,
             )
 
+            best_in_filter = pick_best_g14_run(g14_rows)
+            if best_in_filter and best_in_filter.get("run_id"):
+                st.caption(
+                    f"Best G14 within filter `{chosen_filter}`: "
+                    f"`{best_in_filter.get('run_id')}` "
+                    f"(pass_fail={best_in_filter.get('pass_fail') or '—'})"
+                )
+
             st.markdown("**Calibration iterations (G14)**")
             st.caption(
-                "Like a training-loss curve: each published Twin run is an epoch. "
+                "Per-building dial history (not campus-wide mtime soup). "
                 "Lower |NMBE| / CV(RMSE) is better. "
                 "**Dashed legend entries** are ASHRAE G14 monthly gates "
-                "(±5% |NMBE|, ≤15% CVRMSE) — not extra model series. "
-                "Missing scorecards skip that point. X-axis run # matches the table (oldest → newest)."
+                "(±5% |NMBE|, ≤15% CVRMSE). "
+                "X ticks = dial stem (r56, i32); hover shows full run_id. "
+                "Star markers = G14 PASS. Best callout = pick_best within this filter."
             )
             st.plotly_chart(
-                g14_epoch_figure(g14_rows, height=440),
+                g14_epoch_figure(g14_rows, height=440, building_family=fam_filter),
                 width="stretch",
                 key="twin_g14_epoch",
             )
 
             pick_opts = [h.get("dir") for h in hist_chrono if h.get("dir")]
             run_by_dir = {str(r.get("dir")): r for r in enriched if r.get("dir")}
-            active_now = _resolve_active_run()
             default_ix = 0
             if active_now is not None:
                 active_s = str(active_now.resolve()) if active_now.exists() else str(active_now)

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -1157,18 +1157,21 @@ def render() -> None:
             if fam not in filter_opts:
                 filter_opts.append(fam)
         filter_opts.append("All")
-        # Default = active building family (not All). Persist via widget key.
+        # Default = active building family when known; otherwise All (do not
+        # silently pick an unrelated geo_b* family for a non-geo active run).
+        default_filter = active_fam if active_fam else "All"
         if "twin_g14_building_filter" not in st.session_state:
-            st.session_state["twin_g14_building_filter"] = filter_opts[0]
+            st.session_state["twin_g14_building_filter"] = default_filter
         elif st.session_state["twin_g14_building_filter"] not in filter_opts:
-            st.session_state["twin_g14_building_filter"] = filter_opts[0]
+            st.session_state["twin_g14_building_filter"] = default_filter
         chosen_filter = st.selectbox(
             "Building filter",
             options=filter_opts,
             key="twin_g14_building_filter",
             help=(
                 "Scopes table + G14 chart to one building family. "
-                "Default follows CURRENT_RUN / active Twin run. "
+                "Default follows CURRENT_RUN / active Twin run when it has a "
+                "geo_bNN_ prefix; otherwise All. "
                 "All mixes campus runs — do not read as one training curve."
             ),
         )
@@ -1221,6 +1224,12 @@ def render() -> None:
                     building_family=fam_filter,
                 )
             )
+            # Align caption best with chart: only rows that have elec G14 metrics
+            g14_chart_rows = [
+                r
+                for r in g14_rows
+                if r.get("nmbe_elec_pct") is not None or r.get("cvrmse_elec_pct") is not None
+            ]
             g14_by_dir = {str(r.get("dir")): r for r in g14_rows if r.get("dir")}
 
             def _hist_sort_key(h: dict[str, Any]) -> tuple:
@@ -1299,7 +1308,7 @@ def render() -> None:
                 hide_index=True,
             )
 
-            best_in_filter = pick_best_g14_run(g14_rows)
+            best_in_filter = pick_best_g14_run(g14_chart_rows)
             if best_in_filter and best_in_filter.get("run_id"):
                 st.caption(
                     f"Best G14 within filter `{chosen_filter}`: "


### PR DESCRIPTION
## Summary
- Scope Twin/calibrate G14 epoch chart + iterations table to the active Twin building family (`geo_b100_*` vs `geo_b50_*`), with a Studio **Building filter** (default = active / `CURRENT_RUN`, not All).
- X ticks use dial stems (`r56`, `i32`); hover shows full `run_id` + building; G14 PASS starred; best callout = `pick_best_g14_run` **within filter**.
- Raise history window to 80 (scan up to 500 when filtered) so B50 dial spam does not crowd out B100.
- Regression test: mixed fake `runs/` → B100 chart excludes B50 `i32`; best PASS is `geo_b100_…_r56_…`.
- **open-fdd:** no `g14_epoch_figure` / Twin calibrate UI today (vibe20-only); combined product inherits this when Studio is shared — no duplicate bug to patch in open-fdd tree.

## Docs
Iteration index is **per-building dial history**, not a global mtime soup mixing B50+B100. Do not “fix” by deleting B50 runs.

## Test plan
- [x] `pytest tests/test_twin_g14_model_summary.py` in vibe20 image (6 passed)
- [ ] Liberty workspace with both `geo_b50_*` and `geo_b100_*`: Building filter = geo_b100 never plots B50 points
- [ ] Hover on PASS shows `geo_b100_6stack_shape_r56_sched_mild`
- [ ] After merge: tip GHCR `vibe20` refresh + recreate Studio container


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added building-family filtering for Twin calibration iteration history.
  - Updated iteration tables and charts to show per-building dial history.
  - Added clearer run identifiers, building labels, and full run details on hover.
  - Highlighted the best passing G14 run within the selected filter.
  - Added an “All” option with guidance when viewing unfiltered results.

- **Documentation**
  - Clarified building-scoped iteration numbering, filtering, and best-run selection.

- **Tests**
  - Added coverage for building-family parsing and chart filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->