### PR TITLE
fix(vibe20): reset SAT for both Liberty AHUs

### DIFF
--- a/vibe_code_apps_20/tests/test_ecm_compare.py
+++ b/vibe_code_apps_20/tests/test_ecm_compare.py
@@ -123,6 +123,24 @@ SetpointManager:Scheduled,
   Temperature,                                             !- Control Variable
   HVACTemplate-Always 12.8,                                !- Schedule Name
   VAV Sys 1 Supply Fan Outlet;
+
+SetpointManager:Scheduled,
+  VAV Sys 2 Cooling Supply Air Temp Manager,               !- Name
+  Temperature,                                             !- Control Variable
+  HVACTemplate-Always 12.8,                                !- Schedule Name
+  VAV Sys 2 Supply Fan Outlet;
+
+SetpointManager:Scheduled,
+  VAV Sys 1 Heating Supply Air Temp Manager,               !- Name
+  Temperature,                                             !- Control Variable
+  Winter Dump DAT,                                         !- Schedule Name
+  VAV Sys 1 Supply Fan Outlet;
+
+SetpointManager:Scheduled,
+  VAV Sys 2 Heating Supply Air Temp Manager,               !- Name
+  Temperature,                                             !- Control Variable
+  Winter Dump DAT,                                         !- Schedule Name
+  VAV Sys 2 Supply Fan Outlet;
 """,
         encoding="utf-8",
     )
@@ -134,6 +152,12 @@ SetpointManager:Scheduled,
     assert sat["ok"], sat
     sat_txt = (tmp_path / "sat.idf").read_text()
     assert "WattLab SAT Reset Cooling" in sat_txt
+    assert sat["mode"] == "liberty_cooling_spms"
+    assert sat["managers_patched"] == 2
+    assert sat_txt.count("WattLab SAT Reset Cooling,") == 3
+    assert "Through: 3/31,\n  For: AllDays,\n  Until: 24:00,12.8," in sat_txt
+    assert "Through: 9/30,\n  For: AllDays,\n  Until: 24:00,14.0," in sat_txt
+    assert "Winter Dump DAT" in sat_txt
 
     lock = apply_chiller_lockout(idf, tmp_path / "lock.idf", oat_lockout_f=60.0)
     assert lock["ok"] and lock["managers_patched"] == 1

--- a/vibe_code_apps_20/wattlab/energyplus/patches/sat_reset.py
+++ b/vibe_code_apps_20/wattlab/energyplus/patches/sat_reset.py
@@ -20,42 +20,56 @@ SAT_RESET_BODY = """    Temperature,             !- Schedule Type Limits Name
 
 _SCHEDULE_NAME = "Seasonal Reset Supply Air Temp Sch"
 _LIBERTY_SAT_SCH = "WattLab SAT Reset Cooling"
-_LIBERTY_SAT_C = 14.0  # warmer leaving-air (°C) screening raise
+_LIBERTY_WINTER_SAT_C = 12.8
+_LIBERTY_COOLING_SAT_C = 14.0  # warmer leaving-air (°C) screening raise
 
 
-def _inject_liberty_cooling_sat(text: str) -> tuple[str, bool]:
-    """Point VAV cooling SPM at a constant warmer SAT schedule (Liberty / HVACTemplate)."""
+def _inject_liberty_cooling_sat(text: str) -> tuple[str, int]:
+    """Reset every Liberty VAV cooling SPM without changing its winter DAT path."""
     sch_block = (
         f"Schedule:Compact,\n"
         f"  {_LIBERTY_SAT_SCH},\n"
         f"  Temperature,\n"
+        f"  Through: 3/31,\n"
+        f"  For: AllDays,\n"
+        f"  Until: 24:00,{_LIBERTY_WINTER_SAT_C},\n"
+        f"  Through: 9/30,\n"
+        f"  For: AllDays,\n"
+        f"  Until: 24:00,{_LIBERTY_COOLING_SAT_C},\n"
         f"  Through: 12/31,\n"
         f"  For: AllDays,\n"
-        f"  Until: 24:00,{_LIBERTY_SAT_C};\n\n"
+        f"  Until: 24:00,{_LIBERTY_WINTER_SAT_C};\n\n"
     )
-    if _LIBERTY_SAT_SCH not in text:
-        anchor = "SetpointManager:Scheduled,\n  VAV Sys 1 Cooling Supply Air Temp Manager,"
-        if anchor in text:
-            text = text.replace(anchor, sch_block + anchor, 1)
-        else:
-            text = sch_block + text
 
-    new, n = re.subn(
-        r"(SetpointManager:Scheduled,\s*\n\s*VAV Sys 1 Cooling Supply Air Temp Manager,[^\n]*\n"
+    # Do not match the heating managers: their schedule is the winter DAT
+    # evidence and must remain untouched.  Match every cooling manager so a
+    # dual-AHU Liberty model cannot silently patch only VAV Sys 1.
+    cooling_spm = re.compile(
+        r"(SetpointManager:Scheduled,\s*\n\s*[^\n,]*Cooling Supply Air Temp Manager,[^\n]*\n"
         r"\s*Temperature,[^\n]*\n\s*)([^,\n]+)(,)",
+        re.IGNORECASE,
+    )
+    first = cooling_spm.search(text)
+    if first is None:
+        return text, 0
+
+    if _LIBERTY_SAT_SCH not in text:
+        text = text[: first.start()] + sch_block + text[first.start() :]
+
+    new, n = cooling_spm.subn(
         rf"\g<1>{_LIBERTY_SAT_SCH}\3",
         text,
-        count=1,
     )
-    return new, n > 0
+    return new, n
 
 
 def apply_sat_reset(idf_path: Path, out_path: Path) -> dict:
-    """Widen seasonal SAT band, or retarget Liberty cooling SPM to warmer SAT."""
+    """Widen seasonal SAT band, or reset all Liberty cooling AHUs."""
     text = idf_path.read_text(encoding="utf-8", errors="replace")
     flags: list[str] = ["sat_reset_proxy", "not_full_gl36_sat_reset"]
     ok = False
     mode = "none"
+    managers_patched = 0
 
     pattern = re.compile(
         rf"(  Schedule:Compact,\s*\n\s*{re.escape(_SCHEDULE_NAME)}\s*,[^\n]*\n)"
@@ -69,11 +83,11 @@ def apply_sat_reset(idf_path: Path, out_path: Path) -> dict:
         mode = "seasonal_schedule"
 
     if not ok:
-        text, hit = _inject_liberty_cooling_sat(text)
-        if hit:
+        text, managers_patched = _inject_liberty_cooling_sat(text)
+        if managers_patched:
             ok = True
-            mode = "liberty_cooling_spm"
-            flags.append("liberty_vav_sat_spm")
+            mode = "liberty_cooling_spms"
+            flags.extend(["liberty_vav_sat_spm", "liberty_dual_ahu_sat_spm"])
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     header = f"! App20 IDF patch: sat_reset (mode={mode}; not full G36 SAT reset)\n"
@@ -85,4 +99,5 @@ def apply_sat_reset(idf_path: Path, out_path: Path) -> dict:
         "out": str(out_path),
         "ok": ok,
         "flags": flags,
+        "managers_patched": managers_patched,
     }


### PR DESCRIPTION
## Summary
- replace the Liberty flat 14°C, VAV Sys 1-only SAT patch with a seasonal reset applied to every cooling supply-air setpoint manager
- preserve winter DAT at 12.8°C and raise the cooling-season setpoint to 14.0°C
- add a dual-AHU regression fixture that verifies both cooling managers are patched while winter heating/DAT references remain unchanged

## Test plan
- [x] `/home/ben/.venvs/vibe19/bin/python -m pytest tests/test_ecm_compare.py tests/test_wattlab_easy_button.py tests/test_patch_registry.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Liberty SAT reset handling for multiple cooling air-temperature managers.
  * Applied distinct winter and cooling temperature reset values.
  * Excluded heating managers from cooling reset updates.
  * Enhanced patch results to report the number of updated managers and clearer operating status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->