### PR TITLE
vibe20: full-parity Studio ss_* + Stage 1 evidence export

### DIFF
--- a/vibe_code_apps_20/AGENTS.md
+++ b/vibe_code_apps_20/AGENTS.md
@@ -6,9 +6,28 @@
 
 **ECM math SoT:** Generic spreadsheet/ESCO calculators live on PyPI `open-fdd` (`open_fdd.ecm_engineering`). Call them through `wattlab.engineering.openfdd_ecm` — do not invent a second affinity/bin/finance stack. EnergyPlus, IDF, Studio, catalog IDs, and EP-vs-engineering presentation stay in WattLab.
 
+**Ownership (Stage 1+):**
+- **Open-FDD owns** schemas, equations, provenance, workbook/DOCX builders, publication gates, agent CLI/API, SQL FDD rules.
+- **Vibe20 owns** IDF/MCP/sim, G14, measure/package/cascade runs, and **evidence export** (`wattlab.ecm.evidence_export` → `ecm_simulation_evidence.json` + dual-rail `ecm_engineering_inputs.json`).
+- Studio ECMs merges `reports/ecm_full_parity_compare.json` into `ss_*` when present (BUG-ECM-015 / ENH-VIBE-002) — never invent spreadsheet numbers.
+
 ```text
 Open-FDD evidence → Open-FDD ECM engineering → Vibe 20 EnergyPlus → engineering vs EP cross-check
+Vibe20 cascade/sizing → ecm_simulation_evidence.json → Open-FDD import/validate → workbook
 ```
+
+### GHCR image tip (ENH-VIBE-001)
+
+Prefer a pulled tip — running containers never auto-update:
+
+```bash
+# Moving tip after CI publish (develop/latest), or pin immutable sha:
+./scripts/docker_update_vibe20.sh latest
+# ./scripts/docker_update_vibe20.sh sha-<shortsha>
+docker exec vibe20 sh -c 'echo "VIBE20_GIT_SHA=${VIBE20_GIT_SHA:-unset}"'
+```
+
+Image: `ghcr.io/bbartling/vibe20:<tag>` — see `scripts/docker_update_vibe20.sh` and `README.md` Run (Docker / GHCR).
 
 **Quick link (vibe19 historian zips):** [`../vibe_code_apps_19/docs/PACKAGE_SPEC.md`](../vibe_code_apps_19/docs/PACKAGE_SPEC.md) — `openfdd_package_v1` layout before bridging / calibrating.
 

--- a/vibe_code_apps_20/SESSION_LOG.md
+++ b/vibe_code_apps_20/SESSION_LOG.md
@@ -2,6 +2,18 @@
 
 Newest first. One entry per shipped work session.
 
+## 2026-07-29 — ENH-VIBE-001/002 + Stage 1 evidence exporter
+
+- **ENH-VIBE-002 / BUG-ECM-015:** `merge_full_parity_ss` fills Studio `ss_*` from
+  `reports/ecm_full_parity_compare.json` when present; ECMs page + `load_compare`
+  wired; nested `reports/notebooks/**/*.xlsx` downloads.
+- **Stage 1:** `wattlab.ecm.evidence_export` writes `ecm_simulation_evidence_v1` +
+  dual-rail `ecm_engineering_inputs.json`; soft hook on `agent_build_notebook`.
+- **Ownership:** Open-FDD = schemas/workbook; vibe20 = IDF/sim/evidence export
+  (AGENTS.md).
+- **ENH-VIBE-001:** GHCR tip note — `ghcr.io/bbartling/vibe20:latest` (or
+  `:sha-<sha>`) via `scripts/docker_update_vibe20.sh`; recreate after publish.
+
 ## 2026-07-20 — Studio mega dumb-down (4 pages + workspace)
 
 - Replaced 12-page Studio with **Uploads / Fuel dashboard / Twin·calibrate / ECMs**.

--- a/vibe_code_apps_20/tests/test_ecm_evidence_stage1.py
+++ b/vibe_code_apps_20/tests/test_ecm_evidence_stage1.py
@@ -1,0 +1,200 @@
+"""ENH-VIBE-002 / Stage-1 evidence: full-parity merge + evidence export."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wattlab.ecm.compare import (
+    build_compare_from_cascade,
+    discover_notebook_xlsx,
+    empty_compare_stub,
+    load_compare,
+    merge_full_parity_ss,
+    write_compare,
+)
+from wattlab.ecm.evidence_export import (
+    EVIDENCE_SCHEMA_VERSION,
+    build_dual_rail_sizing_inputs,
+    engineering_input,
+    export_ecm_simulation_evidence,
+    validate_engineering_inputs,
+)
+
+
+def test_merge_full_parity_ss_fills_ss(tmp_path: Path):
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    compare = build_compare_from_cascade(
+        {
+            "twin_run": "t1",
+            "savings_by_measure": [
+                {
+                    "measure_id": "ECM-DSP-RESET",
+                    "vs_baseline": {
+                        "kwh_saved": 1000.0,
+                        "therms_saved": 0.0,
+                        "cost_saved_usd": 120.0,
+                    },
+                }
+            ],
+        },
+        measure_ids=["ECM-DSP-RESET"],
+        twin_run="t1",
+        profile={"conditioned_floor_area_ft2": 100_000},
+    )
+    assert compare["measures"][0]["ss_kwh"] is None
+
+    parity = {
+        "measures": [
+            {
+                "measure_id": "ECM-DSP-RESET",
+                "ss_kwh": 950.0,
+                "ss_therms": 2.5,
+                "ss_usd": 114.0,
+                "payback_yr_ss": 4.2,
+                "roi_ss": 0.24,
+            }
+        ]
+    }
+    (reports / "ecm_full_parity_compare.json").write_text(
+        json.dumps(parity) + "\n", encoding="utf-8"
+    )
+
+    merged = merge_full_parity_ss(compare, reports)
+    row = merged["measures"][0]
+    assert row["ss_kwh"] == 950.0
+    assert row["ss_therms"] == 2.5
+    assert row["ss_usd"] == 114.0
+    assert row["payback_yr_ss"] == 4.2
+    assert row["roi_ss"] == 0.24
+    assert merged["spreadsheet"]["status"] == "full_parity"
+    assert row["status"] == "ss_ep_ready"
+
+
+def test_merge_full_parity_ss_noop_without_file(tmp_path: Path):
+    stub = empty_compare_stub(measure_ids=["ECM-SAT-RESET"])
+    out = merge_full_parity_ss(stub, tmp_path / "reports")
+    assert out["spreadsheet"]["status"] == "pending_external"
+    assert all(m["ss_kwh"] is None for m in out["measures"])
+
+
+def test_load_compare_merges_full_parity(tmp_path: Path):
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    stub = empty_compare_stub(measure_ids=["ECM-DSP-RESET"])
+    cpath = write_compare(reports / "ecm_compare.json", stub)
+    (reports / "ecm_full_parity_compare.json").write_text(
+        json.dumps(
+            {
+                "measures": [
+                    {"measure_id": "ECM-DSP-RESET", "ss_kwh": 10.0, "ss_usd": 1.2}
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    loaded = load_compare(cpath, reports_dir=reports)
+    assert loaded is not None
+    assert loaded["measures"][0]["ss_kwh"] == 10.0
+
+
+def test_discover_notebook_xlsx_recursive(tmp_path: Path):
+    nb = tmp_path / "notebooks"
+    (nb / "full_parity_ecm").mkdir(parents=True)
+    top = nb / "legacy.xlsx"
+    nested = nb / "full_parity_ecm" / "ECM_FULL_PARITY.xlsx"
+    lock = nb / "full_parity_ecm" / "~$lock.xlsx"
+    top.write_bytes(b"PK")
+    nested.write_bytes(b"PK")
+    lock.write_bytes(b"PK")
+    found = discover_notebook_xlsx(nb)
+    names = {p.name for p in found}
+    assert names == {"legacy.xlsx", "ECM_FULL_PARITY.xlsx"}
+    assert any("full_parity_ecm" in p.parts for p in found)
+
+
+def test_evidence_export_schema_and_dual_rail(tmp_path: Path):
+    cascade = {
+        "twin_run": "synth_twin",
+        "run_id": "cascade_1",
+        "report_path": str(tmp_path / "wattlab_report.json"),
+        "savings_by_measure": [
+            {
+                "measure_id": "ECM-SAT-RESET",
+                "run_id": "sat_1",
+                "vs_baseline": {"kwh_saved": 500.0, "therms_saved": 10.0},
+            }
+        ],
+        "weather_suitability": {"mode": "ACTUAL_YEAR_CALIBRATION"},
+    }
+    sizing = {"fan_hp": 75.0, "ep_fan_hp": 72.5, "cooling_tons": 180.0}
+    result = export_ecm_simulation_evidence(
+        tmp_path,
+        cascade_report=cascade,
+        sizing=sizing,
+        profile={"building_type": "office", "floor_area_ft2": 100000},
+        ss_fan_hours=4000.0,
+        ep_fan_hours=5200.0,
+    )
+    assert result["ok"]
+    evidence = json.loads(Path(result["evidence_path"]).read_text(encoding="utf-8"))
+    assert evidence["schema_version"] == EVIDENCE_SCHEMA_VERSION
+    assert evidence["schema_version"] == "ecm_simulation_evidence_v1"
+    assert "equipment_autosizing" in evidence
+    assert evidence["individual_measures"][0]["measure_id"] == "ECM-SAT-RESET"
+    assert evidence["individual_measures"][0]["baseline_run_id"]
+    assert evidence["individual_measures"][0]["comparison_mode"]
+    assert evidence["individual_measures"][0]["result_scope"]
+
+    inputs_doc = json.loads(Path(result["inputs_path"]).read_text(encoding="utf-8"))
+    ids = {i["input_id"] for i in inputs_doc["inputs"]}
+    assert "ss_fan_hp" in ids
+    assert "ep_fan_hp" in ids
+    assert validate_engineering_inputs(inputs_doc["inputs"]) == []
+
+
+def test_reject_missing_assumption_note_for_agent_inferred_hours():
+    bad = engineering_input(
+        input_id="ss_sched_hours_saved",
+        display_name="Sched hours saved",
+        value=2500,
+        unit="h/yr",
+        rail="spreadsheet",
+        source_type="agent_inferred",
+        assumption_note="",
+    )
+    issues = validate_engineering_inputs([bad])
+    assert issues
+    assert "assumption_note" in issues[0]
+
+    good = engineering_input(
+        input_id="ss_sched_hours_saved",
+        display_name="Sched hours saved",
+        value=2500,
+        unit="h/yr",
+        rail="spreadsheet",
+        source_type="agent_inferred",
+        assumption_note="FLH back-calc from cascade; not AMY calendar FanAvail.",
+        assumption_method="flh_from_cascade",
+    )
+    assert validate_engineering_inputs([good]) == []
+
+
+def test_dual_rail_pair_helper():
+    inputs = build_dual_rail_sizing_inputs(ss_fan_hp=80.0, ep_fan_hp=78.0)
+    ids = {i["input_id"] for i in inputs}
+    assert "ss_fan_hp" in ids and "ep_fan_hp" in ids
+    assert validate_engineering_inputs(inputs) == []
+
+
+def test_evidence_dry_run_ok(tmp_path: Path):
+    result = export_ecm_simulation_evidence(
+        tmp_path,
+        cascade_report={"savings_by_measure": []},
+        dry_run=True,
+    )
+    assert result["dry_run"] is True
+    assert result["evidence_path"] is None
+    assert not (tmp_path / "ecm_simulation_evidence.json").exists()

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md
@@ -32,7 +32,7 @@ Twin / WattLab Studio / EnergyPlus patch + notebook builder code primarily lives
 | **BUG-ECM-011** | Open | Demand (kW) missing from py → Excel / Studio Compare API. |
 | **BUG-ECM-012** | Partial | Load-shed DR not in product agent Excel / cascade; workaround tool `load_shed_demand_screen.py` exists. |
 | **BUG-ECM-014** | Open (doc) | Calendar FanAvail / OAT-bin hours ≠ formula FLH. Pasting calendar into Inputs over-predicts vs E+. Fix: Matchup calendar + FLH Inputs (`build_eplus_matched_ecm_workbook.py` / full-parity builder). |
-| **BUG-ECM-015** | Open | Studio **ECMs** tab does not show full-parity sheet↔E+ results. Page uses `reports/ecm_compare.json` with spreadsheet side `pending_external`; agent xlsx retired; legacy download only globs top-level `notebooks/*.xlsx` (misses `full_parity_ecm/`). |
+| **BUG-ECM-015** | Fixed (ENH-VIBE-002) | Studio merges `ecm_full_parity_compare.json` → `ss_*` when present; nested `notebooks/**/*.xlsx` downloads. |
 
 ---
 
@@ -50,12 +50,12 @@ Twin / WattLab Studio / EnergyPlus patch + notebook builder code primarily lives
 
 | ID | Priority | Ask |
 |----|----------|-----|
-| **ENH-ECM-001** | High | Wire full-parity Compare into Studio ECMs: populate `ecm_compare.json` `ss_*` + `ep_*` from `ecm_full_parity_compare.json` (or rebuild path) so the Streamlit table shows the 8-measure ballpark. |
+| **ENH-ECM-001** | Done (ENH-VIBE-002) | Wire full-parity Compare into Studio ECMs: merge `ss_*` from `ecm_full_parity_compare.json` when present. |
 | **ENH-ECM-002** | High | Promote MCP prototypes (enthalpy econ, CHW OA reset, occ floor proxy) into product patch registry + cascade. |
 | **ENH-ECM-003** | High | Auto on `agent-build`: eio tons/fan HP + Twin AMY calendar + FLH Inputs (collapse BUG-ECM-003). |
 | **ENH-ECM-004** | Med | Write Compare status / ±50% honesty back into xlsx Compare sheet (BUG-ECM-001 / 007). |
 | **ENH-ECM-005** | Med | Demand + load-shed columns in Excel + Studio (BUG-ECM-011 / 012); default DR fraction from July MCP pair (~0.13 on B100 r56). |
-| **ENH-ECM-006** | Med | Nested notebook picker / download under `reports/notebooks/**` (or promote `ECM_FULL_PARITY.xlsx` to product path). |
+| **ENH-ECM-006** | Done (ENH-VIBE-002) | Nested notebook picker / download under `reports/notebooks/**`. |
 | **ENH-ECM-007** | Med | Honor `--ecms` on `g36_airside_controls` (BUG-ECM-004). |
 | **ENH-ECM-008** | Done | Filter Studio G14 chart / best-run picker by building — shipped with BUG-ECM-008 / [#65](https://github.com/bbartling/py-bacnet-stacks-playground/pull/65). |
 | **ENH-ECM-009** | Low | Default package builds from `VAV_AHU_CONTROLS_ECM_PACKAGE.json` (was BUG-ECM-013 — process/enhancement, not a defect). |

--- a/vibe_code_apps_20/wattlab/ecm/compare.py
+++ b/vibe_code_apps_20/wattlab/ecm/compare.py
@@ -13,10 +13,34 @@ from typing import Any
 
 SCHEMA = "wattlab_ecm_compare_v1"
 DEFAULT_COMPARE_NAME = "ecm_compare.json"
+FULL_PARITY_COMPARE_NAME = "ecm_full_parity_compare.json"
+FULL_PARITY_SS_KEYS = (
+    "ss_kwh",
+    "ss_therms",
+    "ss_usd",
+    "payback_yr_ss",
+    "roi_ss",
+)
 
 
 def compare_path(reports: Path | str) -> Path:
     return Path(reports) / DEFAULT_COMPARE_NAME
+
+
+def full_parity_compare_path(reports: Path | str) -> Path:
+    return Path(reports) / FULL_PARITY_COMPARE_NAME
+
+
+def discover_notebook_xlsx(notebooks_dir: Path | str) -> list[Path]:
+    """Recursive ``*.xlsx`` under ``reports/notebooks/**`` (skip Excel lockfiles)."""
+    root = Path(notebooks_dir)
+    if not root.is_dir():
+        return []
+    return sorted(
+        p
+        for p in root.rglob("*.xlsx")
+        if p.is_file() and not p.name.startswith("~$")
+    )
 
 
 def _f(v: Any) -> float | None:
@@ -169,11 +193,186 @@ def write_compare(path: Path | str, payload: dict[str, Any]) -> Path:
     return path
 
 
-def load_compare(path: Path | str) -> dict[str, Any] | None:
+def _parity_measure_rows(parity: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize full-parity JSON shapes into measure dicts with ss_* fields."""
+    rows = parity.get("measures")
+    if isinstance(rows, list):
+        return [r for r in rows if isinstance(r, dict)]
+    ss = parity.get("spreadsheet")
+    if isinstance(ss, dict) and isinstance(ss.get("measures"), list):
+        return [r for r in ss["measures"] if isinstance(r, dict)]
+    by_mid = parity.get("savings_by_measure") or parity.get("by_measure")
+    if isinstance(by_mid, list):
+        out: list[dict[str, Any]] = []
+        for row in by_mid:
+            if not isinstance(row, dict):
+                continue
+            mid = str(row.get("measure_id") or "")
+            if not mid:
+                continue
+            # Prefer explicit ss_*; else map common spreadsheet aliases.
+            mapped = {
+                "measure_id": mid,
+                "ss_kwh": row.get("ss_kwh", row.get("kwh_saved", row.get("ss_kWh"))),
+                "ss_therms": row.get("ss_therms", row.get("therms_saved")),
+                "ss_usd": row.get("ss_usd", row.get("cost_saved_usd", row.get("usd_saved"))),
+                "payback_yr_ss": row.get("payback_yr_ss", row.get("payback_yr")),
+                "roi_ss": row.get("roi_ss", row.get("roi")),
+                "ss_note": row.get("ss_note"),
+            }
+            out.append(mapped)
+        return out
+    if isinstance(by_mid, dict):
+        out = []
+        for mid, row in by_mid.items():
+            if not isinstance(row, dict):
+                continue
+            out.append(
+                {
+                    "measure_id": str(mid),
+                    "ss_kwh": row.get("ss_kwh", row.get("kwh_saved")),
+                    "ss_therms": row.get("ss_therms", row.get("therms_saved")),
+                    "ss_usd": row.get("ss_usd", row.get("cost_saved_usd")),
+                    "payback_yr_ss": row.get("payback_yr_ss", row.get("payback_yr")),
+                    "roi_ss": row.get("roi_ss", row.get("roi")),
+                    "ss_note": row.get("ss_note"),
+                }
+            )
+        return out
+    return []
+
+
+def merge_full_parity_ss(
+    compare_payload: dict[str, Any],
+    reports_dir: Path | str,
+    *,
+    parity_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Fill ``ss_*`` from ``ecm_full_parity_compare.json`` when present (BUG-ECM-015).
+
+    Merge-if-present only — never invent spreadsheet numbers. Returns the same
+    payload dict (mutated in place when parity file exists and has values).
+    """
+    reports = Path(reports_dir)
+    path = Path(parity_path) if parity_path else full_parity_compare_path(reports)
+    if not path.is_file():
+        return compare_payload
+
+    try:
+        parity = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return compare_payload
+    if not isinstance(parity, dict):
+        return compare_payload
+
+    by_mid: dict[str, dict[str, Any]] = {}
+    for row in _parity_measure_rows(parity):
+        mid = str(row.get("measure_id") or "")
+        if mid:
+            by_mid[mid] = row
+
+    if not by_mid:
+        return compare_payload
+
+    measures = compare_payload.get("measures")
+    if not isinstance(measures, list):
+        measures = []
+        compare_payload["measures"] = measures
+
+    existing = {str(m.get("measure_id")): m for m in measures if isinstance(m, dict)}
+    filled = 0
+    for mid, src in by_mid.items():
+        row = existing.get(mid)
+        if row is None:
+            row = {
+                "measure_id": mid,
+                "ep_kwh": None,
+                "ep_therms": None,
+                "ep_usd": None,
+                "ep_note": None,
+                "ss_kwh": None,
+                "ss_therms": None,
+                "ss_usd": None,
+                "ss_note": None,
+                "capital_usd": None,
+                "payback_yr_ep": None,
+                "payback_yr_ss": None,
+                "roi_ep": None,
+                "roi_ss": None,
+                "status": "ss_ready",
+            }
+            measures.append(row)
+            existing[mid] = row
+
+        for key in FULL_PARITY_SS_KEYS:
+            val = src.get(key)
+            if val is None or val == "":
+                continue
+            # Only fill from parity — do not invent; coerce numerics when present.
+            if key in ("ss_kwh", "ss_therms", "ss_usd", "payback_yr_ss", "roi_ss"):
+                num = _f(val)
+                if num is None:
+                    continue
+                row[key] = num
+            else:
+                row[key] = val
+            filled += 1
+
+        if src.get("ss_note"):
+            row["ss_note"] = src["ss_note"]
+        elif row.get("ss_kwh") is not None and row.get("ss_note") in (
+            None,
+            "pending_external_spreadsheet",
+        ):
+            row["ss_note"] = "full_parity_workbook"
+
+        # Recompute payback/ROI from capital + ss_usd when parity omitted them.
+        capital = _f(row.get("capital_usd"))
+        ss_usd = _f(row.get("ss_usd"))
+        if row.get("payback_yr_ss") is None and capital is not None and ss_usd is not None:
+            row["payback_yr_ss"] = _payback(capital, ss_usd)
+        if row.get("roi_ss") is None and capital is not None and ss_usd is not None:
+            row["roi_ss"] = _roi(capital, ss_usd)
+
+        if row.get("ss_kwh") is not None or row.get("ss_usd") is not None:
+            if row.get("ep_kwh") is not None:
+                row["status"] = "ss_ep_ready"
+            else:
+                row["status"] = "ss_ready"
+
+    if filled:
+        ss_meta = dict(compare_payload.get("spreadsheet") or {})
+        ss_meta["status"] = "full_parity"
+        ss_meta["path"] = str(path)
+        ss_meta["note"] = (
+            ss_meta.get("note")
+            or "Spreadsheet columns from ecm_full_parity_compare.json (merge-if-present)."
+        )
+        compare_payload["spreadsheet"] = ss_meta
+        honesty = compare_payload.get("honesty") or ""
+        tip = "Spreadsheet ss_* merged from ecm_full_parity_compare.json when present."
+        if tip not in honesty:
+            compare_payload["honesty"] = (honesty + " " + tip).strip()
+
+    return compare_payload
+
+
+def load_compare(
+    path: Path | str,
+    *,
+    reports_dir: Path | str | None = None,
+    merge_full_parity: bool = True,
+) -> dict[str, Any] | None:
     path = Path(path)
     if not path.is_file():
         return None
-    return json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return None
+    if merge_full_parity:
+        reports = Path(reports_dir) if reports_dir is not None else path.parent
+        merge_full_parity_ss(payload, reports)
+    return payload
 
 
 def empty_compare_stub(
@@ -197,8 +396,12 @@ def empty_compare_stub(
 __all__ = [
     "SCHEMA",
     "DEFAULT_COMPARE_NAME",
+    "FULL_PARITY_COMPARE_NAME",
     "compare_path",
+    "full_parity_compare_path",
+    "discover_notebook_xlsx",
     "build_compare_from_cascade",
+    "merge_full_parity_ss",
     "write_compare",
     "load_compare",
     "empty_compare_stub",

--- a/vibe_code_apps_20/wattlab/ecm/evidence_export.py
+++ b/vibe_code_apps_20/wattlab/ecm/evidence_export.py
@@ -1,0 +1,546 @@
+"""Stage-1 ECM simulation evidence + dual-rail engineering Inputs exporter.
+
+Vibe20 owns EnergyPlus / cascade / sizing evidence. Open-FDD owns schemas and
+workbook builders — this module emits JSON sidecars Open-FDD can import.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+EVIDENCE_SCHEMA_VERSION = "ecm_simulation_evidence_v1"
+EVIDENCE_FILENAME = "ecm_simulation_evidence.json"
+INPUTS_FILENAME = "ecm_engineering_inputs.json"
+INPUTS_SCHEMA_VERSION = "ecm_engineering_inputs_v1"
+
+_NEEDS_ASSUMPTION_NOTE = frozenset(
+    {
+        "agent_inferred",
+        "engineering_assumption",
+        "EnergyPlus_derived",
+        "synthetic_rehearsal",
+    }
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _f(v: Any) -> float | None:
+    if v is None or v == "":
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def engineering_input(
+    *,
+    input_id: str,
+    display_name: str,
+    value: Any,
+    unit: str,
+    rail: str,
+    source_type: str,
+    assumption_note: str = "",
+    assumption_method: str = "unknown",
+    linked_measure_ids: list[str] | None = None,
+    confidence: str = "unknown",
+    editable: bool = True,
+    validation_status: str = "ok",
+    source_reference: str = "",
+    notes: str = "",
+) -> dict[str, Any]:
+    """EngineeringInput-like dict (Open-FDD Stage-1 contract shape)."""
+    return {
+        "input_id": input_id,
+        "display_name": display_name,
+        "value": value,
+        "unit": unit,
+        "rail": rail,
+        "source_type": source_type,
+        "confidence": confidence,
+        "editable": editable,
+        "validation_status": validation_status,
+        "assumption_note": assumption_note,
+        "assumption_method": assumption_method,
+        "linked_measure_ids": list(linked_measure_ids or []),
+        "source_reference": source_reference,
+        "notes": notes,
+    }
+
+
+def validate_engineering_inputs(inputs: list[dict[str, Any]]) -> list[str]:
+    """Local Stage-1 gate: agent_inferred / estimated hours need assumption_note."""
+    issues: list[str] = []
+    for inp in inputs:
+        if not isinstance(inp, dict):
+            issues.append("input entry must be an object")
+            continue
+        iid = str(inp.get("input_id") or "?")
+        source = str(inp.get("source_type") or "")
+        note = str(inp.get("assumption_note") or "").strip()
+        needs = source in _NEEDS_ASSUMPTION_NOTE
+        lid = iid.lower()
+        if "hour" in lid or lid.endswith("_flh") or "hours_saved" in lid:
+            if source not in ("measured", "human_entered"):
+                needs = True
+        if needs and not note:
+            issues.append(
+                f"{iid}: assumption_note required for {source or 'estimated'} / estimated hours"
+            )
+    return issues
+
+
+def build_dual_rail_sizing_inputs(
+    *,
+    ss_fan_hp: float | None = None,
+    ep_fan_hp: float | None = None,
+    ss_cooling_tons: float | None = None,
+    ep_cooling_tons: float | None = None,
+    ss_fan_hours: float | None = None,
+    ep_fan_hours: float | None = None,
+    linked_measure_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """At least one ss_* / ep_* sizing pair plus optional hour rails."""
+    linked = list(linked_measure_ids or [])
+    inputs: list[dict[str, Any]] = []
+
+    # Prefer provided values; synthetic-friendly defaults keep a dual-rail pair present.
+    ss_hp = ss_fan_hp if ss_fan_hp is not None else 80.0
+    ep_hp = ep_fan_hp if ep_fan_hp is not None else ss_hp
+    inputs.append(
+        engineering_input(
+            input_id="ss_fan_hp",
+            display_name="Fan power (spreadsheet)",
+            value=ss_hp,
+            unit="hp",
+            rail="spreadsheet",
+            source_type="engineering_assumption" if ss_fan_hp is None else "nameplate",
+            assumption_note=(
+                "Screening fan HP for ESCO formulas; not a field-verified nameplate."
+                if ss_fan_hp is None
+                else "Operator / nameplate fan HP for spreadsheet rail."
+            ),
+            assumption_method="engineering_judgment" if ss_fan_hp is None else "nameplate",
+            linked_measure_ids=linked,
+        )
+    )
+    inputs.append(
+        engineering_input(
+            input_id="ep_fan_hp",
+            display_name="Fan power (EnergyPlus autosized)",
+            value=ep_hp,
+            unit="hp",
+            rail="energyplus",
+            source_type="EnergyPlus_autosized" if ep_fan_hp is not None else "agent_inferred",
+            assumption_note=(
+                "From EnergyPlus eio / sizing inventory when available; "
+                "mirrored from spreadsheet rail when EP sizing absent."
+                if ep_fan_hp is None
+                else "Parsed from EnergyPlus Component Sizing / eio inventory."
+            ),
+            assumption_method="eio_autosize" if ep_fan_hp is not None else "engineering_judgment",
+            linked_measure_ids=linked,
+            source_reference="eplusout.eio" if ep_fan_hp is not None else "",
+        )
+    )
+
+    if ss_cooling_tons is not None or ep_cooling_tons is not None:
+        ss_tons = ss_cooling_tons if ss_cooling_tons is not None else ep_cooling_tons
+        ep_tons = ep_cooling_tons if ep_cooling_tons is not None else ss_cooling_tons
+        inputs.append(
+            engineering_input(
+                input_id="ss_cooling_tons",
+                display_name="Cooling capacity (spreadsheet)",
+                value=ss_tons,
+                unit="ton",
+                rail="spreadsheet",
+                source_type="nameplate" if ss_cooling_tons is not None else "engineering_assumption",
+                assumption_note="Spreadsheet cooling tons for ESCO kW/ton screens.",
+                assumption_method="nameplate" if ss_cooling_tons is not None else "engineering_judgment",
+                linked_measure_ids=linked,
+            )
+        )
+        inputs.append(
+            engineering_input(
+                input_id="ep_cooling_tons",
+                display_name="Cooling capacity (EnergyPlus)",
+                value=ep_tons,
+                unit="ton",
+                rail="energyplus",
+                source_type=(
+                    "EnergyPlus_autosized" if ep_cooling_tons is not None else "agent_inferred"
+                ),
+                assumption_note="EnergyPlus plant / coil autosized cooling capacity.",
+                assumption_method="eio_autosize" if ep_cooling_tons is not None else "engineering_judgment",
+                linked_measure_ids=linked,
+            )
+        )
+
+    if ss_fan_hours is not None:
+        inputs.append(
+            engineering_input(
+                input_id="ss_fan_hours",
+                display_name="Fan full-load hours (spreadsheet)",
+                value=ss_fan_hours,
+                unit="h/yr",
+                rail="spreadsheet",
+                source_type="agent_inferred",
+                assumption_note=(
+                    "FLH for spreadsheet formulas — not Twin AMY calendar FanAvail hours "
+                    "(BUG-ECM-014: never silently paste calendar over FLH)."
+                ),
+                assumption_method="flh_from_cascade",
+                linked_measure_ids=linked,
+            )
+        )
+    if ep_fan_hours is not None:
+        inputs.append(
+            engineering_input(
+                input_id="ep_fan_hours",
+                display_name="Fan availability hours (EnergyPlus)",
+                value=ep_fan_hours,
+                unit="h/yr",
+                rail="energyplus",
+                source_type="EnergyPlus_derived",
+                assumption_note=(
+                    "Calendar / schedule FanAvail hours from Twin AMY period — "
+                    "distinct from spreadsheet FLH."
+                ),
+                assumption_method="amy_calendar_hours",
+                linked_measure_ids=linked,
+            )
+        )
+    return inputs
+
+
+def _hour_bases_from_row(row: dict[str, Any]) -> dict[str, Any]:
+    bases: dict[str, Any] = {}
+    for key in (
+        "hour_bases",
+        "hours",
+        "sched_hours_saved",
+        "fan_hours",
+        "lockout_hours",
+        "sat_hours",
+        "standby_hours",
+        "flh",
+    ):
+        if key in row and row[key] is not None:
+            bases[key] = row[key]
+    return bases
+
+
+def _measure_from_cascade_row(
+    row: dict[str, Any],
+    *,
+    baseline_run_id: str,
+    comparison_mode: str = "vs_common_baseline",
+) -> dict[str, Any]:
+    mid = str(row.get("measure_id") or "")
+    vs = row.get("vs_baseline") or {}
+    run_id = str(row.get("run_id") or row.get("out_dir") or mid or "unknown")
+    return {
+        "measure_id": mid,
+        "run_id": run_id,
+        "baseline_run_id": baseline_run_id,
+        "comparison_mode": row.get("comparison_mode") or comparison_mode,
+        "result_scope": row.get("result_scope") or "whole_building",
+        "allocation_status": row.get("allocation_status") or "model_metered",
+        "hour_bases": _hour_bases_from_row(row),
+        "savings": {
+            "kwh_saved": _f(vs.get("kwh_saved") if isinstance(vs, dict) else None)
+            if isinstance(vs, dict)
+            else _f(row.get("kwh_saved")),
+            "therms_saved": _f(vs.get("therms_saved") if isinstance(vs, dict) else None)
+            if isinstance(vs, dict)
+            else _f(row.get("therms_saved")),
+            "cost_saved_usd": _f(vs.get("cost_saved_usd") if isinstance(vs, dict) else None)
+            if isinstance(vs, dict)
+            else _f(row.get("cost_saved_usd")),
+        },
+        "patch_ok": row.get("patch_ok"),
+        "error": row.get("error"),
+    }
+
+
+def build_ecm_simulation_evidence(
+    *,
+    cascade_report: dict[str, Any] | None = None,
+    sizing: dict[str, Any] | None = None,
+    profile: dict[str, Any] | None = None,
+    project: dict[str, Any] | None = None,
+    facility: dict[str, Any] | None = None,
+    baseline: dict[str, Any] | None = None,
+    calibration: dict[str, Any] | None = None,
+    model: dict[str, Any] | None = None,
+    weather: dict[str, Any] | None = None,
+    package_runs: list[dict[str, Any]] | None = None,
+    sequential_cascades: list[dict[str, Any]] | None = None,
+    run_artifacts: list[dict[str, Any]] | None = None,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build ``ecm_simulation_evidence_v1`` document (synthetic-friendly)."""
+    cascade_report = cascade_report or {}
+    profile = profile or {}
+    twin_run = str(
+        cascade_report.get("twin_run")
+        or cascade_report.get("run_id")
+        or ((baseline or {}).get("run_id") if baseline else None)
+        or "synthetic_baseline"
+    )
+    baseline_run_id = str(
+        (baseline or {}).get("run_id")
+        or cascade_report.get("baseline_run_id")
+        or twin_run
+        or "baseline"
+    )
+
+    measures: list[dict[str, Any]] = []
+    for row in cascade_report.get("savings_by_measure") or []:
+        if not isinstance(row, dict):
+            continue
+        mid = str(row.get("measure_id") or "")
+        if not mid or mid.lower() == "baseline":
+            continue
+        measures.append(
+            _measure_from_cascade_row(row, baseline_run_id=baseline_run_id)
+        )
+
+    equip = dict(sizing or cascade_report.get("equipment_autosizing") or {})
+    if not equip and profile:
+        # Soft profile hints only — stamped as screening, not measured.
+        hint: dict[str, Any] = {}
+        for k in ("fan_hp", "cooling_tons", "heating_mmbtu"):
+            if profile.get(k) is not None:
+                hint[k] = profile[k]
+        if hint:
+            equip = {"source": "profile_screening", **hint}
+
+    weather_block = weather
+    if weather_block is None:
+        ws = cascade_report.get("weather_suitability")
+        weather_block = ws if isinstance(ws, dict) else {"suitability": ws}
+
+    model_block = model or {
+        "twin_run": twin_run or None,
+        "source": cascade_report.get("source") or "cascade_measures_on_twin",
+    }
+
+    doc: dict[str, Any] = {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "project": project
+        or {
+            "project_id": profile.get("project_id") or profile.get("building_id") or "unknown",
+            "updated_at": _utc_now(),
+        },
+        "facility": facility
+        or {
+            "building_type": profile.get("building_type"),
+            "floor_area_ft2": profile.get("floor_area_ft2")
+            or profile.get("conditioned_floor_area_ft2"),
+            "city": profile.get("city"),
+        },
+        "baseline": baseline
+        or {
+            "run_id": baseline_run_id,
+            "twin_run": twin_run or None,
+        },
+        "model": model_block,
+        "weather": weather_block or {},
+        "equipment_autosizing": equip,
+        "individual_measures": measures,
+        "package_runs": list(package_runs or []),
+        "sequential_cascades": list(
+            sequential_cascades
+            or (
+                [
+                    {
+                        "cascade_id": cascade_report.get("run_id") or twin_run,
+                        "out_dir": cascade_report.get("out_dir"),
+                        "report_path": cascade_report.get("report_path"),
+                        "measure_ids": [m["measure_id"] for m in measures],
+                    }
+                ]
+                if cascade_report
+                else []
+            )
+        ),
+        "run_artifacts": list(
+            run_artifacts
+            or (
+                [{"path": cascade_report.get("report_path"), "kind": "cascade_report"}]
+                if cascade_report.get("report_path")
+                else []
+            )
+        ),
+        "warnings": list(warnings or []),
+    }
+    if calibration is not None:
+        doc["calibration"] = calibration
+    elif cascade_report.get("calibration") is not None:
+        doc["calibration"] = cascade_report["calibration"]
+    return doc
+
+
+def write_engineering_inputs(
+    path: Path | str,
+    inputs: list[dict[str, Any]],
+    *,
+    validate: bool = True,
+) -> Path:
+    path = Path(path)
+    if validate:
+        issues = validate_engineering_inputs(inputs)
+        if issues:
+            raise ValueError("; ".join(issues))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = {
+        "schema_version": INPUTS_SCHEMA_VERSION,
+        "updated_at": _utc_now(),
+        "inputs": inputs,
+    }
+    path.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def export_ecm_simulation_evidence(
+    out_dir: Path | str,
+    *,
+    cascade_report: dict[str, Any] | None = None,
+    sizing: dict[str, Any] | None = None,
+    profile: dict[str, Any] | None = None,
+    project: dict[str, Any] | None = None,
+    facility: dict[str, Any] | None = None,
+    baseline: dict[str, Any] | None = None,
+    calibration: dict[str, Any] | None = None,
+    model: dict[str, Any] | None = None,
+    weather: dict[str, Any] | None = None,
+    package_runs: list[dict[str, Any]] | None = None,
+    sequential_cascades: list[dict[str, Any]] | None = None,
+    run_artifacts: list[dict[str, Any]] | None = None,
+    warnings: list[str] | None = None,
+    write_inputs: bool = True,
+    ss_fan_hp: float | None = None,
+    ep_fan_hp: float | None = None,
+    ss_cooling_tons: float | None = None,
+    ep_cooling_tons: float | None = None,
+    ss_fan_hours: float | None = None,
+    ep_fan_hours: float | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Write ``ecm_simulation_evidence.json`` (+ optional dual-rail inputs sidecar).
+
+    Synthetic-friendly: works from cascade report + optional sizing dict alone.
+    ``dry_run=True`` builds payloads without writing files.
+    """
+    out_dir = Path(out_dir)
+    evidence = build_ecm_simulation_evidence(
+        cascade_report=cascade_report,
+        sizing=sizing,
+        profile=profile,
+        project=project,
+        facility=facility,
+        baseline=baseline,
+        calibration=calibration,
+        model=model,
+        weather=weather,
+        package_runs=package_runs,
+        sequential_cascades=sequential_cascades,
+        run_artifacts=run_artifacts,
+        warnings=warnings,
+    )
+
+    equip = evidence.get("equipment_autosizing") or {}
+    if ss_fan_hp is None:
+        ss_fan_hp = _f(equip.get("fan_hp") or (profile or {}).get("fan_hp"))
+    if ep_fan_hp is None:
+        ep_fan_hp = _f(equip.get("ep_fan_hp") or equip.get("fan_hp_autosized"))
+    if ss_cooling_tons is None:
+        ss_cooling_tons = _f(equip.get("cooling_tons") or (profile or {}).get("cooling_tons"))
+    if ep_cooling_tons is None:
+        ep_cooling_tons = _f(equip.get("ep_cooling_tons") or equip.get("cooling_tons_autosized"))
+
+    linked = [m["measure_id"] for m in evidence.get("individual_measures") or [] if m.get("measure_id")]
+    inputs = build_dual_rail_sizing_inputs(
+        ss_fan_hp=ss_fan_hp,
+        ep_fan_hp=ep_fan_hp,
+        ss_cooling_tons=ss_cooling_tons,
+        ep_cooling_tons=ep_cooling_tons,
+        ss_fan_hours=ss_fan_hours,
+        ep_fan_hours=ep_fan_hours,
+        linked_measure_ids=linked,
+    )
+
+    result: dict[str, Any] = {
+        "ok": True,
+        "dry_run": dry_run,
+        "evidence": evidence,
+        "inputs": inputs,
+        "evidence_path": None,
+        "inputs_path": None,
+    }
+    if dry_run:
+        return result
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ev_path = out_dir / EVIDENCE_FILENAME
+    ev_path.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+    result["evidence_path"] = str(ev_path)
+
+    if write_inputs:
+        in_path = write_engineering_inputs(out_dir / INPUTS_FILENAME, inputs)
+        result["inputs_path"] = str(in_path)
+    return result
+
+
+def maybe_export_from_agent_build(
+    out_dir: Path | str,
+    *,
+    report: dict[str, Any] | None = None,
+    profile: dict[str, Any] | None = None,
+    sizing: dict[str, Any] | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any] | None:
+    """Light hook for agent-build: emit evidence when cascade/sizing available."""
+    report = report or {}
+    has_cascade = bool(report.get("savings_by_measure"))
+    has_sizing = bool(sizing) or bool(report.get("equipment_autosizing"))
+    if not has_cascade and not has_sizing and not profile:
+        # Still emit a minimal dual-rail pair so Stage-1 sidecars exist for dry paths.
+        return export_ecm_simulation_evidence(
+            out_dir,
+            cascade_report={},
+            profile=profile or {},
+            sizing=sizing,
+            dry_run=dry_run,
+            warnings=["agent_build: no cascade savings — synthetic dual-rail Inputs only"],
+        )
+    return export_ecm_simulation_evidence(
+        out_dir,
+        cascade_report=report if has_cascade or report else {},
+        profile=profile,
+        sizing=sizing or report.get("equipment_autosizing"),
+        dry_run=dry_run,
+    )
+
+
+__all__ = [
+    "EVIDENCE_SCHEMA_VERSION",
+    "EVIDENCE_FILENAME",
+    "INPUTS_FILENAME",
+    "INPUTS_SCHEMA_VERSION",
+    "engineering_input",
+    "validate_engineering_inputs",
+    "build_dual_rail_sizing_inputs",
+    "build_ecm_simulation_evidence",
+    "write_engineering_inputs",
+    "export_ecm_simulation_evidence",
+    "maybe_export_from_agent_build",
+]

--- a/vibe_code_apps_20/wattlab/ecm/run_on_twin.py
+++ b/vibe_code_apps_20/wattlab/ecm/run_on_twin.py
@@ -73,6 +73,7 @@ def run_ecms_on_twin(
     from wattlab.ecm.compare import (
         build_compare_from_cascade,
         compare_path,
+        merge_full_parity_ss,
         write_compare as _write,
     )
     from wattlab.notebooks.twin_cascade import cascade_measures_on_twin
@@ -97,6 +98,7 @@ def run_ecms_on_twin(
             twin_run=twin_dir.name,
         )
         stub["energyplus"]["status"] = "dry_run"
+        merge_full_parity_ss(stub, workspace / "reports")
         out: dict[str, Any] = {
             "ok": True,
             "dry_run": True,
@@ -118,6 +120,7 @@ def run_ecms_on_twin(
         cascade_dir=report.get("out_dir"),
         profile=profile,
     )
+    merge_full_parity_ss(compare, workspace / "reports")
     result: dict[str, Any] = {
         "ok": True,
         "dry_run": False,

--- a/vibe_code_apps_20/wattlab/notebooks/builder.py
+++ b/vibe_code_apps_20/wattlab/notebooks/builder.py
@@ -1594,12 +1594,20 @@ def agent_build_notebook(
     measure_ids: list[str] | tuple[str, ...] | None = None,
     twin_run: str | Path | None = None,
     write_manifest: bool = True,
+    export_evidence: bool = True,
+    evidence_dry_run: bool = False,
+    sizing: dict[str, Any] | None = None,
 ) -> dict[str, Path]:
-    """Agent-owned workbook write (BUG-050). Soft Twin paste — never fails on missing E+."""
+    """Agent-owned workbook write (BUG-050). Soft Twin paste — never fails on missing E+.
+
+    When ``export_evidence`` is true, also writes Stage-1
+    ``ecm_simulation_evidence.json`` + dual-rail ``ecm_engineering_inputs.json``
+    sidecars beside the workbook (dry_run skips disk writes for evidence only).
+    """
     twin_label = None
     if twin_run is not None:
         twin_label = str(twin_run)
-    return build_and_save_notebook(
+    written = build_and_save_notebook(
         package_id,
         out_dir,
         profile=profile,
@@ -1610,6 +1618,25 @@ def agent_build_notebook(
         write_manifest=write_manifest,
         use_template=True,
     )
+    if export_evidence:
+        try:
+            from wattlab.ecm.evidence_export import maybe_export_from_agent_build
+
+            ev = maybe_export_from_agent_build(
+                out_dir,
+                report=report or {},
+                profile=profile,
+                sizing=sizing,
+                dry_run=evidence_dry_run,
+            )
+            if ev and ev.get("evidence_path"):
+                written["evidence"] = Path(ev["evidence_path"])
+            if ev and ev.get("inputs_path"):
+                written["engineering_inputs"] = Path(ev["inputs_path"])
+        except Exception:
+            # Soft path — workbook remains the primary agent-build artifact.
+            pass
+    return written
 
 
 def sync_notebook_from_twin(

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -1,6 +1,6 @@
 """ECMs — simple spreadsheet vs EnergyPlus compare (energy, cost, ROI).
 
-Spreadsheet calcs come from external sources later (columns stay pending).
+Spreadsheet calcs come from external sources / full-parity merge when present.
 EnergyPlus side = cascade on best G14 Twin via MCP/DinD simulate.
 """
 
@@ -15,8 +15,10 @@ import streamlit as st
 
 from wattlab.ecm.compare import (
     compare_path,
+    discover_notebook_xlsx,
     empty_compare_stub,
     load_compare,
+    merge_full_parity_ss,
     write_compare,
 )
 from wattlab.ecm.run_on_twin import DEFAULT_G36_ECMS, run_ecms_on_twin
@@ -57,7 +59,7 @@ def _compare_table(payload: dict[str, Any]) -> pd.DataFrame:
 def render(*, profile: dict[str, Any] | None = None) -> None:
     st.header("ECMs")
     st.caption(
-        "Two columns of truth: **spreadsheet** (external ESCO books — pending) vs "
+        "Two columns of truth: **spreadsheet** (full-parity / external ESCO when present) vs "
         "**EnergyPlus** (best calibrated Twin + MCP/DinD). "
         "ROI is a first-year screening attempt, not a bid."
     )
@@ -65,9 +67,10 @@ def render(*, profile: dict[str, Any] | None = None) -> None:
     ws = workspace_root()
     reports = reports_dir()
     path = compare_path(reports)
-    payload = load_compare(path)
+    payload = load_compare(path, reports_dir=reports)
     if payload is None:
         payload = empty_compare_stub(measure_ids=list(DEFAULT_G36_ECMS))
+        merge_full_parity_ss(payload, reports)
         write_compare(path, payload)
 
     # --- Run controls ---
@@ -88,6 +91,7 @@ def render(*, profile: dict[str, Any] | None = None) -> None:
                     write_compare=True,
                 )
                 payload = result.get("compare") or payload
+                merge_full_parity_ss(payload, reports)
                 if result.get("ok"):
                     st.success(
                         f"Wrote `{result.get('compare_path')}` · twin=`{result.get('twin_run')}`"
@@ -105,7 +109,7 @@ def render(*, profile: dict[str, Any] | None = None) -> None:
         st.subheader("Spreadsheet calc")
         st.info(
             f"Status: **{ss.get('status', 'pending_external')}**  \n"
-            f"{ss.get('note') or 'Drop external ESCO workbooks later — columns stay blank for now.'}"
+            f"{ss.get('note') or 'Drop external ESCO / full-parity compare JSON — columns stay blank until present.'}"
         )
     with b:
         st.subheader("EnergyPlus calc")
@@ -134,21 +138,22 @@ def render(*, profile: dict[str, Any] | None = None) -> None:
         st.write(payload.get("honesty") or "")
         st.code(json.dumps({"path": str(path), "schema": payload.get("schema")}, indent=2))
         st.caption(
-            "Agent-built WattLab screening xlsx files are retired from this page. "
-            "Use EnergyPlus for measure deltas; wire external spreadsheets into "
-            "`ss_*` fields when those books are ready."
+            "Spreadsheet ``ss_*`` fills from ``reports/ecm_full_parity_compare.json`` when present "
+            "(BUG-ECM-015 / ENH-VIBE-002). EnergyPlus remains the Twin cascade path."
         )
 
-    # Optional: still allow download of any leftover notebooks without promoting them
+    # Nested notebooks under reports/notebooks/** (full_parity_ecm/, packages, …)
     nb_dir = reports / "notebooks"
-    leftovers = sorted(nb_dir.glob("*.xlsx")) if nb_dir.is_dir() else []
+    leftovers = discover_notebook_xlsx(nb_dir)
     if leftovers:
         with st.expander("Legacy notebooks on disk (not the product path)", expanded=False):
             for p in leftovers:
+                rel = p.relative_to(nb_dir) if p.is_relative_to(nb_dir) else Path(p.name)
+                key = f"legacy_dl_{rel.as_posix().replace('/', '__')}"
                 st.download_button(
-                    f"Download {p.name}",
+                    f"Download {rel.as_posix()}",
                     data=p.read_bytes(),
                     file_name=p.name,
                     mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                    key=f"legacy_dl_{p.name}",
+                    key=key,
                 )


### PR DESCRIPTION
## Summary
- **ENH-VIBE-002 / BUG-ECM-015:** merge `reports/ecm_full_parity_compare.json` into Studio `ss_*` when present; recursive notebook picker under `reports/notebooks/**`.
- **Stage 1:** `ecm_simulation_evidence.json` exporter + dual-rail Inputs sidecar; soft hook from agent-build.
- **ENH-VIBE-001 / ownership:** AGENTS.md + session log — Open-FDD owns schemas/workbook; vibe20 owns IDF/sim/evidence export.

Companion: open-fdd ECM Stage 1/2 + Gate C honesty PR.

## Test plan
- [x] `cd vibe_code_apps_20 && pytest tests/test_ecm_evidence_stage1.py tests/test_ecm_compare.py -q`
- [ ] CI green on PR
- [ ] Studio: drop full-parity JSON and confirm `ss_*` populate


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stage 1 ECM evidence exports, including simulation evidence and dual-rail engineering input files.
  * Added optional dry-run evidence generation without writing files.
  * Added automatic spreadsheet parity data merging into ECM comparisons.
  * Added recursive discovery and download support for nested notebook spreadsheets.

* **Bug Fixes**
  * Corrected ECM comparisons to use full-parity spreadsheet results when available.
  * Improved payback, ROI, status, and spreadsheet metadata updates from parity data.

* **Documentation**
  * Expanded guidance for feature ownership, evidence workflows, and container updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->