### PR TITLE
docs: sync ECM spreadsheet↔E+ bug register (vibe19+20)

### DIFF
--- a/vibe_code_apps_19/vibe19_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
@@ -1,22 +1,77 @@
 # BUG_REPORT — ECM spreadsheet ↔ EnergyPlus / Studio
 
-**Pointer (vibe19):** FDD dumps from vibe19 feed WattLab Twin / ECM Excel in vibe20 and the combined open-fdd product. The authoritative bug + enhancement register lives in both places and must stay identical:
-
-| Repo | Path |
-|------|------|
-| playground vibe20 | [`../../../vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`](../../../vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md) |
-| open-fdd | https://github.com/bbartling/open-fdd/blob/master/docs/migration/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md |
-
 **Date:** 2026-07-29  
 **Twin SoT:** `geo_b100_6stack_shape_r56_sched_mild` (G14 PASS)  
+**Artifacts (not bugs):** `reports/notebooks/full_parity_ecm/ECM_FULL_PARITY.xlsx` · `reports/ecm_full_parity_compare.json` · `tools/build_full_parity_ecm_workbook.py`
+
+**Git SoT (keep in sync):**
+- playground vibe20: `vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`
+- open-fdd (combined product): `docs/migration/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`
+- vibe19 pointer: `vibe_code_apps_19/vibe19_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`
+
+Workspace copies of artifacts live under Studio `/data` (`wattlab_workspace/reports/…`). Do not commit client workbooks to git.
+
 Screening proof (full-parity book): **8 BALLPARK / 0 DIVERGE / 0 NO_EP** — not M&V.
 
-## Status snapshot (do not drift)
+Twin / WattLab Studio / EnergyPlus patch + notebook builder code primarily lives in playground **vibe20**. open-fdd Jobs / ECM honesty (`honesty.openfdd`, cascade-if-ready) must stay aligned with this register when the combined UI surfaces Compare / ECMs.
 
-| Bucket | IDs |
-|--------|-----|
-| Open / partial | BUG-ECM-001…007, 010…012, 014, 015 |
-| Fixed | BUG-ECM-008 (G14 per-building chart, playground #65), BUG-ECM-009; 013 → ENH-ECM-009 |
-| Enhancements | ENH-ECM-001…010 (008 Done with #65) |
+---
 
-When fixing Studio / ECM / Compare in vibe20, update **open-fdd** and this pointer in the same change set whenever the combined product shares the UI or Jobs ECM path. No container refresh until the follow-on ECM product PRs land.
+## Open bugs
+
+| ID | Status | Summary |
+|----|--------|---------|
+| **BUG-ECM-001** | Open | Compare CLI exists; still no rewrite of Compare sheet **inside** agent xlsx; no demand (kW) columns in Compare contract. |
+| **BUG-ECM-002** | Open | `FORMULA_ESCO_*` map incomplete for econ / CHW reset / load-shed **kW**; full-parity book bypasses with MCP-calibrated Inputs. |
+| **BUG-ECM-003** | Open | Dump / Twin / eio sizing + FLH not auto-applied on `wattlab notebook agent-build` (manual builders exist). |
+| **BUG-ECM-004** | Open | Polished `g36_airside_controls` package ignores `--ecms`. |
+| **BUG-ECM-005** | Partial | Registry still missing product patches for enthalpy econ / CHW OA reset / true occ-standby. MCP prototypes work (`prototype_no_ep_eplus_patches.py`) but are **not** in `wattlab.energyplus.patches.registry`. Per-VAV occ impossible on 1-zone/floor Twin. |
+| **BUG-ECM-006** | Open | Cascade measure set ⊂ workbook set — Studio / Compare must keep `NO_EP` honest when registry lacks a patch (do not invent E+ kWh). |
+| **BUG-ECM-007** | Open | Agent Excel lacks ±50% honesty / BALLPARK column vs E+. |
+| **BUG-ECM-010** | Open | Agents skip EnergyPlus-MCP and re-read old cascade when enhancing sims (process). |
+| **BUG-ECM-011** | Open | Demand (kW) missing from py → Excel / Studio Compare API. |
+| **BUG-ECM-012** | Partial | Load-shed DR not in product agent Excel / cascade; workaround tool `load_shed_demand_screen.py` exists. |
+| **BUG-ECM-014** | Open (doc) | Calendar FanAvail / OAT-bin hours ≠ formula FLH. Pasting calendar into Inputs over-predicts vs E+. Fix: Matchup calendar + FLH Inputs (`build_eplus_matched_ecm_workbook.py` / full-parity builder). |
+| **BUG-ECM-015** | Open | Studio **ECMs** tab does not show full-parity sheet↔E+ results. Page uses `reports/ecm_compare.json` with spreadsheet side `pending_external`; agent xlsx retired; legacy download only globs top-level `notebooks/*.xlsx` (misses `full_parity_ecm/`). |
+
+---
+
+## Fixed
+
+| ID | Notes |
+|----|-------|
+| **BUG-ECM-008** | Studio G14 iteration chart mixed B50 + B100 — fixed in playground [#65](https://github.com/bbartling/py-bacnet-stacks-playground/pull/65) (`7b26df9`). Per-building dial history + Building filter; best picker scoped within filter. Combined open-fdd Studio must keep the same rule when Twin UI is shared. |
+| **BUG-ECM-009** | `score_g14_monthly` writes elec + gas absolutes (tools). |
+| **BUG-ECM-013** | Reclassified as **ENH-ECM-009** (flexible `vav_ahu_controls` package / process — not a defect). |
+
+---
+
+## Enhancements
+
+| ID | Priority | Ask |
+|----|----------|-----|
+| **ENH-ECM-001** | High | Wire full-parity Compare into Studio ECMs: populate `ecm_compare.json` `ss_*` + `ep_*` from `ecm_full_parity_compare.json` (or rebuild path) so the Streamlit table shows the 8-measure ballpark. |
+| **ENH-ECM-002** | High | Promote MCP prototypes (enthalpy econ, CHW OA reset, occ floor proxy) into product patch registry + cascade. |
+| **ENH-ECM-003** | High | Auto on `agent-build`: eio tons/fan HP + Twin AMY calendar + FLH Inputs (collapse BUG-ECM-003). |
+| **ENH-ECM-004** | Med | Write Compare status / ±50% honesty back into xlsx Compare sheet (BUG-ECM-001 / 007). |
+| **ENH-ECM-005** | Med | Demand + load-shed columns in Excel + Studio (BUG-ECM-011 / 012); default DR fraction from July MCP pair (~0.13 on B100 r56). |
+| **ENH-ECM-006** | Med | Nested notebook picker / download under `reports/notebooks/**` (or promote `ECM_FULL_PARITY.xlsx` to product path). |
+| **ENH-ECM-007** | Med | Honor `--ecms` on `g36_airside_controls` (BUG-ECM-004). |
+| **ENH-ECM-008** | Done | Filter Studio G14 chart / best-run picker by building — shipped with BUG-ECM-008 / [#65](https://github.com/bbartling/py-bacnet-stacks-playground/pull/65). |
+| **ENH-ECM-009** | Low | Default package builds from `VAV_AHU_CONTROLS_ECM_PACKAGE.json` (was BUG-ECM-013 — process/enhancement, not a defect). |
+| **ENH-ECM-010** | Low | Skills / `AGENT_CONTEXT` / companion doc prefer full-parity workbook + FLH rules (keep in sync with this file). |
+
+---
+
+## Out of scope here
+
+- vibe19/20 ops BUG-061–064 (tip through `56f6e7b`+)
+- open-fdd SQL ↔ pandas parity
+- Investment-grade M&V / IPMVP
+- Container / GHCR refresh (deferred — more ECM work coming)
+
+---
+
+## Sync rule
+
+Product fixes for Twin / Studio / ECM Excel in **vibe20** must be mirrored or tracked in **open-fdd** (combined product) and noted from **vibe19** agent docs when FDD dumps feed the same ECM path. Do not leave this register drift between repos.

--- a/vibe_code_apps_19/vibe19_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
@@ -1,0 +1,22 @@
+# BUG_REPORT — ECM spreadsheet ↔ EnergyPlus / Studio
+
+**Pointer (vibe19):** FDD dumps from vibe19 feed WattLab Twin / ECM Excel in vibe20 and the combined open-fdd product. The authoritative bug + enhancement register lives in both places and must stay identical:
+
+| Repo | Path |
+|------|------|
+| playground vibe20 | [`../../../vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`](../../../vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md) |
+| open-fdd | https://github.com/bbartling/open-fdd/blob/master/docs/migration/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md |
+
+**Date:** 2026-07-29  
+**Twin SoT:** `geo_b100_6stack_shape_r56_sched_mild` (G14 PASS)  
+Screening proof (full-parity book): **8 BALLPARK / 0 DIVERGE / 0 NO_EP** — not M&V.
+
+## Status snapshot (do not drift)
+
+| Bucket | IDs |
+|--------|-----|
+| Open / partial | BUG-ECM-001…007, 010…012, 014, 015 |
+| Fixed | BUG-ECM-008 (G14 per-building chart, playground #65), BUG-ECM-009; 013 → ENH-ECM-009 |
+| Enhancements | ENH-ECM-001…010 (008 Done with #65) |
+
+When fixing Studio / ECM / Compare in vibe20, update **open-fdd** and this pointer in the same change set whenever the combined product shares the UI or Jobs ECM path. No container refresh until the follow-on ECM product PRs land.

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
@@ -1,230 +1,75 @@
-# BUG_REPORT — ECM spreadsheet API vs EnergyPlus (VAV AHU + demand)
+# BUG_REPORT — ECM spreadsheet ↔ EnergyPlus / Studio
 
 **Date:** 2026-07-29  
-**Focus:** AI agent–driveable ECM Excel (`wattlab notebook agent-build`) vs Twin E+ on Building 100 — **energy + demand**, flexible VAV-AHU package (screenshot list is a **template**, not a hard-coded building).  
-**Twin:** `geo_b100_6stack_shape_r56_sched_mild` (G14 PASS)  
-**Workbook:** `reports/notebooks/liberty_ecm6/05_esco_top15_hvac.xlsx`  
-**Flexible package SoT:** `reports/VAV_AHU_CONTROLS_ECM_PACKAGE.json`  
-**Assumptions (Liberty example):** `reports/LIBERTY_100_ECM6_ASSUMPTIONS.json`  
-**Compare (annual kWh):** `reports/ecm_eplus_vs_spreadsheet_compare.{json,csv}`  
-**Compare (DR demand):** `reports/load_shed_july_peak/load_shed_demand_compare.json`  
-**Tools:** `tools/compare_ecm_eplus_vs_spreadsheet.py`, `tools/load_shed_demand_screen.py`, `tools/BEST_PRACTICES_EPLUS_MCP_ECM.md`
+**Twin SoT:** `geo_b100_6stack_shape_r56_sched_mild` (G14 PASS)  
+**Artifacts (not bugs):** `reports/notebooks/full_parity_ecm/ECM_FULL_PARITY.xlsx` · `reports/ecm_full_parity_compare.json` · `tools/build_full_parity_ecm_workbook.py`
 
-> Workspace copies of the above live under the Studio `/data` volume (`wattlab_workspace/reports/…`). This file is the **git SoT** for BUG-ECM-001…013 so agents and PRs can track without committing client workbooks.
+**Git SoT (keep in sync):**
+- playground vibe20: `vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`
+- open-fdd (combined product): `docs/migration/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`
+- vibe19 pointer: `vibe_code_apps_19/vibe19_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`
 
----
+Workspace copies of artifacts live under Studio `/data` (`wattlab_workspace/reports/…`). Do not commit client workbooks to git.
 
-## Verdict — E+ vs spreadsheet **right now**
-
-| Scope | Result |
-|-------|--------|
-| **Annual kWh** (r56 cascade vs sheet) | **0 BALLPARK / 4 DIVERGE / 3 NO_EP** — sheet still ~3–4× E+ (untuned hours) |
-| **Demand / load-shed** | Sheet nomination **260 kW** (400 t × 0.65); E+ July-24 peak day **~35 kW** mean shed with SAT+zone +3F → **DIVERGE** until `inp_loadshed_kw_fraction≈0.13` |
-| **Flexibility** | Screenshot ECMs = reusable **`vav_ahu_controls`** catalog list; plant Inputs must stay parametric (not Liberty-baked) |
-
-### Annual kWh snapshot
-
-| Measure | Sheet kWh | E+ kWh | Status |
-|---------|-----------|--------|--------|
-| ECON | 134k | — | NO_EP |
-| CHILLER-LOCKOUT | 208k | 56k | DIVERGE |
-| AHU-SCHED | 228k | 35k | DIVERGE |
-| DSP | 114k | 29k | DIVERGE |
-| SAT | 73k | 15k | DIVERGE |
-| CHW-RESET | 70k | — | NO_EP |
-| OCC-STANDBY | 13k | — | NO_EP |
-
-### Demand / DR load-shed snapshot (2025-07-24 Thu, 14:00–16:00)
-
-| Side | ΔkW | Event kWh | Notes |
-|------|-----|-----------|-------|
-| Spreadsheet (fraction=1) | **260** | 520 | = `tons × kW/ton` (chiller size proxy / DR nomination) |
-| E+ (EnergyPlus-MCP DinD) | **~35** | ~70 | Zone Clg SP **and** VAV SAT +3°F; zone-only SP was **no-op** (MAT ~22°C ≪ 24°C Clg SP) |
-| Calibrated sheet fraction | **~0.13** | — | `recommended_inp_loadshed_kw_fraction` in load_shed JSON |
+Screening proof (full-parity book): **8 BALLPARK / 0 DIVERGE / 0 NO_EP** — not M&V.
 
 ---
 
-## VAV-AHU ECM map (screenshot Phase 1–2 + DR — template, not one building)
+## Open bugs
 
-Same catalog IDs for any VAV+AHU office; costs/phases from screenshot are **defaults** in `VAV_AHU_CONTROLS_ECM_PACKAGE.json`.
-
-| # | Operator ECM | Catalog | Sheet today | E+ today |
-|---|--------------|---------|-------------|----------|
-| 1 | Web weather / dewpoint economizer | `ECM-ECON-REPAIR` | proxy | NO_EP |
-| 2 | Demand-based chiller enable | `ECM-CHILLER-LOCKOUT` | kWh formula | patch |
-| 3 | Optimal start / recirculation | `ECM-AHU-SCHED-ALIGN` | kWh formula | patch |
-| 4 | G36 T&R | `ECM-DSP-RESET` + `ECM-SAT-RESET` | kWh | patches |
-| 5 | CHW reset low load | `ECM-CHW-RESET` | proxy | NO_EP |
-| 6 | VAV occ / standby | `ECM-OCC-STANDBY-DCV` | kWh | NO_EP |
-| **DR** | Load shed +3°F × 2 h | **`ECM-LOAD-SHED-DR`** | **KW+KWH needed** | July hourly pair tool |
-
----
-
-## Bugs — agent spreadsheet / Compare API
-
-### BUG-ECM-001 — No first-class E+ vs spreadsheet Compare CLI (partially fixed)
-
-**Now:** `compare_ecm_eplus_vs_spreadsheet.py` → JSON/CSV statuses.  
-**Still short:** Does not rewrite workbook Compare sheet; **no demand (kW) columns** yet (see BUG-ECM-011).
-
-### BUG-ECM-002 — `FORMULA_ESCO_*` catalog incomplete vs ESCO Python
-
-Missing live Excel for enthalpy econ, CHW reset, **and load-shed KW** (BUG-ECM-012).
-
-### BUG-ECM-003 — Dump analytics not auto-injected into Inputs
-
-### BUG-ECM-004 — Polished G36 package ignores `--ecms`
-
-### BUG-ECM-005 — Missing IDF patches (econ / CHW / true occ-standby)
-
-### BUG-ECM-006 — Cascade measure set ≠ workbook measure set
-
-**Current r56 `wattlab_report.json`:** lockout, sched, DSP, SAT (4 patched). Workbook / VAV package also lists ECON, CHW, OCC, and (target) `ECM-LOAD-SHED-DR` → Compare must keep those as `NO_EP` / demand-tool, not assume one cascade filled every row.
-
-### BUG-ECM-007 — Ballpark divergence / no honesty band in Excel
-
-### BUG-ECM-008 — Studio G14 iteration chart mixes buildings
-
-**Status: FIXED** on playground tip via [#65](https://github.com/bbartling/py-bacnet-stacks-playground/pull/65) (`7b26df9`). Iteration index is per-building dial history (`geo_b100` vs `geo_b50`); Building filter defaults to active Twin family.
-
-### BUG-ECM-009 — `score_g14_monthly.py` omitted elec absolutes (**fixed** in tools)
-
-### BUG-ECM-010 — Agents skip EnergyPlus-MCP when enhancing ECM sims
-
-### BUG-ECM-011 — **Demand (kW) savings missing from py→Excel API**
-
-**Gap:** Compare and `FORMULA_ESCO_*` are **kWh/therms only**. Screenshot “Project Savings” needs **kW + kWh + $** (energy rate + demand charge).
-
-**Where to add (product):**
-
-1. `wattlab/notebooks/builder.py` — new maps:
-   - `FORMULA_ESCO_KW: dict[str, str]`
-   - Inputs: `inp_demand_rate_usd_per_kw_mo`, `inp_loadshed_*`, peak proxies per measure
-2. Baseline / Screening_Results columns: `sheet_kw`, `eplus_kw`, `status_kw`
-3. `open_fdd.ecm_engineering` — optional `demand_rate` already on job globals; wire measure-level ΔkW
-4. Workspace oracle today: `tools/load_shed_demand_screen.py` → `sheet_ecm_peak_kw_proxy()` + load-shed KW
-
-**Screening KW heuristics (until E+ peak meter):**
-
-| Measure | Sheet ΔkW proxy |
-|---------|-----------------|
-| `ECM-LOAD-SHED-DR` | `tons×kW/ton×fraction` (default fraction 1.0 nomination; calibrate ~0.13 on r56) |
-| `ECM-DSP-RESET` | fan affinity slice |
-| `ECM-SAT-RESET` / `ECM-CHW-RESET` / `ECM-ECON-REPAIR` | fraction of chiller kW |
-| Sched / lockout | **0** at summer coincident peak (off-peak measures) |
-
-### BUG-ECM-012 — **Load-shed DR algorithm not in agent Excel / E+ cascade**
-
-**Operator algo (easy):** For a DR event lasting `inp_loadshed_hours` (default **2**), raise zone cooling setpoints by `inp_loadshed_delta_f` (default **+3°F**). Expected building kW change ≈ **chiller size** = `inp_cooling_tons * inp_kw_per_ton` (nomination). Event kWh ≈ ΔkW × hours.
-
-**Py→Excel API (add to builder):**
-
-```excel
-inp_loadshed_hours = 2
-inp_loadshed_delta_f = 3
-inp_loadshed_kw_fraction = 1   ! or ~0.13 after Twin July calibrate
-
-FORMULA_ESCO_KW[ECM-LOAD-SHED-DR] =
-  =IF(OR(inp_cooling_tons="",inp_cooling_tons=0),0,
-     inp_cooling_tons*inp_kw_per_ton*inp_loadshed_kw_fraction)
-
-FORMULA_ESCO_KWH[ECM-LOAD-SHED-DR] =
-  =FORMULA_ESCO_KW * inp_loadshed_hours
-```
-
-**E+ (EnergyPlus-MCP / `energyplus-mcp-dev`) — required pattern:**
-
-```bash
-docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
-  -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace vibe20 \
-  wattlab energyplus-ensure
-
-docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
-  -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace \
-  -e ENERGYPLUS_DOCKER_USER=1000:1000 vibe20 \
-  python /data/tools/load_shed_demand_screen.py --run-eplus
-```
-
-- Pick hottest July **weekday** afternoon from Twin AMY (B100: **2025-07-24**).
-- RunPeriod = that day; hourly `Electricity:Facility` + `Cooling:Electricity`.
-- Apply DR: zone Clg SP +ΔF **and** (on this Twin) **VAV SAT +ΔF** — zone-only bump is ineffective while MAT ≪ Clg SP with fixed 12.8°C SAT.
-- Compare event-window mean kW vs baseline → tune `inp_loadshed_kw_fraction`.
-
-**Honesty:** Full-chiller KW is a **DR nomination / upper bound**, not investment-grade M&V.
-
-### BUG-ECM-013 — Spreadsheet / package hard-coded to one building’s ECM list
-
-Screenshot Phase 1–2 list is a **common VAV AHU controls package**, not Liberty-only.  
-**Fix:** Treat `reports/VAV_AHU_CONTROLS_ECM_PACKAGE.json` as the reusable catalog; build with:
-
-```bash
-wattlab notebook agent-build --package esco_top15 \
-  --ecms ECM-ECON-REPAIR,ECM-CHILLER-LOCKOUT,ECM-AHU-SCHED-ALIGN,ECM-DSP-RESET,ECM-SAT-RESET,ECM-CHW-RESET,ECM-OCC-STANDBY-DCV,ECM-LOAD-SHED-DR \
-  --answers /data/reports/answers_<site>.json --fan-hp <site> --twin-run <g14>
-```
-
-Site-specific data lives in **Inputs / answers / dump** — not in the measure list. Product should add polished package id `vav_ahu_controls` that honors `--ecms` + demand Inputs (today `g36_airside_controls` ignores `--ecms` — BUG-ECM-004).
+| ID | Status | Summary |
+|----|--------|---------|
+| **BUG-ECM-001** | Open | Compare CLI exists; still no rewrite of Compare sheet **inside** agent xlsx; no demand (kW) columns in Compare contract. |
+| **BUG-ECM-002** | Open | `FORMULA_ESCO_*` map incomplete for econ / CHW reset / load-shed **kW**; full-parity book bypasses with MCP-calibrated Inputs. |
+| **BUG-ECM-003** | Open | Dump / Twin / eio sizing + FLH not auto-applied on `wattlab notebook agent-build` (manual builders exist). |
+| **BUG-ECM-004** | Open | Polished `g36_airside_controls` package ignores `--ecms`. |
+| **BUG-ECM-005** | Partial | Registry still missing product patches for enthalpy econ / CHW OA reset / true occ-standby. MCP prototypes work (`prototype_no_ep_eplus_patches.py`) but are **not** in `wattlab.energyplus.patches.registry`. Per-VAV occ impossible on 1-zone/floor Twin. |
+| **BUG-ECM-006** | Open | Cascade measure set ⊂ workbook set — Studio / Compare must keep `NO_EP` honest when registry lacks a patch (do not invent E+ kWh). |
+| **BUG-ECM-007** | Open | Agent Excel lacks ±50% honesty / BALLPARK column vs E+. |
+| **BUG-ECM-010** | Open | Agents skip EnergyPlus-MCP and re-read old cascade when enhancing sims (process). |
+| **BUG-ECM-011** | Open | Demand (kW) missing from py → Excel / Studio Compare API. |
+| **BUG-ECM-012** | Partial | Load-shed DR not in product agent Excel / cascade; workaround tool `load_shed_demand_screen.py` exists. |
+| **BUG-ECM-014** | Open (doc) | Calendar FanAvail / OAT-bin hours ≠ formula FLH. Pasting calendar into Inputs over-predicts vs E+. Fix: Matchup calendar + FLH Inputs (`build_eplus_matched_ecm_workbook.py` / full-parity builder). |
+| **BUG-ECM-015** | Open | Studio **ECMs** tab does not show full-parity sheet↔E+ results. Page uses `reports/ecm_compare.json` with spreadsheet side `pending_external`; agent xlsx retired; legacy download only globs top-level `notebooks/*.xlsx` (misses `full_parity_ecm/`). |
 
 ---
 
-## What “badass” Compare must do (acceptance)
+## Fixed
 
-1. Assumptions JSON per **site** + shared **`vav_ahu_controls`** catalog.  
-2. Dump → Inputs for hours; plant tons/HP parametric.  
-3. Cascade patched ECMs only; `NO_EP` explicit.  
-4. Machine Compare for **kWh and kW** + API gaps.  
-5. Live Excel formulas including **`ECM-LOAD-SHED-DR` KW/KWH**.  
-6. EnergyPlus-MCP July peak-day DR pair when enhancing demand sims.  
-7. Screening honesty band; never invent E+ for `NO_EP`.
-
-```bash
-# Flexible VAV-AHU workbook (not Liberty-hardcoded)
-docker exec -e WATTLAB_STUDIO_WORKSPACE=/data vibe20 \
-  wattlab notebook agent-build --package esco_top15 \
-    --ecms ECM-ECON-REPAIR,ECM-CHILLER-LOCKOUT,ECM-AHU-SCHED-ALIGN,ECM-DSP-RESET,ECM-SAT-RESET,ECM-CHW-RESET,ECM-OCC-STANDBY-DCV,ECM-LOAD-SHED-DR \
-    --answers /data/reports/answers_building_100_geo.json \
-    --twin-run /data/runs/geo_b100_6stack_shape_r56_sched_mild \
-    --fan-hp 150 --out /data/reports/notebooks/vav_ahu_controls
-
-# Annual kWh Compare
-docker exec vibe20 python /data/tools/compare_ecm_eplus_vs_spreadsheet.py
-
-# Demand / load-shed July peak (MCP DinD)
-docker exec -e WATTLAB_STUDIO_WORKSPACE=/data \
-  -e WATTLAB_HOST_WORKSPACE=$HOME/wattlab_workspace \
-  -e ENERGYPLUS_DOCKER_USER=1000:1000 vibe20 \
-  python /data/tools/load_shed_demand_screen.py --run-eplus
-```
+| ID | Notes |
+|----|-------|
+| **BUG-ECM-008** | Studio G14 iteration chart mixed B50 + B100 — fixed in playground [#65](https://github.com/bbartling/py-bacnet-stacks-playground/pull/65) (`7b26df9`). Per-building dial history + Building filter; best picker scoped within filter. Combined open-fdd Studio must keep the same rule when Twin UI is shared. |
+| **BUG-ECM-009** | `score_g14_monthly` writes elec + gas absolutes (tools). |
+| **BUG-ECM-013** | Reclassified as **ENH-ECM-009** (flexible `vav_ahu_controls` package / process — not a defect). |
 
 ---
 
-## Cursor agent prompt (demand + flexible VAV Excel)
+## Enhancements
 
-```text
-Extend vibe20 WattLab py→Excel so VAV AHU control ECMs are flexible (not one-building hardcode)
-and include demand (kW) + load-shed DR.
-
-Read:
-- vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md (BUG-ECM-011…013)
-- wattlab_workspace/reports/VAV_AHU_CONTROLS_ECM_PACKAGE.json
-- wattlab_workspace/tools/load_shed_demand_screen.py
-- wattlab_workspace/tools/BEST_PRACTICES_EPLUS_MCP_ECM.md
-- open-fdd/docs/mcp-agents/companion-wattlab-energyplus.md
-- wattlab/notebooks/builder.py (FORMULA_ESCO_*)
-
-Priority:
-1) Add FORMULA_ESCO_KW + Inputs for ECM-LOAD-SHED-DR and peak proxies; Screening $ = energy + demand.
-2) Package `vav_ahu_controls` (or esco_top15 --ecms) must stay site-parametric.
-3) Wire July peak-day EnergyPlus-MCP DR pair into Compare (status_kw).
-4) On stacked Twins with fixed SAT, DR patch = zone SP + SAT bump (document honesty).
-5) Do not hardcode Liberty dump hours into the package definition.
-```
+| ID | Priority | Ask |
+|----|----------|-----|
+| **ENH-ECM-001** | High | Wire full-parity Compare into Studio ECMs: populate `ecm_compare.json` `ss_*` + `ep_*` from `ecm_full_parity_compare.json` (or rebuild path) so the Streamlit table shows the 8-measure ballpark. |
+| **ENH-ECM-002** | High | Promote MCP prototypes (enthalpy econ, CHW OA reset, occ floor proxy) into product patch registry + cascade. |
+| **ENH-ECM-003** | High | Auto on `agent-build`: eio tons/fan HP + Twin AMY calendar + FLH Inputs (collapse BUG-ECM-003). |
+| **ENH-ECM-004** | Med | Write Compare status / ±50% honesty back into xlsx Compare sheet (BUG-ECM-001 / 007). |
+| **ENH-ECM-005** | Med | Demand + load-shed columns in Excel + Studio (BUG-ECM-011 / 012); default DR fraction from July MCP pair (~0.13 on B100 r56). |
+| **ENH-ECM-006** | Med | Nested notebook picker / download under `reports/notebooks/**` (or promote `ECM_FULL_PARITY.xlsx` to product path). |
+| **ENH-ECM-007** | Med | Honor `--ecms` on `g36_airside_controls` (BUG-ECM-004). |
+| **ENH-ECM-008** | Done | Filter Studio G14 chart / best-run picker by building — shipped with BUG-ECM-008 / [#65](https://github.com/bbartling/py-bacnet-stacks-playground/pull/65). |
+| **ENH-ECM-009** | Low | Default package builds from `VAV_AHU_CONTROLS_ECM_PACKAGE.json` (was BUG-ECM-013 — process/enhancement, not a defect). |
+| **ENH-ECM-010** | Low | Skills / `AGENT_CONTEXT` / companion doc prefer full-parity workbook + FLH rules (keep in sync with this file). |
 
 ---
 
-## Closed / playground (context)
+## Out of scope here
 
-- Prior vibe19/20 ops bugs BUG-061–064 fixed on playground tip through `56f6e7b`.
-- BUG-ECM-008 (G14 chart mtime soup) fixed in [#65](https://github.com/bbartling/py-bacnet-stacks-playground/pull/65) / `7b26df9`.
-- open-fdd SQL↔pandas parity remains a separate product track.
-- **This commit is docs-only** — ECM-011…013 implementation is follow-on work; do not treat this register as a product fix.
+- vibe19/20 ops BUG-061–064 (tip through `56f6e7b`+)
+- open-fdd SQL ↔ pandas parity
+- Investment-grade M&V / IPMVP
+- Container / GHCR refresh (deferred — more ECM work coming)
+
+---
+
+## Sync rule
+
+Product fixes for Twin / Studio / ECM Excel in **vibe20** must be mirrored or tracked in **open-fdd** (combined product) and noted from **vibe19** agent docs when FDD dumps feed the same ECM path. Do not leave this register drift between repos.

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
@@ -13,6 +13,8 @@ Workspace copies of artifacts live under Studio `/data` (`wattlab_workspace/repo
 
 Screening proof (full-parity book): **8 BALLPARK / 0 DIVERGE / 0 NO_EP** — not M&V.
 
+Twin / WattLab Studio / EnergyPlus patch + notebook builder code primarily lives in playground **vibe20**. open-fdd Jobs / ECM honesty (`honesty.openfdd`, cascade-if-ready) must stay aligned with this register when the combined UI surfaces Compare / ECMs.
+
 ---
 
 ## Open bugs


### PR DESCRIPTION
## Summary
- Refresh ECM bug/enhancement register (BUG-ECM-014/015, ENH-ECM-001…010, full-parity 8 BALLPARK proof).
- Keep **BUG-ECM-008 / ENH-ECM-008** marked fixed (#65); reclassify 013 → ENH-ECM-009.
- Add vibe19 pointer so vibe19 + vibe20 stay on the same page with open-fdd.
- Docs only — **no container refresh**.

## Test plan
- [x] Docs-only; CI green
- [ ] CodeRabbit evaluated


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ECM spreadsheet and EnergyPlus bug-report documentation with current status snapshots, bug and enhancement registers, and screening references.
  * Added synchronized documentation pointers across related product repositories and the canonical open-fdd source.
  * Condensed one report by removing detailed implementation notes, tooling instructions, and agent prompts while retaining key findings and tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->