### PR TITLE
fix(vibe22): bakeoff completion evidence (majority E+-only + arch fixtures 02-09)

### DIFF
--- a/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_02_leaderboard.json
+++ b/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_02_leaderboard.json
@@ -1,0 +1,128 @@
+{
+  "iter": 2,
+  "n": 10,
+  "n_pass": 10,
+  "plant_peak_cap_kw": 450.0,
+  "rows": [
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.771328751087427,
+      "peak_kw": 103.23568962537571,
+      "mae": 8.771328751087427,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_hgb_multi via ablate_strategy",
+      "parent": "sklearn_hgb_multi",
+      "mutation": "ablate_strategy"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.60726439285011,
+      "peak_kw": 106.18515160417802,
+      "mae": 9.60726439285011,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_chain_kw via deeper",
+      "parent": "sklearn_chain_kw",
+      "mutation": "deeper"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.794801533494615,
+      "peak_kw": 106.97488290907333,
+      "mae": 9.794801533494615,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_hgb_multi via lower_lr",
+      "parent": "sklearn_hgb_multi",
+      "mutation": "lower_lr"
+    },
+    {
+      "name": "sklearn_et_native__i02_weaker_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.38776286634365,
+      "peak_kw": 100.2471603584665,
+      "mae": 10.38776286634365,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_et_native via weaker_physics",
+      "parent": "sklearn_et_native",
+      "mutation": "weaker_physics"
+    },
+    {
+      "name": "sklearn_et_native__i02_wider",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.203681453380483,
+      "peak_kw": 98.89996637888585,
+      "mae": 11.203681453380483,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_et_native via wider",
+      "parent": "sklearn_et_native",
+      "mutation": "wider"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_ensemble_pair",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.208020972207033,
+      "peak_kw": 102.92769711170038,
+      "mae": 11.208020972207033,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_chain_kw via ensemble_pair",
+      "parent": "sklearn_chain_kw",
+      "mutation": "ensemble_pair"
+    },
+    {
+      "name": "sklearn_et_native__i02_more_dropout",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.416405449479655,
+      "peak_kw": 99.09253896264485,
+      "mae": 11.416405449479655,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_et_native via more_dropout",
+      "parent": "sklearn_et_native",
+      "mutation": "more_dropout"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_longer_horizon",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.564101733478541,
+      "peak_kw": 89.22498755077704,
+      "mae": 11.564101733478541,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_chain_kw via longer_horizon",
+      "parent": "sklearn_chain_kw",
+      "mutation": "longer_horizon"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_stronger_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 12.225851854904835,
+      "peak_kw": 94.62655551873343,
+      "mae": 12.225851854904835,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_hgb_multi via stronger_physics",
+      "parent": "sklearn_hgb_multi",
+      "mutation": "stronger_physics"
+    },
+    {
+      "name": "sklearn_et_native__i02_ablate_forecast",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 12.973120105999948,
+      "peak_kw": 110.29228838196973,
+      "mae": 12.973120105999948,
+      "backend": "sklearn",
+      "theme": "iter2 mutate sklearn_et_native via ablate_forecast",
+      "parent": "sklearn_et_native",
+      "mutation": "ablate_forecast"
+    }
+  ]
+}

--- a/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_03_leaderboard.json
+++ b/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_03_leaderboard.json
@@ -1,0 +1,128 @@
+{
+  "iter": 3,
+  "n": 10,
+  "n_pass": 10,
+  "plant_peak_cap_kw": 450.0,
+  "rows": [
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 7.774397411565547,
+      "peak_kw": 107.09719906715402,
+      "mae": 7.774397411565547,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_hgb_multi__i02_ablate_strategy via more_dropout",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy",
+      "mutation": "more_dropout"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.05145462947711,
+      "peak_kw": 102.6965532474821,
+      "mae": 8.05145462947711,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_chain_kw__i02_deeper via deeper",
+      "parent": "sklearn_chain_kw__i02_deeper",
+      "mutation": "deeper"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.577833944697542,
+      "peak_kw": 101.36043782299116,
+      "mae": 8.577833944697542,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_hgb_multi__i02_lower_lr via lower_lr",
+      "parent": "sklearn_hgb_multi__i02_lower_lr",
+      "mutation": "lower_lr"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr__i03_ablate_strategy",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.995457911597557,
+      "peak_kw": 101.95780407642175,
+      "mae": 8.995457911597557,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_hgb_multi__i02_lower_lr via ablate_strategy",
+      "parent": "sklearn_hgb_multi__i02_lower_lr",
+      "mutation": "ablate_strategy"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr__i03_stronger_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.653690447536505,
+      "peak_kw": 104.65470962837513,
+      "mae": 9.653690447536505,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_hgb_multi__i02_lower_lr via stronger_physics",
+      "parent": "sklearn_hgb_multi__i02_lower_lr",
+      "mutation": "stronger_physics"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_weaker_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.825630519581171,
+      "peak_kw": 101.5841208707442,
+      "mae": 9.825630519581171,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_hgb_multi__i02_ablate_strategy via weaker_physics",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy",
+      "mutation": "weaker_physics"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_wider",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.680357757039397,
+      "peak_kw": 105.70682682611057,
+      "mae": 10.680357757039397,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_hgb_multi__i02_ablate_strategy via wider",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy",
+      "mutation": "wider"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_ablate_forecast",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.770890293124513,
+      "peak_kw": 105.21354155160411,
+      "mae": 10.770890293124513,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_hgb_multi__i02_ablate_strategy via ablate_forecast",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy",
+      "mutation": "ablate_forecast"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_longer_horizon",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.66000261760323,
+      "peak_kw": 98.24168894741952,
+      "mae": 11.66000261760323,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_chain_kw__i02_deeper via longer_horizon",
+      "parent": "sklearn_chain_kw__i02_deeper",
+      "mutation": "longer_horizon"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_ensemble_pair",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 14.75543853029701,
+      "peak_kw": 103.56143705392822,
+      "mae": 14.75543853029701,
+      "backend": "sklearn",
+      "theme": "iter3 mutate sklearn_chain_kw__i02_deeper via ensemble_pair",
+      "parent": "sklearn_chain_kw__i02_deeper",
+      "mutation": "ensemble_pair"
+    }
+  ]
+}

--- a/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_04_leaderboard.json
+++ b/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_04_leaderboard.json
@@ -1,0 +1,128 @@
+{
+  "iter": 4,
+  "n": 10,
+  "n_pass": 10,
+  "plant_peak_cap_kw": 450.0,
+  "rows": [
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 7.765346416635427,
+      "peak_kw": 102.8806394817435,
+      "mae": 7.765346416635427,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout via wider",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout",
+      "mutation": "wider"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.752080933052568,
+      "peak_kw": 109.95398619140174,
+      "mae": 8.752080933052568,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_chain_kw__i02_deeper__i03_deeper via ensemble_pair",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper",
+      "mutation": "ensemble_pair"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.797770250817397,
+      "peak_kw": 97.01023910347074,
+      "mae": 8.797770250817397,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_hgb_multi__i02_lower_lr__i03_lower_lr via ablate_strategy",
+      "parent": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr",
+      "mutation": "ablate_strategy"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_stronger_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.481094063819647,
+      "peak_kw": 98.71965441860864,
+      "mae": 9.481094063819647,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_hgb_multi__i02_lower_lr__i03_lower_lr via stronger_physics",
+      "parent": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr",
+      "mutation": "stronger_physics"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_lower_lr",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.241143374905318,
+      "peak_kw": 101.80633026885538,
+      "mae": 10.241143374905318,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_hgb_multi__i02_lower_lr__i03_lower_lr via lower_lr",
+      "parent": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr",
+      "mutation": "lower_lr"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_deeper",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.296919460889432,
+      "peak_kw": 97.33882067725355,
+      "mae": 10.296919460889432,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_chain_kw__i02_deeper__i03_deeper via deeper",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper",
+      "mutation": "deeper"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_weaker_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.36172735410847,
+      "peak_kw": 111.78372916601985,
+      "mae": 10.36172735410847,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout via weaker_physics",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout",
+      "mutation": "weaker_physics"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_more_dropout",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.047364794527576,
+      "peak_kw": 101.04738673393486,
+      "mae": 11.047364794527576,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout via more_dropout",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout",
+      "mutation": "more_dropout"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_longer_horizon",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 13.385978012808176,
+      "peak_kw": 95.54406879441957,
+      "mae": 13.385978012808176,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_chain_kw__i02_deeper__i03_deeper via longer_horizon",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper",
+      "mutation": "longer_horizon"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_ablate_forecast",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 13.740649385012153,
+      "peak_kw": 102.78207832283232,
+      "mae": 13.740649385012153,
+      "backend": "sklearn",
+      "theme": "iter4 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout via ablate_forecast",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout",
+      "mutation": "ablate_forecast"
+    }
+  ]
+}

--- a/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_05_leaderboard.json
+++ b/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_05_leaderboard.json
@@ -1,0 +1,128 @@
+{
+  "iter": 5,
+  "n": 10,
+  "n_pass": 10,
+  "plant_peak_cap_kw": 450.0,
+  "rows": [
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.210688404421145,
+      "peak_kw": 102.45440875932556,
+      "mae": 9.210688404421145,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider via wider",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider",
+      "mutation": "wider"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.485386832340074,
+      "peak_kw": 93.34080546123782,
+      "mae": 9.485386832340074,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair via ensemble_pair",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair",
+      "mutation": "ensemble_pair"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.548299812205995,
+      "peak_kw": 105.88927420993643,
+      "mae": 9.548299812205995,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair via longer_horizon",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair",
+      "mutation": "longer_horizon"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy__i05_ablate_strategy",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.721357055927765,
+      "peak_kw": 97.80124314402299,
+      "mae": 9.721357055927765,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy via ablate_strategy",
+      "parent": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy",
+      "mutation": "ablate_strategy"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_weaker_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.81923991429223,
+      "peak_kw": 103.45372923498735,
+      "mae": 9.81923991429223,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider via weaker_physics",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider",
+      "mutation": "weaker_physics"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_deeper",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.212666771972176,
+      "peak_kw": 100.24690296721144,
+      "mae": 10.212666771972176,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair via deeper",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair",
+      "mutation": "deeper"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_more_dropout",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.025739689485565,
+      "peak_kw": 100.13182198656274,
+      "mae": 11.025739689485565,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider via more_dropout",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider",
+      "mutation": "more_dropout"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy__i05_lower_lr",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.383397698773868,
+      "peak_kw": 95.1254784249518,
+      "mae": 11.383397698773868,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy via lower_lr",
+      "parent": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy",
+      "mutation": "lower_lr"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_ablate_forecast",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 12.044149168973025,
+      "peak_kw": 102.46223347677024,
+      "mae": 12.044149168973025,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider via ablate_forecast",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider",
+      "mutation": "ablate_forecast"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy__i05_stronger_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 13.777942562549304,
+      "peak_kw": 100.36937049996405,
+      "mae": 13.777942562549304,
+      "backend": "sklearn",
+      "theme": "iter5 mutate sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy via stronger_physics",
+      "parent": "sklearn_hgb_multi__i02_lower_lr__i03_lower_lr__i04_ablate_strategy",
+      "mutation": "stronger_physics"
+    }
+  ]
+}

--- a/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_06_leaderboard.json
+++ b/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_06_leaderboard.json
@@ -1,0 +1,152 @@
+{
+  "iter": 6,
+  "n": 10,
+  "n_pass": 10,
+  "plant_peak_cap_kw": 450.0,
+  "rows": [
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 7.161839899813655,
+      "peak_kw": 98.57120451752576,
+      "mae": 7.161839899813655,
+      "backend": "sklearn",
+      "theme": "iter6 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider via ablate_forecast",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider",
+      "mutation": "ablate_forecast"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 7.173709876671668,
+      "peak_kw": 104.78480153650166,
+      "mae": 7.173709876671668,
+      "backend": "sklearn",
+      "theme": "iter6 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider via more_dropout",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider",
+      "mutation": "more_dropout"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.913007519621742,
+      "peak_kw": 94.25482035294834,
+      "mae": 8.913007519621742,
+      "backend": "sklearn",
+      "theme": "iter6 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair via deeper",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair",
+      "mutation": "deeper"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_weaker_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.931867313456072,
+      "peak_kw": 101.11492963605095,
+      "mae": 8.931867313456072,
+      "backend": "sklearn",
+      "theme": "iter6 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider via weaker_physics",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider",
+      "mutation": "weaker_physics"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_longer_horizon",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.153173490318071,
+      "peak_kw": 98.26791659050653,
+      "mae": 9.153173490318071,
+      "backend": "sklearn",
+      "theme": "iter6 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair via longer_horizon",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair",
+      "mutation": "longer_horizon"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_ensemble_pair",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.253539026858018,
+      "peak_kw": 97.56663643475164,
+      "mae": 10.253539026858018,
+      "backend": "sklearn",
+      "theme": "iter6 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair via ensemble_pair",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair",
+      "mutation": "ensemble_pair"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_wider",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.06606578144737,
+      "peak_kw": 93.87114626567077,
+      "mae": 11.06606578144737,
+      "backend": "sklearn",
+      "theme": "iter6 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider via wider",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider",
+      "mutation": "wider"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon__i06_stronger_physics",
+      "family": "torch_phys_lstm",
+      "pass": true,
+      "score": 77.67236328125,
+      "peak_kw": 0.6745184063911438,
+      "loss": 77.67236328125,
+      "backend": "torch",
+      "detail": {
+        "ok": true,
+        "kind": "multi_horizon",
+        "loss": 77.67236328125,
+        "recon_peak_kw": 0.6745184063911438,
+        "pass": true,
+        "score": 77.67236328125
+      },
+      "theme": "iter6 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon via stronger_physics",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon",
+      "mutation": "stronger_physics"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon__i06_ablate_strategy",
+      "family": "torch_phys_lstm",
+      "pass": true,
+      "score": 77.73516845703125,
+      "peak_kw": 0.6010408401489258,
+      "loss": 77.73516845703125,
+      "backend": "torch",
+      "detail": {
+        "ok": true,
+        "kind": "multi_horizon",
+        "loss": 77.73516845703125,
+        "recon_peak_kw": 0.6010408401489258,
+        "pass": true,
+        "score": 77.73516845703125
+      },
+      "theme": "iter6 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon via ablate_strategy",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon",
+      "mutation": "ablate_strategy"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon__i06_lower_lr",
+      "family": "torch_phys_lstm",
+      "pass": true,
+      "score": 77.87840270996094,
+      "peak_kw": 0.47635388374328613,
+      "loss": 77.87840270996094,
+      "backend": "torch",
+      "detail": {
+        "ok": true,
+        "kind": "multi_horizon",
+        "loss": 77.87840270996094,
+        "recon_peak_kw": 0.47635388374328613,
+        "pass": true,
+        "score": 77.87840270996094
+      },
+      "theme": "iter6 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon via lower_lr",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_longer_horizon",
+      "mutation": "lower_lr"
+    }
+  ]
+}

--- a/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_07_leaderboard.json
+++ b/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_07_leaderboard.json
@@ -1,0 +1,128 @@
+{
+  "iter": 7,
+  "n": 10,
+  "n_pass": 10,
+  "plant_peak_cap_kw": 450.0,
+  "rows": [
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 7.269382562928465,
+      "peak_kw": 94.43010212391614,
+      "mae": 7.269382562928465,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout via ensemble_pair",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout",
+      "mutation": "ensemble_pair"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.139704632588684,
+      "peak_kw": 100.52981000037583,
+      "mae": 8.139704632588684,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast via wider",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast",
+      "mutation": "wider"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.519644569492096,
+      "peak_kw": 103.56291141898829,
+      "mae": 8.519644569492096,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout via deeper",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout",
+      "mutation": "deeper"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_more_dropout",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.638739635195105,
+      "peak_kw": 103.69643041268395,
+      "mae": 9.638739635195105,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast via more_dropout",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast",
+      "mutation": "more_dropout"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_longer_horizon",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.066473583113709,
+      "peak_kw": 98.30160966320558,
+      "mae": 10.066473583113709,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout via longer_horizon",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout",
+      "mutation": "longer_horizon"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_ablate_forecast",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.747525441157373,
+      "peak_kw": 94.72994133265546,
+      "mae": 10.747525441157373,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast via ablate_forecast",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast",
+      "mutation": "ablate_forecast"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper__i07_lower_lr",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 12.096298080216915,
+      "peak_kw": 97.68120752223042,
+      "mae": 12.096298080216915,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper via lower_lr",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper",
+      "mutation": "lower_lr"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_weaker_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 12.835990590837843,
+      "peak_kw": 98.11239752766834,
+      "mae": 12.835990590837843,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast via weaker_physics",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast",
+      "mutation": "weaker_physics"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper__i07_stronger_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 13.69914661957932,
+      "peak_kw": 96.49128122821361,
+      "mae": 13.69914661957932,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper via stronger_physics",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper",
+      "mutation": "stronger_physics"
+    },
+    {
+      "name": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper__i07_ablate_strategy",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 14.141801855713817,
+      "peak_kw": 94.18362522764356,
+      "mae": 14.141801855713817,
+      "backend": "sklearn",
+      "theme": "iter7 mutate sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper via ablate_strategy",
+      "parent": "sklearn_chain_kw__i02_deeper__i03_deeper__i04_ensemble_pair__i05_ensemble_pair__i06_deeper",
+      "mutation": "ablate_strategy"
+    }
+  ]
+}

--- a/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_08_leaderboard.json
+++ b/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_08_leaderboard.json
@@ -1,0 +1,128 @@
+{
+  "iter": 8,
+  "n": 10,
+  "n_pass": 10,
+  "plant_peak_cap_kw": 450.0,
+  "rows": [
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.179490419839297,
+      "peak_kw": 98.4093576569826,
+      "mae": 9.179490419839297,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider via longer_horizon",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider",
+      "mutation": "longer_horizon"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.908461066549693,
+      "peak_kw": 101.00635813948914,
+      "mae": 9.908461066549693,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair via ablate_forecast",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair",
+      "mutation": "ablate_forecast"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.400426277849892,
+      "peak_kw": 86.079358657659,
+      "mae": 10.400426277849892,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper via lower_lr",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper",
+      "mutation": "lower_lr"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_more_dropout",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.688499786508578,
+      "peak_kw": 92.93414289144708,
+      "mae": 10.688499786508578,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair via more_dropout",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair",
+      "mutation": "more_dropout"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_ablate_strategy",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.274161417864917,
+      "peak_kw": 98.63657286372481,
+      "mae": 11.274161417864917,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper via ablate_strategy",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper",
+      "mutation": "ablate_strategy"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_deeper",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.641307608619206,
+      "peak_kw": 101.19409788983491,
+      "mae": 11.641307608619206,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider via deeper",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider",
+      "mutation": "deeper"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_weaker_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.986079925985422,
+      "peak_kw": 97.82700963346538,
+      "mae": 11.986079925985422,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair via weaker_physics",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair",
+      "mutation": "weaker_physics"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_wider",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 12.21482975858406,
+      "peak_kw": 105.84491311316728,
+      "mae": 12.21482975858406,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair via wider",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair",
+      "mutation": "wider"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_stronger_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 12.859152433329527,
+      "peak_kw": 109.25011450014941,
+      "mae": 12.859152433329527,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper via stronger_physics",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper",
+      "mutation": "stronger_physics"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_ensemble_pair",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 14.13018836171924,
+      "peak_kw": 102.34252935877171,
+      "mae": 14.13018836171924,
+      "backend": "sklearn",
+      "theme": "iter8 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider via ensemble_pair",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider",
+      "mutation": "ensemble_pair"
+    }
+  ]
+}

--- a/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_09_leaderboard.json
+++ b/vibe_code_apps_22/ml/artifacts/fixtures/arch_search/iter_09_leaderboard.json
@@ -1,0 +1,160 @@
+{
+  "iter": 9,
+  "n": 10,
+  "n_pass": 10,
+  "plant_peak_cap_kw": 450.0,
+  "rows": [
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast__i09_longer_horizon",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 8.394406198167697,
+      "peak_kw": 102.37948207779387,
+      "mae": 8.394406198167697,
+      "backend": "sklearn",
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast via longer_horizon",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast",
+      "mutation": "longer_horizon"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr__i09_lower_lr",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.024150227283222,
+      "peak_kw": 94.62431003047467,
+      "mae": 9.024150227283222,
+      "backend": "sklearn",
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr via lower_lr",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr",
+      "mutation": "lower_lr"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast__i09_ensemble_pair",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.756408325288552,
+      "peak_kw": 97.24458874834917,
+      "mae": 9.756408325288552,
+      "backend": "sklearn",
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast via ensemble_pair",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast",
+      "mutation": "ensemble_pair"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr__i09_ablate_strategy",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 9.902270261171129,
+      "peak_kw": 104.20056107430625,
+      "mae": 9.902270261171129,
+      "backend": "sklearn",
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr via ablate_strategy",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr",
+      "mutation": "ablate_strategy"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast__i09_deeper",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 10.89961837593539,
+      "peak_kw": 103.0361424276036,
+      "mae": 10.89961837593539,
+      "backend": "sklearn",
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast via deeper",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_ensemble_pair__i08_ablate_forecast",
+      "mutation": "deeper"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr__i09_stronger_physics",
+      "family": "hist_gradient_boosting",
+      "pass": true,
+      "score": 11.428164817239463,
+      "peak_kw": 115.46377767756235,
+      "mae": 11.428164817239463,
+      "backend": "sklearn",
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr via stronger_physics",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_more_dropout__i07_deeper__i08_lower_lr",
+      "mutation": "stronger_physics"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon__i09_wider",
+      "family": "torch_phys_lstm",
+      "pass": true,
+      "score": 77.44976043701172,
+      "peak_kw": 1.0287702083587646,
+      "loss": 77.44976043701172,
+      "backend": "torch",
+      "detail": {
+        "ok": true,
+        "kind": "multi_horizon",
+        "loss": 77.44976043701172,
+        "recon_peak_kw": 1.0287702083587646,
+        "pass": true,
+        "score": 77.44976043701172
+      },
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon via wider",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon",
+      "mutation": "wider"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon__i09_more_dropout",
+      "family": "torch_phys_lstm",
+      "pass": true,
+      "score": 77.51697540283203,
+      "peak_kw": 0.8321016430854797,
+      "loss": 77.51697540283203,
+      "backend": "torch",
+      "detail": {
+        "ok": true,
+        "kind": "multi_horizon",
+        "loss": 77.51697540283203,
+        "recon_peak_kw": 0.8321016430854797,
+        "pass": true,
+        "score": 77.51697540283203
+      },
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon via more_dropout",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon",
+      "mutation": "more_dropout"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon__i09_weaker_physics",
+      "family": "torch_phys_lstm",
+      "pass": true,
+      "score": 77.65856170654297,
+      "peak_kw": 0.533433735370636,
+      "loss": 77.65856170654297,
+      "backend": "torch",
+      "detail": {
+        "ok": true,
+        "kind": "multi_horizon",
+        "loss": 77.65856170654297,
+        "recon_peak_kw": 0.533433735370636,
+        "pass": true,
+        "score": 77.65856170654297
+      },
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon via weaker_physics",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon",
+      "mutation": "weaker_physics"
+    },
+    {
+      "name": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon__i09_ablate_forecast",
+      "family": "torch_phys_lstm",
+      "pass": true,
+      "score": 77.75672912597656,
+      "peak_kw": 0.8510763645172119,
+      "loss": 77.75672912597656,
+      "backend": "torch",
+      "detail": {
+        "ok": true,
+        "kind": "multi_horizon",
+        "loss": 77.75672912597656,
+        "recon_peak_kw": 0.8510763645172119,
+        "pass": true,
+        "score": 77.75672912597656
+      },
+      "theme": "iter9 mutate sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon via ablate_forecast",
+      "parent": "sklearn_hgb_multi__i02_ablate_strategy__i03_more_dropout__i04_wider__i05_wider__i06_ablate_forecast__i07_wider__i08_longer_horizon",
+      "mutation": "ablate_forecast"
+    }
+  ]
+}

--- a/vibe_code_apps_22/ml/artifacts/fixtures/hybrid_vs_eplus_scorecard.json
+++ b/vibe_code_apps_22/ml/artifacts/fixtures/hybrid_vs_eplus_scorecard.json
@@ -1,10 +1,11 @@
 {
-  "USE_EPLUS_ONLY": false,
+  "USE_EPLUS_ONLY": true,
   "plant_peak_cap_kw": 450.0,
   "corr_floor": 0.35,
   "peak_mae_max": 200.0,
   "n_pass": 1,
   "n_eval": 12,
+  "min_pass_for_ml": 6,
   "snap_days": [
     "2026-01-23",
     "2026-01-25",
@@ -190,5 +191,5 @@
     }
   ],
   "honesty": "HYBRID_SCREENING",
-  "note": "IdealLoads+COP farm is strategy shape reference, not W2A plant twin. USE_EPLUS_ONLY=true means no ML strategy-day cleared sanity+fidelity gates."
+  "note": "IdealLoads+COP farm is strategy shape reference, not W2A plant twin. USE_EPLUS_ONLY=true unless a majority of strategy-days clear sanity+fidelity gates."
 }

--- a/vibe_code_apps_22/scripts/eval_hybrid_vs_eplus_farm.py
+++ b/vibe_code_apps_22/scripts/eval_hybrid_vs_eplus_farm.py
@@ -33,6 +33,12 @@ CORR_FLOOR = 0.35
 PEAK_MAE_MAX = 200.0
 
 
+def decide_use_eplus_only(n_pass: int, n_eval: int) -> tuple[bool, int]:
+    """Return (USE_EPLUS_ONLY, min_pass_for_ml). Majority of eval rows must pass for ML."""
+    min_pass = max(1, (int(n_eval) + 1) // 2) if n_eval else 1
+    return int(n_pass) < min_pass, min_pass
+
+
 def _site() -> Path:
     for key in ("LAKESIDE_SITE_ROOT", "VIBE22_SITE_ROOT"):
         v = os.environ.get(key, "").strip()
@@ -194,7 +200,7 @@ def main() -> int:
                 }
             )
 
-    use_eplus_only = n_pass == 0
+    use_eplus_only, min_pass = decide_use_eplus_only(n_pass, len(rows))
     scorecard = {
         "USE_EPLUS_ONLY": use_eplus_only,
         "plant_peak_cap_kw": PLANT_PEAK_CAP_KW,
@@ -202,12 +208,13 @@ def main() -> int:
         "peak_mae_max": PEAK_MAE_MAX,
         "n_pass": n_pass,
         "n_eval": len(rows),
+        "min_pass_for_ml": min_pass,
         "snap_days": snap,
         "rows": rows,
         "honesty": "HYBRID_SCREENING",
         "note": (
             "IdealLoads+COP farm is strategy shape reference, not W2A plant twin. "
-            "USE_EPLUS_ONLY=true means no ML strategy-day cleared sanity+fidelity gates."
+            "USE_EPLUS_ONLY=true unless a majority of strategy-days clear sanity+fidelity gates."
         ),
     }
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/vibe_code_apps_22/tests/test_arch_search_smoke.py
+++ b/vibe_code_apps_22/tests/test_arch_search_smoke.py
@@ -17,6 +17,16 @@ def test_iter01_has_ten():
     assert any("phys_lstm" in c["name"] for c in ITER_01)
 
 
+def test_fixtures_cover_iters_01_through_10():
+    root = _APP / "ml" / "artifacts" / "fixtures" / "arch_search"
+    for i in range(1, 11):
+        p = root / f"iter_{i:02d}_leaderboard.json"
+        assert p.is_file(), p
+        doc = json.loads(p.read_text(encoding="utf-8"))
+        assert doc.get("iter") == i or doc.get("n") == 10
+        assert len(doc.get("rows") or []) == 10
+
+
 def test_mutate_produces_ten():
     fake = [{"name": c["name"], "pass": True, "score": float(i)} for i, c in enumerate(ITER_01)]
     nxt = mutate_for_next_iter(fake, iter_n=2)

--- a/vibe_code_apps_22/tests/test_eplus_dsm_fidelity.py
+++ b/vibe_code_apps_22/tests/test_eplus_dsm_fidelity.py
@@ -8,8 +8,9 @@ import numpy as np
 import pytest
 
 _APP = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(_APP / "ml"))
+sys.path[:0] = [str(_APP / "ml"), str(_APP / "scripts")]
 
+from eval_hybrid_vs_eplus_farm import decide_use_eplus_only  # noqa: E402
 from hybrid_sanity import PLANT_PEAK_CAP_KW, assert_walk_sane  # noqa: E402
 
 
@@ -52,3 +53,14 @@ def test_sane_aligned_series_passes_corr_floor():
     ]
     assert assert_walk_sane({"steps": steps, "summary": {}}) is None
     assert _corr(hybrid, eplus) >= 0.85
+
+
+def test_use_eplus_only_requires_majority_pass():
+    use, min_pass = decide_use_eplus_only(n_pass=1, n_eval=12)
+    assert min_pass == 6
+    assert use is True
+    use2, min2 = decide_use_eplus_only(n_pass=6, n_eval=12)
+    assert min2 == 6
+    assert use2 is False
+    use3, _ = decide_use_eplus_only(n_pass=0, n_eval=12)
+    assert use3 is True


### PR DESCRIPTION
## Summary
- Tighten `USE_EPLUS_ONLY` so ML cold-snap overlays require a **majority** of strategy-day scorecard passes (1/12 no longer unlocks ML).
- Commit arch_search leaderboard fixtures for iters **02–09** (01/10 already present) and assert fixtures cover 01–10 in CI.
- Align fixture scorecard with majority gate (`USE_EPLUS_ONLY=true` for the recorded 1/12 pass run).

## Test plan
- [x] `pytest vibe_code_apps_22/tests/test_eplus_dsm_fidelity.py vibe_code_apps_22/tests/test_arch_search_smoke.py`
- [ ] GH Actions `vibe22-ci` green on this PR
- [ ] Merge to `develop`; delete branch; confirm no stale PR/branch

Made with [Cursor](https://cursor.com)