### PR TITLE
fix(vibe19): topology.csv parent_ahu in Engineering Bundle

### DIFF
--- a/vibe_code_apps_19/app/agent_api.py
+++ b/vibe_code_apps_19/app/agent_api.py
@@ -737,12 +737,21 @@ def export_agent_bundle(
 
     # Analytic-tab CSVs (topology, data model, sensor health, RCx comfort, meters)
     try:
+        from app.data_contract import load_vav_to_ahu_map
         from app.data_model_tree import build_data_model_tree
+
+        vav_to_ahu: dict[str, str] = {}
+        if dataset.source_path:
+            try:
+                vav_to_ahu = load_vav_to_ahu_map(Path(dataset.source_path))
+            except Exception:
+                vav_to_ahu = {}
 
         tree = build_data_model_tree(
             dataset.frames,
             dataset.role_map,
             building_id=dataset.building_id,
+            vav_to_ahu=vav_to_ahu,
         )
         topo = pd.DataFrame(tree.topology_rows())
         if not topo.empty:
@@ -754,8 +763,10 @@ def export_agent_bundle(
             path = out / "data_model.csv"
             dm.to_csv(path, index=False)
             written["data_model"] = path
-    except Exception:
-        pass
+    except Exception as exc:
+        import logging
+
+        logging.getLogger(__name__).warning("topology/data_model export failed: %s", exc)
 
     try:
         from app.analytics import sensor_fault_summary, sensor_health_matrix

--- a/vibe_code_apps_19/app/data_model_tree.py
+++ b/vibe_code_apps_19/app/data_model_tree.py
@@ -82,6 +82,8 @@ class BuildingDataModelTree:
                     "relation": "fedBy",
                     "related_ids": ahu_id,
                     "related_count": 1,
+                    "parent_ahu": ahu_id,
+                    "vav_id": vav_id,
                 }
             )
         return rows

--- a/vibe_code_apps_19/tests/test_topology_enrich.py
+++ b/vibe_code_apps_19/tests/test_topology_enrich.py
@@ -71,7 +71,14 @@ def test_data_model_tree_feeds():
     assert by_id["AHU_1"].feeds == ["VAV_1"]
     topo = tree.topology_rows()
     assert {"equipment_id": "AHU_1", "relation": "feeds", "related_ids": "VAV_1", "related_count": 1} in topo
-    assert {"equipment_id": "VAV_1", "relation": "fedBy", "related_ids": "AHU_1", "related_count": 1} in topo
+    assert {
+        "equipment_id": "VAV_1",
+        "relation": "fedBy",
+        "related_ids": "AHU_1",
+        "related_count": 1,
+        "parent_ahu": "AHU_1",
+        "vav_id": "VAV_1",
+    } in topo
     point_cols = set(tree.to_rows()[0]) if tree.to_rows() else set()
     assert "fed_by" not in point_cols and "feeds" not in point_cols
 


### PR DESCRIPTION
## Summary
- Load `vav_to_ahu_simple.csv` when exporting the Engineering Bundle
- Emit `parent_ahu` / `vav_id` on fedBy rows so dump-vs-dump topology checks work

## Test plan
- [ ] vibe19-pytest + vibe19-ghcr green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Topology and data-model exports now include VAV-to-AHU relationship details, including parent AHU and VAV identifiers.
  - Exported relationship data retains existing connection and count information.

- **Bug Fixes**
  - Export issues are now reported with a warning instead of being silently ignored, making failures easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->