### PR TITLE
docs(agent): Twin ops/reheat dial AI context + G14 recipe

### DIFF
--- a/vibe_code_apps_20/SESSION_LOG.md
+++ b/vibe_code_apps_20/SESSION_LOG.md
@@ -2,6 +2,15 @@
 
 Newest first. One entry per shipped work session.
 
+## 2026-07-30 — Twin dial AI context (ops/reheat) agent docs only
+
+- Method SoT: `vibe20_agent_spec/docs/BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`
+  (generic G14 recipe — no campus IDs).
+- Playbook §2c + adaptive fuel order; skill `wattlab-twin-ops-reheat-dial`;
+  calibrate-dial links Phase 2c; AGENT_CONTEXT / AGENT_TOOLS updated + synced
+  to `docs/`, `examples/workspace_tools/`, host `~/wattlab_workspace/tools/`.
+- Docs-only (no patch CLI / eval harness in this pass).
+
 ## 2026-07-30 — ECM-ERV-001 residual + AGENT_CONTEXT full-parity SoT
 
 - **BUG-ECM-015** (prior commit on branch): `merge_full_parity_ss` accepts

--- a/vibe_code_apps_20/docs/AGENT_CONTEXT.md
+++ b/vibe_code_apps_20/docs/AGENT_CONTEXT.md
@@ -1,11 +1,135 @@
-# Agent context (pointer)
+# Agent context — WattLab Studio twin dial + ECM spreadsheet SoT
 
-**Canonical handoff:** [`../vibe20_agent_spec/docs/AGENT_CONTEXT.md`](../vibe20_agent_spec/docs/AGENT_CONTEXT.md)
+**Audience:** Cursor / product agents building WattLab Studio features that touch
+EnergyPlus twins, Uploads, G14 scoring, dial UX, or ECM Excel / Compare.
 
-**Workspace / tools seed:** [`../examples/workspace_tools/AGENT_CONTEXT.md`](../examples/workspace_tools/AGENT_CONTEXT.md)
-→ copy to `~/wattlab_workspace/tools/AGENT_CONTEXT.md` (`/data/tools` in containers).
+**Use:** Drop this file into agent context first. High-level only — not a run log.
 
-Prefer **`ECM_FULL_PARITY.xlsx`** / `build_full_parity_ecm_workbook_v2.py` for
-spreadsheet SoT (BUG-ECM-015, OFDD-UI-V20, OFDD-MCP-CTX). Do **not** treat
-matched-hours as product SoT. ERV cascade: **HAS_EP_PROTOTYPE** residual
-(ECM-ERV-001) — see canonical file.
+**Not for:** Paste entire `reports/CALIBRATE_SESSION.md` or `.artifacts/` ladders
+into every chat unless debugging a specific campaign.
+
+**Live copy:** Prefer `/data/tools/AGENT_CONTEXT.md` (host
+`~/wattlab_workspace/tools/AGENT_CONTEXT.md`) when the workspace mount has one;
+otherwise this tree copy (`vibe20_agent_spec/docs/` or
+`examples/workspace_tools/`).
+
+---
+
+## Product truth (one paragraph)
+
+WattLab Studio twins are EnergyPlus models scored against **monthly utility
+bills**. ASHRAE Guideline 14–style gates: **|NMBE| ≤ 5%** and **CVRMSE ≤ 15%**
+on **both** electricity and natural gas. Stacked campus twins (HVACTemplate →
+ExpandObjects) keep plant/terminal flows **`autosize`**. Calibration is
+**envelope → internal gains → as-operated controls / schedules**, not “pick
+boiler tons.” Product CLIs: `wattlab geo-idf`, `wattlab dial-loads`,
+`wattlab score-monthly`. Workspace CLIs live under `/data/tools` (host:
+`~/wattlab_workspace/tools`).
+
+---
+
+## ECM spreadsheet SoT (do not regress)
+
+| Prefer | Avoid as product SoT |
+| --- | --- |
+| `reports/notebooks/full_parity_ecm/ECM_FULL_PARITY.xlsx` | `ECM_EPLUS_MATCHED_HOURS.xlsx` / matched-hours books |
+| `tools/build_full_parity_ecm_workbook_v2.py` | Treating calendar FanAvail hours as FLH Inputs |
+| `reports/ecm_full_parity_compare.json` → Studio `ss_*` | Inventing spreadsheet kWh/USD in Compare |
+
+- **BUG-ECM-015:** Studio `merge_full_parity_ss` accepts top-level **`rows`** and
+  maps **`annual_usd` → `ss_usd`** (plus existing aliases). Fixed in
+  `wattlab/ecm/compare.py`.
+- **OFDD-UI-V20:** Open-FDD WattLab section embeds vibe20 Studio pages; shared
+  `/data` workspace; honest E+ runner status (never fake cascade).
+- **OFDD-MCP-CTX:** `openfdd-mcp` is FDD/sites/historian only — Twin/IDF/ECM Excel
+  use EnergyPlus-MCP + WattLab `tools/` (see open-fdd
+  `docs/mcp-agents/companion-wattlab-energyplus.md`).
+- **BUG-ECM-014:** Calendar hours ≠ formula FLH; Matchup sheet in v2 is supporting
+  evidence, **not** the spreadsheet SoT.
+
+### ECM-ERV-001 residual (honest)
+
+Catalog id **`ECM-ERV`** (workbook alias **`ECM-AHU-ERV`**) stays
+`PRODUCTION_PROXY_ONLY` with `energyplus_patch: null`. Stub registry entry
+`erv_ahu_prototype` is **`HAS_EP_PROTOTYPE`** only
+(`wattlab.energyplus.patches.prototype_residuals`) — **not** a product cascade
+patch. Full ERV HX on Twin needs OA↔exhaust topology the stacked 1-zone/floor
+G14 Twin lacks. Screen via full-parity `ss_*` (~29.8k kWh Liberty B100); cascade
+must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
+
+---
+
+## Dial order (adaptive — do not skip geometry)
+
+1. **Geometry** — Confirm what the human wants (e.g. N stacked floors × 1 zone).
+   DOE midrise×4 perimeter-core is a different twin; do not substitute silently.
+2. **Weather + bills** — AMY EPW overlapping bill months. Bills must match the
+   building (shared elec allocation + **that** building’s gas).
+3. **Annual gas short → envelope first** — Raise WWR, then leakier glass U, then
+   infiltration ACH. Do **not** start with plant oversizing.
+4. **Annual elec short → EPD / LPD** — Hold these steady while chasing **shape**.
+5. **Monthly shape — which fuel’s CV fails?** (do **not** always gas-then-elec)
+   - Elec long in shoulders / short in peak cool months → **ops first** (fan
+     hours, OA, DAT) before more glass — see skill `wattlab-twin-ops-reheat-dial`.
+   - Gas CV fail with elec already pass → **reheat / HW / winter fans** only
+     (daytime HW, not full plant off). Do not undo elec knobs blindly.
+   - Classic gas shape after annual flat: banded SAT, VAV min-flow, seasonal OA.
+6. **Reheat coupling** — cool DAT + long fans + low OA → more reheat → gas up
+   unless HW is scheduled/softened. Dial **both sides** of the coil story.
+7. **Publish** — Score both fuels → write Twin G14 scorecard → promote CURRENT /
+   best model when the human asks. Barely-≤15% CV is provisional (“edge pass”).
+
+---
+
+## Hard-won rules (agents keep relearning these)
+
+| Rule | Why |
+| --- | --- |
+| Annual flat ≠ monthly good | Winter/summer can cancel; CVRMSE still fails. |
+| Bills ≠ HDD | Peak bill months may not match coldest weather — fix with OA/ops, not more glass. |
+| Cold summer SAT only where DAT dumps | Broad “Apr–Oct @ 50°F” can blow shoulder months (Oct/Aug). |
+| Adaptive fuel order | Default gas-then-elec; **flip to elec-first** when monthly ±% is cooling/runtime-shaped. |
+| Full HW off is a trap | Daytime-only HW in spike months; plant kill → gas ≈ −100% that month. |
+| Reheat coupling | More mechanical cooling raises gas unless HW hours/SP are dialed too. |
+| Autosize stays on | Dialing ≠ naming plant capacity. |
+| Paths/args for any building | Never bake one campus id into product defaults. |
+| G14 needs **both** fuels | Gas-only pass is not done. Never promote a run that flips the other fuel. |
+| Full-parity ≠ matched-hours | Prefer `ECM_FULL_PARITY.xlsx` / v2 builder for Compare `ss_*`. |
+
+---
+
+## What “done” looks like
+
+- Scorecard + monthly charts for both fuels (including monthly ±% dial chart).
+- Preferred IDF / run promoted (Uploads + `CURRENT_RUN` / best-model freeze).
+- Assumptions logged (envelope + controls + **ops/HW schedule** story in one place).
+- ECMs Compare: `ss_*` from full-parity merge when present; `ep_*` only from real
+  cascade (never invent).
+
+---
+
+## Where to go deeper (optional)
+
+| Doc | When |
+| --- | --- |
+| [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md) | Ordered phases + §2c ops/HW |
+| Skill `wattlab-twin-calibrate-dial` | Envelope → SAT / VAV phases |
+| Skill `wattlab-twin-ops-reheat-dial` | As-operated + reheat chess |
+| [`BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`](BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md) | Method SoT (generic dial recipe) |
+| [`AGENT_TOOLS.md`](AGENT_TOOLS.md) | `/data/tools` campaign scripts vs product CLIs |
+| [`BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`](BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md) | BUG-ECM-* / ENH-ECM-* register |
+| Product `wattlab-assumptions` | Short/long fuel + checklist |
+| `reports/CALIBRATE_SESSION.md` | One campus’s full dial log (not default context) |
+
+---
+
+## Studio wiring (agents shipping features)
+
+- Twin G14 UI reads **scorecard JSON**, not raw `eplusout.sql` alone.
+- Uploads / prototypes path must match where dialed IDFs are published.
+- Engineering Findings (docx/json) is a **separate** reporting path from twin
+  calibrate — do not conflate FDD findings DOCX with G14 dial status.
+- ECMs tab: checkbox proxies vs calibrated Twin baseline; ERV / toilet-exhaust
+  recovery are **PRODUCTION_PROXY_ONLY** with ERV EnergyPlus path
+  **HAS_EP_PROTOTYPE** residual until Twin topology + product patch land
+  (ECM-ERV-001).

--- a/vibe_code_apps_20/examples/workspace_tools/AGENT_CONTEXT.md
+++ b/vibe_code_apps_20/examples/workspace_tools/AGENT_CONTEXT.md
@@ -59,7 +59,7 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
 
 ---
 
-## Dial order (do not skip)
+## Dial order (adaptive — do not skip geometry)
 
 1. **Geometry** — Confirm what the human wants (e.g. N stacked floors × 1 zone).
    DOE midrise×4 perimeter-core is a different twin; do not substitute silently.
@@ -67,17 +67,17 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
    building (shared elec allocation + **that** building’s gas).
 3. **Annual gas short → envelope first** — Raise WWR, then leakier glass U, then
    infiltration ACH. Do **not** start with plant oversizing.
-4. **Annual elec short → EPD / LPD** — Hold these steady while chasing gas
-   **shape** once annual elec is near gate.
-5. **Monthly gas CVRMSE** — After annual gas ~flat. Use **vibe19 AHU DAT** (or
-   site ops) before inventing SAT. Typical levers: seasonal/banded cooling SAT,
-   scheduled VAV min-flow, **seasonal outdoor-air hours** (often more powerful
-   than SAT alone when bills ≠ HDD).
-6. **Monthly elec CVRMSE** — After gas is near/pass. Prefer **month-aware light /
-   equipment schedules** over blunt annual LPD cuts (flat cuts trade months and
-   can break gas).
+4. **Annual elec short → EPD / LPD** — Hold these steady while chasing **shape**.
+5. **Monthly shape — which fuel’s CV fails?** (do **not** always gas-then-elec)
+   - Elec long in shoulders / short in peak cool months → **ops first** (fan
+     hours, OA, DAT) before more glass — see skill `wattlab-twin-ops-reheat-dial`.
+   - Gas CV fail with elec already pass → **reheat / HW / winter fans** only
+     (daytime HW, not full plant off). Do not undo elec knobs blindly.
+   - Classic gas shape after annual flat: banded SAT, VAV min-flow, seasonal OA.
+6. **Reheat coupling** — cool DAT + long fans + low OA → more reheat → gas up
+   unless HW is scheduled/softened. Dial **both sides** of the coil story.
 7. **Publish** — Score both fuels → write Twin G14 scorecard → promote CURRENT /
-   best model when the human asks.
+   best model when the human asks. Barely-≤15% CV is provisional (“edge pass”).
 
 ---
 
@@ -88,10 +88,12 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
 | Annual flat ≠ monthly good | Winter/summer can cancel; CVRMSE still fails. |
 | Bills ≠ HDD | Peak bill months may not match coldest weather — fix with OA/ops, not more glass. |
 | Cold summer SAT only where DAT dumps | Broad “Apr–Oct @ 50°F” can blow shoulder months (Oct/Aug). |
-| Gas shape before elec shape | Elec-first LPD cuts often wreck a hard-won gas pass. |
+| Adaptive fuel order | Default gas-then-elec; **flip to elec-first** when monthly ±% is cooling/runtime-shaped. |
+| Full HW off is a trap | Daytime-only HW in spike months; plant kill → gas ≈ −100% that month. |
+| Reheat coupling | More mechanical cooling raises gas unless HW hours/SP are dialed too. |
 | Autosize stays on | Dialing ≠ naming plant capacity. |
 | Paths/args for any building | Never bake one campus id into product defaults. |
-| G14 needs **both** fuels | Gas-only pass is not done. |
+| G14 needs **both** fuels | Gas-only pass is not done. Never promote a run that flips the other fuel. |
 | Full-parity ≠ matched-hours | Prefer `ECM_FULL_PARITY.xlsx` / v2 builder for Compare `ss_*`. |
 
 ---
@@ -100,7 +102,7 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
 
 - Scorecard + monthly charts for both fuels (including monthly ±% dial chart).
 - Preferred IDF / run promoted (Uploads + `CURRENT_RUN` / best-model freeze).
-- Assumptions logged (envelope + controls + schedule story in one place).
+- Assumptions logged (envelope + controls + **ops/HW schedule** story in one place).
 - ECMs Compare: `ss_*` from full-parity merge when present; `ep_*` only from real
   cascade (never invent).
 
@@ -110,8 +112,10 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
 
 | Doc | When |
 | --- | --- |
-| [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md) | Ordered phases + practice trajectory |
-| Skill `wattlab-twin-calibrate-dial` | Agent skill frontmatter + same phases |
+| [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md) | Ordered phases + §2c ops/HW |
+| Skill `wattlab-twin-calibrate-dial` | Envelope → SAT / VAV phases |
+| Skill `wattlab-twin-ops-reheat-dial` | As-operated + reheat chess |
+| [`BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`](BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md) | Method SoT (generic dial recipe) |
 | [`AGENT_TOOLS.md`](AGENT_TOOLS.md) | `/data/tools` campaign scripts vs product CLIs |
 | [`BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`](BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md) | BUG-ECM-* / ENH-ECM-* register |
 | Product `wattlab-assumptions` | Short/long fuel + checklist |

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_CONTEXT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_CONTEXT.md
@@ -59,7 +59,7 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
 
 ---
 
-## Dial order (do not skip)
+## Dial order (adaptive — do not skip geometry)
 
 1. **Geometry** — Confirm what the human wants (e.g. N stacked floors × 1 zone).
    DOE midrise×4 perimeter-core is a different twin; do not substitute silently.
@@ -67,17 +67,17 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
    building (shared elec allocation + **that** building’s gas).
 3. **Annual gas short → envelope first** — Raise WWR, then leakier glass U, then
    infiltration ACH. Do **not** start with plant oversizing.
-4. **Annual elec short → EPD / LPD** — Hold these steady while chasing gas
-   **shape** once annual elec is near gate.
-5. **Monthly gas CVRMSE** — After annual gas ~flat. Use **vibe19 AHU DAT** (or
-   site ops) before inventing SAT. Typical levers: seasonal/banded cooling SAT,
-   scheduled VAV min-flow, **seasonal outdoor-air hours** (often more powerful
-   than SAT alone when bills ≠ HDD).
-6. **Monthly elec CVRMSE** — After gas is near/pass. Prefer **month-aware light /
-   equipment schedules** over blunt annual LPD cuts (flat cuts trade months and
-   can break gas).
+4. **Annual elec short → EPD / LPD** — Hold these steady while chasing **shape**.
+5. **Monthly shape — which fuel’s CV fails?** (do **not** always gas-then-elec)
+   - Elec long in shoulders / short in peak cool months → **ops first** (fan
+     hours, OA, DAT) before more glass — see skill `wattlab-twin-ops-reheat-dial`.
+   - Gas CV fail with elec already pass → **reheat / HW / winter fans** only
+     (daytime HW, not full plant off). Do not undo elec knobs blindly.
+   - Classic gas shape after annual flat: banded SAT, VAV min-flow, seasonal OA.
+6. **Reheat coupling** — cool DAT + long fans + low OA → more reheat → gas up
+   unless HW is scheduled/softened. Dial **both sides** of the coil story.
 7. **Publish** — Score both fuels → write Twin G14 scorecard → promote CURRENT /
-   best model when the human asks.
+   best model when the human asks. Barely-≤15% CV is provisional (“edge pass”).
 
 ---
 
@@ -88,10 +88,12 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
 | Annual flat ≠ monthly good | Winter/summer can cancel; CVRMSE still fails. |
 | Bills ≠ HDD | Peak bill months may not match coldest weather — fix with OA/ops, not more glass. |
 | Cold summer SAT only where DAT dumps | Broad “Apr–Oct @ 50°F” can blow shoulder months (Oct/Aug). |
-| Gas shape before elec shape | Elec-first LPD cuts often wreck a hard-won gas pass. |
+| Adaptive fuel order | Default gas-then-elec; **flip to elec-first** when monthly ±% is cooling/runtime-shaped. |
+| Full HW off is a trap | Daytime-only HW in spike months; plant kill → gas ≈ −100% that month. |
+| Reheat coupling | More mechanical cooling raises gas unless HW hours/SP are dialed too. |
 | Autosize stays on | Dialing ≠ naming plant capacity. |
 | Paths/args for any building | Never bake one campus id into product defaults. |
-| G14 needs **both** fuels | Gas-only pass is not done. |
+| G14 needs **both** fuels | Gas-only pass is not done. Never promote a run that flips the other fuel. |
 | Full-parity ≠ matched-hours | Prefer `ECM_FULL_PARITY.xlsx` / v2 builder for Compare `ss_*`. |
 
 ---
@@ -100,7 +102,7 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
 
 - Scorecard + monthly charts for both fuels (including monthly ±% dial chart).
 - Preferred IDF / run promoted (Uploads + `CURRENT_RUN` / best-model freeze).
-- Assumptions logged (envelope + controls + schedule story in one place).
+- Assumptions logged (envelope + controls + **ops/HW schedule** story in one place).
 - ECMs Compare: `ss_*` from full-parity merge when present; `ep_*` only from real
   cascade (never invent).
 
@@ -110,8 +112,10 @@ must report `NO_EP` until topology + product patch land. Toilet-zone ERV later.
 
 | Doc | When |
 | --- | --- |
-| [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md) | Ordered phases + practice trajectory |
-| Skill `wattlab-twin-calibrate-dial` | Agent skill frontmatter + same phases |
+| [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md) | Ordered phases + §2c ops/HW |
+| Skill `wattlab-twin-calibrate-dial` | Envelope → SAT / VAV phases |
+| Skill `wattlab-twin-ops-reheat-dial` | As-operated + reheat chess |
+| [`BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`](BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md) | Method SoT (generic dial recipe) |
 | [`AGENT_TOOLS.md`](AGENT_TOOLS.md) | `/data/tools` campaign scripts vs product CLIs |
 | [`BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md`](BUG_REPORT_ECM_SPREADSHEET_VS_EPLUS.md) | BUG-ECM-* / ENH-ECM-* register |
 | Product `wattlab-assumptions` | Short/long fuel + checklist |

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/AGENT_TOOLS.md
@@ -20,8 +20,9 @@ Seed themes: [`examples/workspace_tools/`](../../examples/workspace_tools/).
 Human workspace copies often live at `~/wattlab_workspace/tools/` (not in git).
 
 **Primary AI handoff (high-level):** [`AGENT_CONTEXT.md`](AGENT_CONTEXT.md).
-Deeper dial phases: [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md) · skill
-`skills/wattlab-twin-calibrate-dial/SKILL.md`.
+Deeper dial phases: [`TWIN_DIAL_PLAYBOOK.md`](TWIN_DIAL_PLAYBOOK.md) · skills
+`wattlab-twin-calibrate-dial` + `wattlab-twin-ops-reheat-dial`.
+Method SoT (ops/reheat chess, generic): [`BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`](BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md).
 
 ECM spreadsheet SoT: prefer `ECM_FULL_PARITY.xlsx` via
 `build_full_parity_ecm_workbook_v2.py` + `ecm_full_parity_compare.json` merge
@@ -29,9 +30,10 @@ ECM spreadsheet SoT: prefer `ECM_FULL_PARITY.xlsx` via
 
 **Twin calibrate dial** (short/long gas & elec, monthly shape): envelope first
 (WWR / U / ACH), then banded SAT + VAV min-flow; EnergyPlus stays **autosize**.
+**Adaptive fuel order:** when monthly ±% is cooling/runtime-shaped, dial ops
+(fans/OA/DAT) before more glass; recover gas with **daytime HW** (not plant kill).
 After gas shape near/pass, prefer **month-aware light/equipment schedules** over
-blunt annual LPD cuts.
-
+blunt annual LPD cuts unless residuals are clearly ops-shaped.
 ## Layout
 
 ```text

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md
@@ -1,0 +1,120 @@
+# BUG_REPORT — Twin dial AI context gaps + generic G14 dial recipe
+
+**Purpose:** This is **not** a Liberty building log. It is (1) where agent/report/skill
+context falls short for dialing EnergyPlus twins to utility bills, and (2) a
+**generic** recipe distilled from a dual-AHU campaign that reached full G14.
+
+**Status:** Method SoT until playbook + skills fully absorb §2. Campus run tables
+stay in `BEST_MODELS` / liberty reports only — do not paste building IDs here as
+product defaults.
+
+G14 gate (both fuels): **|NMBE| ≤ 5%** and **CVRMSE ≤ 15%**.
+
+Example outcome (shape-led campaign, fuel-agnostic lesson):
+
+| Fuel | NMBE | CVRMSE | Pass |
+|------|------|--------|------|
+| Elec | −2.6% | 14.8% | yes |
+| Gas | −0.2% | 15.0% | yes (barely) |
+
+---
+
+## 1. Where AI context is falling short
+
+### A. Reports (`wattlab_workspace/reports/`)
+
+| Gap | Why it hurts agents |
+|-----|---------------------|
+| **No durable “ops / as-operated” dial chapter** | Agents only see envelope→SAT→VAV playbooks. They miss: fan runtime by month, 24/7 + 0% OA months, partial HW (daytime) vs plant kill. |
+| **BUG_REPORT used as campus scratch** | Builder agents get building IDs / run names instead of transferable dial physics. |
+| **No tradeoff matrix (elec↔gas)** | Cool DAT + long fans fixes elec short → reheat gas explodes. Full HW off fixes gas spike → gas −100% that month. **Partial HW hours** is the missing middle — undocumented in reports. |
+| **No “which fuel first?” decision tree** | Skills say “gas before elec.” Campaign needed **elec-first** when spring chiller / Oct cooling dominated CV, then gas recovery. Reports don’t say when to flip order. |
+| **Scoreboard ≠ method** | `BEST_MODELS` / liberty tables list pass/fail runs but not the *generic knob sequence* that closed CV. |
+| **Provisional near-gate CV** | Barely-≤15% gas CV has no “freeze vs keep dialing” rule in reports. |
+
+### B. Tools docs (`wattlab_workspace/tools/`)
+
+| Artifact | Has | Missing |
+|----------|-----|---------|
+| `TWIN_DIAL_PLAYBOOK.md` | Envelope, banded SAT, VAV min, OA, CHW free-cool, soft HW | Operator fan/OA schedules; HW **availability by hour**; elec-first path; reheat coupling trap |
+| `AGENT_CONTEXT.md` | Best-run pointers, ECM after G14 | Points at BUG_REPORT for bugs — but no dial physics; still campus-run-centric |
+| `skills/wattlab-twin-calibrate-dial` | Phase 0–3, Liberty-heavy triggers | Same gaps as playbook; description still Building 50/100–centric |
+| `patch_dual_ahu_from_dump.py` | Dump DAT/fan, soft HW, `--oct-plant-off` | No flags for: Aug 24/7+0% OA, Mar–Jun short fans, Aug/Oct **daytime HW**, winter fan cut |
+| `dial_dual_ahu_ops_*.py` | **Encoded the winning knobs** (scripts) | Not lifted into playbook/skill/report — tribal knowledge in one-off CLIs |
+| `score_g14_monthly.py` | Correct gate | No “monthly residual → suggested knob” helper for agents |
+
+### C. vibe20 agent spec (`py-bacnet-stacks-playground/.../vibe20_agent_spec`)
+
+| Has | Missing |
+|-----|---------|
+| Twin dial skill + playbook + Studio/ECM skills | No skill for **as-operated schedule hypothesis** from FDD/dump → IDF |
+| Controls-FDD skill | Does not close the loop: FDD finding → monthly bill residual → G14 knob |
+| Docs assume gas-then-elec | No dual-fuel CV chess (hold elec pass while dialing gas) |
+
+### D. open-fdd (`open-fdd/openfdd_agent_spec`)
+
+| Has | Missing |
+|-----|---------|
+| Architecture: “E+ calibration stays in vibe20” | **Zero** G14 / NMBE / CVRMSE / dial skills |
+| SQL FDD, cookbook, ECM engineering | No “fault / ops story → Twin schedule patch” skill |
+| Ownership splits FDD vs Twin | Agents in open-fdd have no recipe when bills disagree with model |
+
+### E. Eval
+
+| Gap |
+|-----|
+| No eval harness that scores an agent on: given monthly ±% table → propose ≤N knobs → expect CV improvement without flipping the other fuel |
+| No golden “tradeoff traps” cases (cool Oct DAT; HW full-off; May CHW off) |
+
+**Bottom line:** Tools *implement* pieces of the dial; skills/playbooks teach envelope+SAT era; **reports never captured the ops/reheat chess that actually closed dual-fuel G14.** Planet-wide, there is still no first-class agent skill for that loop.
+
+---
+
+## 2. Generic dial recipe (transferable — no campus IDs)
+
+### Gate
+Both fuels: `|NMBE| ≤ 5%` and `CVRMSE ≤ 15%`. Annual % alone ≠ calibrated.
+
+### Order (adaptive)
+1. **Geometry + AMY + bills lock**
+2. **Annual** short/long → envelope / LPD (classic)
+3. Look at **which fuel’s CV fails** and **which months**:
+   - Elec long in spring / short in peak cool months → **runtime & OA & DAT** (ops) before more glass
+   - Gas CV fail with elec already pass → **reheat / HW / winter fans** only (do not undo elec knobs blindly)
+4. One hypothesis per run; score both fuels every time
+
+### Elec-shape knobs (as-operated)
+| Symptom | Try |
+|---------|-----|
+| Shoulder months elec **long** | Shorten AHU fan hours those months |
+| Peak cool month elec **short** | Longer fans and/or cooler DAT and/or lower OA (more mechanical) |
+| Peak month short + dump says recirc | **Fans on, OA ≈ 0** (even 24/7) |
+
+### Gas recovery without killing elec (the missing chapter)
+| Symptom | Try | Trap |
+|---------|-----|------|
+| Gas spike after cooler DAT / longer fans | **Daytime-only HW** in spike months (not full plant off) | Full HW off → that month gas → −100% vs bills |
+| Still high gas in dump month | Soften HW OA-reset high SP; warm DAT slightly; shorten HW hours | Cooler DAT alone without HW control |
+| Winter gas high | Shorter winter fan hours; softer HW | Cutting OA/fans can also cut useful reheat shoulder months |
+| Shoulder gas short | Cooler DAT and/or higher VAV min-flow those months | Raises chiller elec — watch elec CV |
+| Near gas CV gate (~15–17) | Stack small knobs: winter fans + spring DAT + VAV min bump | One big plant-off usually overshoots |
+
+### Reheat coupling (always print this)
+```
+more mechanical cooling (cool DAT, long fans, low OA)
+  → more reheat opportunity
+  → gas up unless HW is scheduled/softened
+```
+Dial **both sides** of the coil story.
+
+### Score honesty
+- Prefer dual pass with gas CV **barely** ≤15 only as provisional; freeze after a margin or document “edge pass.”
+- Never promote a run that flips the previously-passing fuel.
+
+---
+
+## 3. What to add next (implementation backlog — not this docs pass)
+
+1. Lift ops CLI patterns into `patch_*` flags + playbook section (partially absorbed in playbook §2c / skill).
+2. vibe20 eval: 3 golden monthly residual → knob quizzes (cool-DAT reheat trap; HW full-off trap; elec-first then gas).
+3. Keep this BUG_REPORT as the **method** SoT until playbook/skill absorb it fully; campus run tables stay in `BEST_MODELS` / liberty only.

--- a/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_DIAL_PLAYBOOK.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/docs/TWIN_DIAL_PLAYBOOK.md
@@ -3,8 +3,10 @@
 Living playbook for agents dialing WattLab Studio twins. **Start here (short):**
 [`AGENT_CONTEXT.md`](AGENT_CONTEXT.md). Skills:
 [`wattlab-twin-calibrate-dial`](../skills/wattlab-twin-calibrate-dial/SKILL.md),
+[`wattlab-twin-ops-reheat-dial`](../skills/wattlab-twin-ops-reheat-dial/SKILL.md),
 [`wattlab-assumptions`](../skills/wattlab-assumptions/SKILL.md) (§ Short/long fuel).
 Tools bin context: [`AGENT_TOOLS.md`](AGENT_TOOLS.md).
+Method SoT (ops/reheat chess): [`BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`](BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md).
 
 Practice campus trajectories (Liberty-style stacked towers) are **labeled
 rehearsal evidence** — pass paths/args for any building; never bake site ids
@@ -63,12 +65,53 @@ Residual CVRMSE ~25–30% can remain after honest HVAC banding — **document it
 do not invent physics to force a 15% CV. Prefer **OA-hours / ops** over more glass
 when bills ≠ HDD.
 
-### 4. Monthly elec shape (CVRMSE) — after gas near/pass
+### 2c. As-operated schedules + HW availability (missing chapter)
 
-Gas shape before elec shape. Once gas is near/pass:
+**Method SoT:** [`BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`](BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md) ·
+skill `wattlab-twin-ops-reheat-dial`.
 
-1. Prefer **month-aware light / equipment schedules** (seasonal Schedule:Compact)
-   over blunt annual LPD/EPD cuts.
+#### Reheat coupling (always print)
+
+```
+more mechanical cooling (cool DAT, long fans, low OA)
+  → more reheat opportunity
+  → gas up unless HW is scheduled/softened
+```
+
+#### Elec-shape knobs (as-operated)
+
+| Symptom | Try |
+| --- | --- |
+| Shoulder months elec **long** | Shorten AHU fan hours those months |
+| Peak cool month elec **short** | Longer fans and/or cooler DAT and/or lower OA |
+| Peak month short + dump says recirc | **Fans on, OA ≈ 0** (even 24/7) |
+
+#### Gas recovery without killing elec
+
+| Symptom | Try | Trap |
+| --- | --- | --- |
+| Gas spike after cooler DAT / longer fans | **Daytime-only HW** in spike months | Full HW off → that month gas ≈ −100% vs bills |
+| Still high gas | Soften HW OA-reset high SP; warm DAT slightly; shorten HW hours | Cooler DAT alone without HW control |
+| Winter gas high | Shorter winter fan hours; softer HW | Cutting OA/fans can cut useful shoulder reheat |
+| Shoulder gas short | Cooler DAT and/or higher VAV min those months | Raises chiller elec — watch elec CV |
+| Near gas CV gate (~15–17) | Stack **small** knobs | One big plant-off usually overshoots |
+
+#### Score honesty
+
+- Barely-≤15% gas CV is **provisional** — freeze after a margin or stamp “edge pass.”
+- Never promote a run that flips the previously-passing fuel.
+- One hypothesis per run; score **both** fuels every time.
+
+### 4. Monthly elec / ops shape (CVRMSE) — adaptive order
+
+**Do not always wait for gas pass.** If monthly ±% shows elec long in shoulders
+or short in peak cool months while gas is near/pass (or gas is not the CV
+driver), dial **ops first** (fans / OA / DAT), then recover gas (§2c).
+
+When gas is the CV driver and elec already passes:
+
+1. Prefer **month-aware light / equipment schedules** only if residuals look
+   lighting-shaped — not when dump shows fan/OA/DAT mismatch.
 2. Flat annual LPD cuts often trade winter/summer months and can **break a hard-won
    gas pass**.
 3. Use Twin monthly ±% chart (over/under by month) to see which seasons elec is wrong.
@@ -106,4 +149,6 @@ Stamp WWR / U / ACH / SAT bands / min-flow / OA / hypothesis on
 | `/data/tools/TWIN_DIAL_PLAYBOOK.md` | Optional live copy of this playbook |
 | `/data/reports/CALIBRATE_SESSION.md` | Session narrative (human/agent append) |
 | `/data/runs/CURRENT_RUN.txt` | Preferred Twin publish |
-| `vibe20_agent_spec/skills/wattlab-twin-calibrate-dial/` | Cursor/agent skill |
+| `vibe20_agent_spec/skills/wattlab-twin-calibrate-dial/` | Cursor/agent skill (envelope → SAT) |
+| `vibe20_agent_spec/skills/wattlab-twin-ops-reheat-dial/` | As-operated + reheat / HW chess |
+| `vibe20_agent_spec/docs/BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md` | Method SoT (generic; no campus IDs) |

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-twin-calibrate-dial/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-twin-calibrate-dial/SKILL.md
@@ -3,9 +3,10 @@ name: wattlab-twin-calibrate-dial
 description: >-
   Dial EnergyPlus Twin models vs utility bills (G14). Use when gas/elec is short
   or long vs monthly bills, Twin calibrate, WWR/glass/infil ladders, seasonal SAT
-  / VAV reheat / DAT dump, or stacked Floor_1–N twins. Triggers on: calibrate,
-  G14, CVRMSE, short gas, short elec, dial knobs, WWR, infiltration, discharge
-  air temp, reheat, AMY bills, calibration_scorecard.
+  / VAV reheat / DAT dump, or stacked Floor_1–N twins. For as-operated fan/OA/HW
+  chess and adaptive elec-first order, also load wattlab-twin-ops-reheat-dial.
+  Triggers on: calibrate, G14, CVRMSE, short gas, short elec, dial knobs, WWR,
+  infiltration, discharge air temp, reheat, AMY bills, calibration_scorecard.
 ---
 
 # WattLab Twin calibrate dial playbook
@@ -16,6 +17,8 @@ the human supplies them.
 
 **Start here:** [`../../docs/AGENT_CONTEXT.md`](../../docs/AGENT_CONTEXT.md).
 Depth: [`../../docs/TWIN_DIAL_PLAYBOOK.md`](../../docs/TWIN_DIAL_PLAYBOOK.md).
+Ops/reheat Phase 2c: [`../wattlab-twin-ops-reheat-dial/SKILL.md`](../wattlab-twin-ops-reheat-dial/SKILL.md).
+Method SoT: [`../../docs/BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`](../../docs/BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md).
 Tools bin: [`../../docs/AGENT_TOOLS.md`](../../docs/AGENT_TOOLS.md).
 Assumptions hierarchy: [`../wattlab-assumptions/SKILL.md`](../wattlab-assumptions/SKILL.md).
 
@@ -71,16 +74,26 @@ Classic failure: **winter/shoulder gas high, summer gas low** (annual cancels).
 Prefer **seasonal / banded** `Schedule:Compact` on cooling SAT + scheduled VAV
 min-flow fraction over year-round constant min-flow bumps.
 
-## Phase 2b — Monthly elec shape (after gas near/pass)
+## Phase 2b — Monthly elec / ops shape (adaptive)
 
-Gas shape **before** elec shape. Prefer **month-aware light/equipment schedules**
-over blunt annual LPD cuts (flat cuts trade months and can break a gas pass).
-Use Twin **monthly ±% dial chart** to see over/under by season.
+Default is gas shape before elec shape. **Flip to elec-first ops** when monthly
+±% shows shoulder elec long / peak-cool elec short (fans, OA, DAT) — see
+[`wattlab-twin-ops-reheat-dial`](../wattlab-twin-ops-reheat-dial/SKILL.md) and
+playbook §2c. Prefer **month-aware light/equipment schedules** only when the
+residual is lighting-shaped. Blunt annual LPD cuts trade months and can break a
+gas pass. Use Twin **monthly ±% dial chart**.
 
-### Honesty
+## Phase 2c — As-operated + reheat / HW (required when ops-shaped)
+
+Always state reheat coupling: cool DAT + long fans + low OA → more reheat → gas
+up unless HW is scheduled/softened. Prefer **daytime-only HW** over full plant
+off. Full HW off → that month gas ≈ −100% vs bills. Barely-≤15% CV is provisional.
+
+## Honesty
 
 - G14 pass = both fuels \|NMBE\|≤5% **and** CVRMSE≤15%.
 - Annual % alone is **not** calibrated.
+- Never promote a run that flips the previously-passing fuel.
 - Document residual: bill shape may not track HDD (log it).
 
 ## Phase 3 — Publish / freeze

--- a/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-twin-ops-reheat-dial/SKILL.md
+++ b/vibe_code_apps_20/vibe20_agent_spec/skills/wattlab-twin-ops-reheat-dial/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: wattlab-twin-ops-reheat-dial
+description: >-
+  As-operated Twin dial for dual-fuel G14: fan/OA runtime, DAT/reheat coupling,
+  daytime HW (not plant kill), adaptive elec-first vs gas-first. Use when monthly
+  ±% shows shape fail after envelope, gas spikes after cool DAT/long fans, or
+  elec CV fails in peak cool months while gas is near pass. Triggers on: ops
+  dial, reheat, HW availability, fan hours, 0% OA, daytime HW, elec-first G14,
+  dual-fuel chess, tradeoff trap.
+---
+
+# WattLab Twin ops + reheat dial (Phase 2c)
+
+**Start here:** [`../../docs/AGENT_CONTEXT.md`](../../docs/AGENT_CONTEXT.md).  
+**Method SoT:** [`../../docs/BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md`](../../docs/BUG_REPORT_TWIN_DIAL_AI_CONTEXT.md).  
+**Envelope/SAT phases:** [`../wattlab-twin-calibrate-dial/SKILL.md`](../wattlab-twin-calibrate-dial/SKILL.md) +
+[`../../docs/TWIN_DIAL_PLAYBOOK.md`](../../docs/TWIN_DIAL_PLAYBOOK.md) §2c.
+
+EnergyPlus stays **autosize**. This skill is **schedules / setpoints / HW
+availability by hour** — not more glass when the residual is ops-shaped.
+
+## Gate (always)
+
+Both fuels: `|NMBE| ≤ 5%` and `CVRMSE ≤ 15%`. Annual % alone ≠ calibrated.
+Barely-≤15% CV is **provisional** — freeze after margin or stamp “edge pass.”
+Never promote a run that flips a previously-passing fuel.
+
+## Adaptive fuel order
+
+Default envelope playbook is gas-then-elec. **Flip when monthly ±% says so:**
+
+| Signal | Order |
+|--------|--------|
+| Elec long in shoulders / short in peak cool months | **Elec-first ops** (fans, OA, DAT), then gas recovery |
+| Gas CV fail with elec already pass | **Gas-only knobs** (HW hours, winter fans, soft HW) — do not undo elec knobs |
+| Both fail | One hypothesis per run; score **both** fuels every time |
+
+## Elec-shape (as-operated)
+
+| Symptom | Try |
+|---------|-----|
+| Shoulder elec **long** | Shorten AHU fan hours those months |
+| Peak cool month elec **short** | Longer fans and/or cooler DAT and/or lower OA |
+| Peak short + dump says recirc | **Fans on, OA ≈ 0** (even 24/7) |
+
+## Gas recovery without killing elec
+
+| Symptom | Try | Trap |
+|---------|-----|------|
+| Gas spike after cooler DAT / longer fans | **Daytime-only HW** in spike months | Full HW off → that month gas ≈ −100% vs bills |
+| Still high gas | Soften HW OA-reset high SP; warm DAT slightly; shorten HW hours | Cooler DAT alone without HW control |
+| Winter gas high | Shorter winter fan hours; softer HW | Cutting OA/fans can cut useful shoulder reheat |
+| Shoulder gas short | Cooler DAT and/or higher VAV min those months | Raises chiller elec — watch elec CV |
+| Near gas CV gate (~15–17) | Stack **small** knobs | One big plant-off usually overshoots |
+
+## Reheat coupling (always state this)
+
+```
+more mechanical cooling (cool DAT, long fans, low OA)
+  → more reheat opportunity
+  → gas up unless HW is scheduled/softened
+```
+
+Dial **both sides** of the coil story in the same campaign narrative.
+
+## FDD / dump → knob (no IDF surgery in openfdd-mcp)
+
+1. Read monthly ±% (Studio dial charts) + dump DAT/fan/OA when present.
+2. Form **one** schedule/HW hypothesis (not three knobs at once).
+3. Patch + simulate via EnergyPlus-MCP / vibe20 tools — never invent savings.
+4. Score both fuels; keep or revert if the other fuel flips.
+
+Open-FDD agents: see `docs/mcp-agents/fdd-ops-to-twin-knobs.md` (pointer only).


### PR DESCRIPTION
## Summary
- Twin dial AI context for ops/reheat chess (BUG_REPORT_TWIN_DIAL_AI_CONTEXT + playbook/skills)
- AGENT_CONTEXT / TOOLS updates for agent-driven Twin calibrate

## Test plan
- [ ] CI green
- [ ] Skills/docs paths resolve under wattlab_workspace/tools


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for calibrating dual-fuel building energy models.
  * Documented adaptive tuning workflows based on monthly electricity and gas performance.
  * Added as-operated schedule, reheat, and hot-water coupling guidance.
  * Added criteria for validating, promoting, or reverting calibration results.
  * Introduced a bug-report and reusable calibration recipe for common twin-model issues.
  * Updated related playbooks, tools guidance, and navigation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->