### PR TITLE
feat(vibe22): closeout desktop ship pipeline

### DIFF
--- a/vibe_code_apps_22/AGENTS.md
+++ b/vibe_code_apps_22/AGENTS.md
@@ -20,7 +20,8 @@ Building id: `LAKESIDE_ES` · `siteRef`: `spasd_lakeside_es`
 Research / notebook display name: fictional **Creekside** (scrubbed site report).
 
 Last validated: **2026-08-09** — W2A plant dual **A04** (~287 kW Jan‑26 + monthly GL14);
-prior CLI four-arm train 2026-08-07.
+four-arm baseline bake-off + smoke desktop ship (`sklearn_allyear` /
+`gradient_boosting`, peak MAE ~29.4 kW; `UNDERPOWERED_SMOKE_FARM`).
 
 ---
 

--- a/vibe_code_apps_22/desktop/README.md
+++ b/vibe_code_apps_22/desktop/README.md
@@ -22,9 +22,9 @@ IdealLoads + fixed-COP ≠ ground-source heat-pump plant.
 Promote artifacts:
 
 ```powershell
-python -u ..\scripts\promote_hybrid_ship.py
+python -u ..\scripts\ship_best_to_desktop.py --no-launch --allow-smoke-promote
 cd vibe_code_apps_22\desktop
-cargo test hybrid_walk_loads --release
+cargo test --release
 cargo run --release
 ```
 

--- a/vibe_code_apps_22/desktop/artifacts/README.md
+++ b/vibe_code_apps_22/desktop/artifacts/README.md
@@ -3,11 +3,18 @@
 Populate by promoting a hybrid ship, or unpack a Drive model pack here:
 
 ```powershell
-$env:VIBE22_ALLOW_CLI_TRAIN="1"
-$env:VIBE22_ALLOW_SMOKE_PROMOTE="1"   # screening farm only
-python -u ..\scripts\ship_best_to_desktop.py --no-launch
+# After train_four_arms (+ E+ delta). Screening farm (<12 pairs) needs smoke flag:
+python -u ..\scripts\ship_best_to_desktop.py --no-launch --allow-smoke-promote
+# Equivalent: $env:VIBE22_ALLOW_SMOKE_PROMOTE="1"
 ```
 
-Expected after promote (local only): `*.onnx`, feature_meta / model_card JSON, `hybrid_dsm_96_v1_walk.json`, `hybrid_ship_manifest.json`.
+Picks the sklearn arm with lowest **recursive held-out peak MAE** (winter wins
+ties; torch never ships), copies baseline into `ml/artifacts/`, promotes the
+hybrid walk + ONNX bundle here, and stamps `hybrid_ship_manifest.json`.
+
+Expected after promote (local only): `*.onnx`, feature_meta / model_card JSON,
+`hybrid_dsm_96_v1_walk.json`, `hybrid_ship_manifest.json`.
+
+Closeout record: [`../../docs/superpowers/specs/2026-08-09-desktop-ship-closeout.md`](../../docs/superpowers/specs/2026-08-09-desktop-ship-closeout.md).
 
 See [`../ml/artifacts/README.md`](../ml/artifacts/README.md) and [`../../data/DATA.md`](../../data/DATA.md).

--- a/vibe_code_apps_22/docs/superpowers/specs/2026-08-09-desktop-ship-closeout.md
+++ b/vibe_code_apps_22/docs/superpowers/specs/2026-08-09-desktop-ship-closeout.md
@@ -1,0 +1,41 @@
+# 2026-08-09 — Desktop ship closeout (smoke)
+
+Local four-arm bake-off → `ship_best_to_desktop` → desktop artifacts.
+
+## Selection
+
+| Field | Value |
+| --- | --- |
+| Selected arm | `sklearn_allyear` |
+| Champion | `gradient_boosting` |
+| Recursive peak MAE | **29.367 kW** |
+| Zone MAE (mean) | ~1.27 °F |
+| Winter runner-up | `sklearn_winter` / `extra_trees` @ 37.52 kW |
+| Torch | not shipped (research only) |
+
+Selection rule: lowest recursive held-out morning-peak MAE among sklearn arms; winter wins ties; torch never ships.
+
+## Promote honesty
+
+| Field | Value |
+| --- | --- |
+| `ship_mode` | `smoke_artifact` |
+| Watermark | `UNDERPOWERED_SMOKE_FARM` |
+| Usable both-arm pairs | **6** (&lt; 12 → smoke only) |
+| `honesty` | `HYBRID_SCREENING` |
+| `operational_dsm` | **false** |
+| Multires hourly | fail (monthly utility GL14 pass separately) |
+
+Command used:
+
+```powershell
+python -u scripts\ship_best_to_desktop.py --no-launch --allow-smoke-promote
+```
+
+## Validate
+
+- `cargo test` (desktop): **32 passed**
+- `pytest tests/test_ship_best_to_desktop.py tests/test_simulation_contract.py`: **6 passed**
+- ONNX / walk / manifest written under `desktop/artifacts/` (gitignored; regenerate locally)
+
+IdealLoads+COP deltas ≠ GSHP plant. Grow the paired E+ farm before claiming operational DSM.

--- a/vibe_code_apps_22/scripts/README.md
+++ b/vibe_code_apps_22/scripts/README.md
@@ -6,8 +6,8 @@
 | --- | --- |
 | `train_four_arms.py` | Parallel sklearn/torch × winter/allyear → `ml/artifacts/runs/` |
 | `train_arm.py` | One arm worker (spawned by four-arm launcher) |
-| `ship_best_to_desktop.py` | Pick best sklearn arm (held-out peak MAE only) → promote → `cargo run --release` |
-| `promote_hybrid_ship.py` | Hybrid walk + copy into `desktop/artifacts/` (smoke &lt;12 pairs needs `VIBE22_ALLOW_SMOKE_PROMOTE=1`) |
+| `ship_best_to_desktop.py` | Pick best sklearn arm (held-out peak MAE only) → promote → `cargo run --release`; `--allow-smoke-promote` for &lt;12 pairs |
+| `promote_hybrid_ship.py` | Hybrid walk + copy into `desktop/artifacts/` (smoke &lt;12 pairs needs `VIBE22_ALLOW_SMOKE_PROMOTE=1` or ship `--allow-smoke-promote`) |
 | `validate_eplus_multires.py` | Monthly / hourly / 15-min DSM multi-res validation JSON |
 | `_gen_results_viewer_notebooks.py` | Regen sklearn/torch **viewer** notebooks |
 | `_gen_load_profile_analysis_nb.py` | Regen load-profile analysis notebook |

--- a/vibe_code_apps_22/scripts/ship_best_to_desktop.py
+++ b/vibe_code_apps_22/scripts/ship_best_to_desktop.py
@@ -6,6 +6,7 @@ Usage (from vibe_code_apps_22)::
     python scripts/ship_best_to_desktop.py
     python scripts/ship_best_to_desktop.py --arm sklearn_winter   # force arm
     python scripts/ship_best_to_desktop.py --no-launch            # promote only
+    python scripts/ship_best_to_desktop.py --no-launch --allow-smoke-promote
 
 Selection (when --arm omitted): among ok sklearn_winter / sklearn_allyear,
 lowest recursive peak MAE wins; winter wins ties. Torch never ships.
@@ -13,6 +14,10 @@ lowest recursive peak MAE wins; winter wins ties. Torch never ships.
 Copies winner baseline into ml/artifacts/ (keeps existing E+ delta), runs
 promote_hybrid, then ``cargo run --release`` in desktop/ unless --no-launch.
 Promote gate failure stops the script (does not launch).
+
+When the paired E+ farm has fewer than 12 usable both-arm pairs, promote
+refuses unless ``--allow-smoke-promote`` (or ``VIBE22_ALLOW_SMOKE_PROMOTE=1``)
+is set — that stamps ``UNDERPOWERED_SMOKE_FARM`` / ``HYBRID_SCREENING``.
 """
 from __future__ import annotations
 
@@ -41,6 +46,7 @@ os.environ.setdefault("VIBE22_ALLOW_CLI_TRAIN", "1")
 SKLEARN_ARMS = ("sklearn_winter", "sklearn_allyear")
 BASELINE_STEM = "real_baseline_15min_v1"
 BASELINE_SUFFIXES = (".joblib", ".onnx", "_feature_meta.json", "_model_card.json")
+SMOKE_ENV = "VIBE22_ALLOW_SMOKE_PROMOTE"
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -164,6 +170,14 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--arm", choices=SKLEARN_ARMS, default=None, help="Force this sklearn arm")
     ap.add_argument("--no-launch", action="store_true", help="Promote only; do not start cargo")
     ap.add_argument(
+        "--allow-smoke-promote",
+        action="store_true",
+        help=(
+            f"Set {SMOKE_ENV}=1 for underpowered farms (<12 pairs). "
+            "Stamps UNDERPOWERED_SMOKE_FARM; not operational DSM."
+        ),
+    )
+    ap.add_argument(
         "--artifacts",
         type=Path,
         default=ART,
@@ -173,6 +187,8 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     os.environ["VIBE22_ALLOW_CLI_TRAIN"] = "1"
+    if args.allow_smoke_promote:
+        os.environ[SMOKE_ENV] = "1"
 
     winner = pick_best_arm(force=args.arm)
     print(


### PR DESCRIPTION
## Summary
- Add `--allow-smoke-promote` to `ship_best_to_desktop.py` for underpowered E+ farms (<12 pairs)
- Document / validate desktop ship after four-arm bake-off: **sklearn_allyear / gradient_boosting** (~29.4 kW peak MAE)
- Local validate: cargo test 32 passed; ship unit tests passed; smoke promote stamps UNDERPOWERED_SMOKE_FARM

## Test plan
- [x] `cargo test` in desktop (32 passed)
- [x] `pytest tests/test_ship_best_to_desktop.py`
- [x] `ship_best_to_desktop.py --no-launch --allow-smoke-promote`
- [ ] CI vibe22-ci green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop promotion now supports explicitly approved smoke datasets with fewer than 12 usable arm pairs.
  * Smoke promotions are labeled with metadata indicating the underpowered validation status.
  * Promotion workflows now support a direct command-line override for smoke shipments.

* **Documentation**
  * Updated desktop and script guides with promotion steps, generated artifacts, validation results, and known limitations.
  * Added a desktop ship closeout record documenting model selection and release validation.
  * Release testing guidance now uses the full desktop suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->