### PR TITLE
fix(studio): keep ECM monthly ±% fuel charts always visible

### DIFF
--- a/vibe_code_apps_20/tests/test_monthly_dial_chart.py
+++ b/vibe_code_apps_20/tests/test_monthly_dial_chart.py
@@ -61,3 +61,33 @@ def test_history_heatmap_empty_without_dirs():
     data = history_heatmap_matrix([{"run": 1}], fuel="elec")
     assert data["months"] == []
     assert data["runs"] == []
+
+
+def test_empty_monthly_pm_figure_never_none():
+    import pytest
+
+    pytest.importorskip("plotly")
+    from wattlab.studio.monthly_dial_chart import (
+        build_empty_monthly_pm_figure,
+        build_monthly_pm_figure,
+        agent_monthly_pct_prompt_text,
+    )
+
+    empty = build_empty_monthly_pm_figure(fuel="elec")
+    assert empty is not None
+    assert len(empty.data[0].x) == 12
+    ph = build_monthly_pm_figure([], fuel="gas", placeholder_when_empty=True)
+    assert ph is not None
+    assert build_monthly_pm_figure([], fuel="gas") is None
+    text = agent_monthly_pct_prompt_text(twin_hint="runs/foo")
+    assert "Please have AI agent render" in text
+    assert "utility_bills.per_month" in text
+    assert "runs/foo" in text
+
+
+def test_agent_monthly_pct_prompt_text_no_plotly():
+    from wattlab.studio.monthly_dial_chart import agent_monthly_pct_prompt_text
+
+    text = agent_monthly_pct_prompt_text()
+    assert "Please have AI agent render" in text
+    assert "observed_kwh" in text

--- a/vibe_code_apps_20/wattlab/studio/monthly_dial_chart.py
+++ b/vibe_code_apps_20/wattlab/studio/monthly_dial_chart.py
@@ -86,18 +86,100 @@ def bar_colors(pcts: list[float], *, ok_band_pct: float = DEFAULT_OK_BAND_PCT) -
     return colors
 
 
+PLACEHOLDER_MONTHS = (
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+)
+
+# Honest agent checklist when utility_bills.per_month JSON is missing.
+AGENT_MONTHLY_PCT_PROMPT_LINES = (
+    "Publish / attach `calibration_scorecard.json` (or `campaign_stamp.json` → scorecard_path).",
+    "Fill `utility_bills.per_month` with 12 months of pairs:",
+    "  • elec: `observed_kwh` + `modeled_kwh` (or `simulated_kwh`)",
+    "  • gas: `observed_therms` + `modeled_therms` (or `simulated_therms`)",
+    "Point ECMs / Twin at the same calibrated run under `runs/…`.",
+    "Re-open this tab — monthly ±% bars must stay visible once JSON is present.",
+)
+
+
+def build_empty_monthly_pm_figure(
+    *,
+    fuel: str,
+    title: str | None = None,
+    ok_band_pct: float = DEFAULT_OK_BAND_PCT,
+):
+    """Always-visible placeholder chart when monthly JSON pairs are absent."""
+    import plotly.graph_objects as go
+
+    fuel_label = "Electricity" if fuel == "elec" else "Natural gas"
+    zeros = [0.0] * len(PLACEHOLDER_MONTHS)
+    fig = go.Figure(
+        data=[
+            go.Bar(
+                x=list(PLACEHOLDER_MONTHS),
+                y=zeros,
+                marker_color="#cbd5e0",
+                text=["—"] * len(PLACEHOLDER_MONTHS),
+                textposition="outside",
+                hovertemplate="%{x}: no bill↔E+ pair yet<extra></extra>",
+                name=f"{fuel} ±% (awaiting data)",
+            )
+        ]
+    )
+    fig.add_hline(y=ok_band_pct, line_dash="dot", line_color=BAND_COLOR)
+    fig.add_hline(y=-ok_band_pct, line_dash="dot", line_color=BAND_COLOR)
+    fig.add_hline(y=0, line_color="#2d3748", line_width=1)
+    fig.add_annotation(
+        text="Awaiting utility_bills.per_month — chart slot reserved",
+        xref="paper",
+        yref="paper",
+        x=0.5,
+        y=0.55,
+        showarrow=False,
+        font=dict(size=13, color="#4a5568"),
+    )
+    fig.update_layout(
+        title=title or f"{fuel_label} — monthly dial ±% (model vs bills)",
+        yaxis_title="% off (model − bill) / bill",
+        yaxis=dict(range=[-ok_band_pct * 2, ok_band_pct * 2]),
+        height=360,
+        margin=dict(l=40, r=20, t=50, b=40),
+        showlegend=False,
+    )
+    return fig
+
+
 def build_monthly_pm_figure(
     per_month: list[dict[str, Any]] | None,
     *,
     fuel: str,
     title: str | None = None,
     ok_band_pct: float = DEFAULT_OK_BAND_PCT,
+    placeholder_when_empty: bool = False,
 ):
-    """Plotly diverging bar: monthly ±% for one fuel."""
+    """Plotly diverging bar: monthly ±% for one fuel.
+
+    When ``placeholder_when_empty`` is True, never returns None — reserves the
+    chart slot so ECM / Twin UI does not collapse when JSON is missing.
+    """
     import plotly.graph_objects as go
 
     series = monthly_pct_series(per_month, fuel=fuel)
     if not series:
+        if placeholder_when_empty:
+            return build_empty_monthly_pm_figure(
+                fuel=fuel, title=title, ok_band_pct=ok_band_pct
+            )
         return None
     months = [r["month"] for r in series]
     pcts = [float(r["pct_off"]) for r in series]
@@ -128,6 +210,56 @@ def build_monthly_pm_figure(
         showlegend=False,
     )
     return fig
+
+
+def agent_monthly_pct_prompt_text(*, twin_hint: str | None = None) -> str:
+    """Operator-visible checklist for agents when scorecard months are missing."""
+    lines = ["**Please have AI agent render / attach:**"]
+    lines.extend(f"- {line}" for line in AGENT_MONTHLY_PCT_PROMPT_LINES)
+    if twin_hint:
+        lines.append(f"- ECM Twin hint: `{twin_hint}`")
+    return "\n".join(lines)
+
+
+def render_required_monthly_pct_charts(
+    per_month: list[dict[str, Any]] | None,
+    *,
+    key_prefix: str = "monthly_pm",
+    twin_hint: str | None = None,
+    fuels: tuple[str, ...] = ("elec", "gas"),
+) -> dict[str, bool]:
+    """Always render monthly ±% chart slots (real data or placeholder).
+
+    Returns ``{fuel: has_series}`` for callers / tests.
+    """
+    import streamlit as st
+
+    from wattlab.studio.monthly_fuel_chart import normalize_per_month_rows
+
+    rows = normalize_per_month_rows(list(per_month or []))
+    st.markdown("#### Monthly dial ±% (E+ model vs actual bills)")
+    st.caption(
+        "Required on Twin and ECMs. Positive = model over-predicts bills; negative = under. "
+        "Chart frames stay visible even when JSON is missing."
+    )
+    status: dict[str, bool] = {}
+    any_series = False
+    for fuel in fuels:
+        series = monthly_pct_series(rows, fuel=fuel)
+        has = bool(series)
+        status[fuel] = has
+        any_series = any_series or has
+        fig = build_monthly_pm_figure(rows, fuel=fuel, placeholder_when_empty=True)
+        st.plotly_chart(fig, width="stretch", key=f"{key_prefix}_{fuel}")
+        if not has:
+            fuel_lab = "Electricity" if fuel == "elec" else "Natural gas"
+            st.info(
+                f"{fuel_lab}: no monthly bill↔E+ pairs yet — placeholder chart kept above."
+            )
+    if not any_series:
+        st.warning(agent_monthly_pct_prompt_text(twin_hint=twin_hint))
+    return status
+
 
 
 def history_heatmap_matrix(

--- a/vibe_code_apps_20/wattlab/studio/pages/ecms.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/ecms.py
@@ -134,6 +134,46 @@ def render(*, profile: dict[str, Any] | None = None) -> None:
             show[col] = show[col].map(_fmt)
         st.dataframe(show, hide_index=True, width="stretch")
 
+    # Required: monthly ±% fuel charts (E+ vs actual). Never collapse when JSON missing.
+    twin_run = payload.get("twin_run") or twin_hint
+    per_month: list[dict[str, Any]] = []
+    try:
+        from wattlab.studio.monthly_pct_off import load_per_month_from_run
+        from wattlab.studio.workspace import runs_dir
+
+        run_dir = None
+        if twin_run and twin_run not in ("(pick best G14 Twin)",):
+            cand = Path(str(twin_run))
+            if cand.is_dir():
+                run_dir = cand
+            else:
+                under = runs_dir() / str(twin_run)
+                if under.is_dir():
+                    run_dir = under
+        if run_dir is None:
+            # Best-effort: newest run with a scorecard
+            from wattlab.studio.g14_history import iter_g14_history
+
+            for row in iter_g14_history(runs_dir(), limit=8):
+                d = row.get("dir")
+                if d:
+                    per_month = load_per_month_from_run(d)
+                    if per_month:
+                        twin_run = str(d)
+                        break
+        else:
+            per_month = load_per_month_from_run(run_dir)
+    except Exception as exc:
+        st.caption(f"Monthly fuel load skipped: {exc}")
+
+    from wattlab.studio.monthly_dial_chart import render_required_monthly_pct_charts
+
+    render_required_monthly_pct_charts(
+        per_month,
+        key_prefix="ecm_monthly_pm",
+        twin_hint=str(twin_run) if twin_run else None,
+    )
+
     with st.expander("Honesty / contract", expanded=False):
         st.write(payload.get("honesty") or "")
         st.code(json.dumps({"path": str(path), "schema": payload.get("schema")}, indent=2))

--- a/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
+++ b/vibe_code_apps_20/wattlab/studio/pages/twin_calibrate.py
@@ -915,33 +915,35 @@ def render() -> None:
             "Use seasons to choose the next dial lever (OA hours, SAT bands, schedules)."
         )
         if show_elec:
-            fig_e = build_monthly_pm_figure(bills_rows, fuel="elec")
-            if fig_e is not None:
-                st.plotly_chart(fig_e, width="stretch", key="twin_monthly_pm_elec")
-                seas_e = season_summary(monthly_pct_series(bills_rows, fuel="elec"))
-                if seas_e:
-                    st.caption(
-                        "Elec season mean ±%: "
-                        + ", ".join(f"{k} {v:+.0f}%" for k, v in seas_e.items())
-                    )
-            else:
+            fig_e = build_monthly_pm_figure(
+                bills_rows, fuel="elec", placeholder_when_empty=True
+            )
+            st.plotly_chart(fig_e, width="stretch", key="twin_monthly_pm_elec")
+            seas_e = season_summary(monthly_pct_series(bills_rows, fuel="elec"))
+            if seas_e:
+                st.caption(
+                    "Elec season mean ±%: "
+                    + ", ".join(f"{k} {v:+.0f}%" for k, v in seas_e.items())
+                )
+            elif not monthly_pct_series(bills_rows, fuel="elec"):
                 st.info(
-                    "Elec dial chart unavailable — no monthly `observed_kwh` + "
+                    "Elec dial: placeholder — no monthly `observed_kwh` + "
                     "`modeled_kwh`/`simulated_kwh` pairs in this scorecard."
                 )
         if show_gas:
-            fig_g = build_monthly_pm_figure(bills_rows, fuel="gas")
-            if fig_g is not None:
-                st.plotly_chart(fig_g, width="stretch", key="twin_monthly_pm_gas")
-                seas_g = season_summary(monthly_pct_series(bills_rows, fuel="gas"))
-                if seas_g:
-                    st.caption(
-                        "Gas season mean ±%: "
-                        + ", ".join(f"{k} {v:+.0f}%" for k, v in seas_g.items())
-                    )
-            else:
+            fig_g = build_monthly_pm_figure(
+                bills_rows, fuel="gas", placeholder_when_empty=True
+            )
+            st.plotly_chart(fig_g, width="stretch", key="twin_monthly_pm_gas")
+            seas_g = season_summary(monthly_pct_series(bills_rows, fuel="gas"))
+            if seas_g:
+                st.caption(
+                    "Gas season mean ±%: "
+                    + ", ".join(f"{k} {v:+.0f}%" for k, v in seas_g.items())
+                )
+            elif not monthly_pct_series(bills_rows, fuel="gas"):
                 st.info(
-                    "Gas dial chart unavailable — no monthly `observed_therms` + "
+                    "Gas dial: placeholder — no monthly `observed_therms` + "
                     "`modeled_therms`/`simulated_therms` pairs in this scorecard."
                 )
 
@@ -987,6 +989,22 @@ def render() -> None:
         st.dataframe(pd.DataFrame(monthly_model).head(24), width="stretch", hide_index=True)
         st.caption(
             "Annual monthly model series only — no utility_bills.per_month pairs for bills-vs-model overlay."
+        )
+        from wattlab.studio.monthly_dial_chart import render_required_monthly_pct_charts
+
+        render_required_monthly_pct_charts(
+            [],
+            key_prefix="twin_monthly_pm_annual_only",
+            twin_hint=str(active) if active else None,
+        )
+    else:
+        # Keep chart frames visible even with no scorecard yet (ECM parity).
+        from wattlab.studio.monthly_dial_chart import render_required_monthly_pct_charts
+
+        render_required_monthly_pct_charts(
+            [],
+            key_prefix="twin_monthly_pm_empty",
+            twin_hint=str(active) if active else None,
         )
 
     st.subheader("Client deliverables")


### PR DESCRIPTION
## Summary
- ECM/Twin monthly ±% dial charts stay visible without requiring JSON evidence
- Placeholder + agent checklist so UI never blanks chart slots

## Test plan
- [ ] CI green
- [ ] Studio ECM page shows monthly dial placeholders when evidence absent


Made with [Cursor](https://cursor.com)