### PR TITLE
fix(vibe22): durable DSM campaign runner with EPW preflight

### DIFF
--- a/vibe_code_apps_22/eplus_gym/env.py
+++ b/vibe_code_apps_22/eplus_gym/env.py
@@ -111,6 +111,24 @@ class EnergyPlusEnv(gym.Env, metaclass=abc.ABCMeta):
         )
         self.energyplus_runner.start()
         obs = self.energyplus_runner.init_exchange(default_action=self.default_action)
+        if obs is None:
+            from .errors import EnergyPlusStartupError
+            from .startup_diag import diagnose_startup_failure
+
+            diag = diagnose_startup_failure(self.energyplus_runner)
+            try:
+                self.energyplus_runner.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            raise EnergyPlusStartupError(
+                diag["message"],
+                exit_code=diag.get("exit_code"),
+                runner_error=diag.get("runner_error"),
+                err_path=diag.get("err_path"),
+                severe_or_fatal=diag.get("severe_or_fatal"),
+                log_tail=diag.get("log_tail"),
+                details=diag,
+            )
         self.last_obs = obs
         return np.array(list(obs.values()), dtype=np.float32), {
             "honesty": self.honesty,

--- a/vibe_code_apps_22/eplus_gym/errors.py
+++ b/vibe_code_apps_22/eplus_gym/errors.py
@@ -1,0 +1,40 @@
+"""Typed EnergyPlus gym failures (preserve eplusout.err text)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+class EnergyPlusStartupError(RuntimeError):
+    """EnergyPlus aborted before the gym received a first observation."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        exit_code: int | None = None,
+        runner_error: str | None = None,
+        err_path: Path | str | None = None,
+        severe_or_fatal: str | None = None,
+        log_tail: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+        self.runner_error = runner_error
+        self.err_path = Path(err_path) if err_path else None
+        self.severe_or_fatal = severe_or_fatal
+        self.log_tail = log_tail
+        self.details = dict(details or {})
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": "EnergyPlusStartupError",
+            "message": str(self),
+            "exit_code": self.exit_code,
+            "runner_error": self.runner_error,
+            "err_path": str(self.err_path) if self.err_path else None,
+            "severe_or_fatal": self.severe_or_fatal,
+            "log_tail": self.log_tail,
+            "details": self.details,
+        }

--- a/vibe_code_apps_22/eplus_gym/simulate.py
+++ b/vibe_code_apps_22/eplus_gym/simulate.py
@@ -233,6 +233,10 @@ def run_rule_episode(
                     verbose=verbose,
                 )
             except Exception as exc:  # noqa: BLE001
+                from .errors import EnergyPlusStartupError
+
+                if isinstance(exc, EnergyPlusStartupError):
+                    raise
                 raise FileNotFoundError(
                     f"W2A live EnergyPlus failed ({exc}); "
                     "will not fall back to IdealLoads"

--- a/vibe_code_apps_22/eplus_gym/startup_diag.py
+++ b/vibe_code_apps_22/eplus_gym/startup_diag.py
@@ -1,0 +1,79 @@
+"""Pull Severe/Fatal lines from EnergyPlus episode folders after a failed reset."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def _first_severe_or_fatal(text: str) -> str | None:
+    for line in text.splitlines():
+        s = line.strip()
+        low = s.lower()
+        if "severe" in low or "fatal" in low or "** severe **" in low or "** fatal **" in low:
+            return s[:400]
+    return None
+
+
+def _tail(text: str, n: int = 40) -> str:
+    lines = text.splitlines()
+    return "\n".join(lines[-n:])
+
+
+def find_eplusout_err(output_root: Path | str | None) -> Path | None:
+    if output_root is None:
+        return None
+    root = Path(output_root)
+    if not root.exists():
+        return None
+    direct = root / "eplusout.err"
+    if direct.is_file():
+        return direct
+    hits = sorted(root.rglob("eplusout.err"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return hits[0] if hits else None
+
+
+def diagnose_startup_failure(runner: Any) -> dict[str, Any]:
+    """Build a structured diagnosis from an EnergyPlusRunner after obs is None."""
+    exit_code = None
+    runner_error = getattr(runner, "handle_error", None)
+    sim = getattr(runner, "sim_results", None) or {}
+    if isinstance(sim, dict):
+        exit_code = sim.get("exit_code")
+        runner_error = runner_error or sim.get("error") or sim.get("message")
+
+    out_root = None
+    cfg = getattr(runner, "runner_config", None)
+    if cfg is not None:
+        out_root = getattr(cfg, "output", None)
+
+    err_path = find_eplusout_err(out_root)
+    severe = None
+    log_tail = None
+    if err_path is not None and err_path.is_file():
+        try:
+            text = err_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            text = ""
+        severe = _first_severe_or_fatal(text)
+        log_tail = _tail(text)
+
+    bits = ["EnergyPlus startup failed: gym received no observation (obs is None)"]
+    if exit_code not in (None, 0):
+        bits.append(f"exit_code={exit_code}")
+    if runner_error:
+        bits.append(f"runner={runner_error}")
+    if severe:
+        bits.append(severe)
+    elif log_tail:
+        bits.append(log_tail.splitlines()[-1][:220] if log_tail else "")
+    if err_path is not None:
+        bits.append(f"err={err_path}")
+
+    return {
+        "message": " · ".join(b for b in bits if b),
+        "exit_code": exit_code,
+        "runner_error": str(runner_error) if runner_error else None,
+        "err_path": str(err_path) if err_path else None,
+        "severe_or_fatal": severe,
+        "log_tail": log_tail,
+    }

--- a/vibe_code_apps_22/eplus_gym_app/dsm_campaign.py
+++ b/vibe_code_apps_22/eplus_gym_app/dsm_campaign.py
@@ -1,0 +1,463 @@
+"""Disk-backed DSM campaign supervisor state + job gates.
+
+Streamlit starts ``scripts/run_dsm_campaign.py`` once via Popen; that CLI is the
+only writer of ``current_dsm_run.json`` / ``campaign_status.json`` transitions.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from eplus_gym.month_calendar import DEPLOYABLE_STRATEGIES
+from eplus_gym_app.dsm_console import live_run_jobs
+from eplus_gym_app.weather_files import KIND_AMY, KIND_TMY_MSN
+
+SCHEMA_VERSION = 1
+ACTIVE_STATES = frozenset({"preflight", "queued", "starting", "running"})
+TERMINAL_STATES = frozenset({"succeeded", "failed", "cancelled"})
+DEFAULT_JOB_TIMEOUT_S = 6 * 3600
+HEARTBEAT_STALE_S = 90.0
+SCORECARD_TOL_KW = 0.05
+SCORECARD_TOL_KWH = 0.25
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def eplus_gym_dir(site: Path) -> Path:
+    return Path(site) / "reports" / "eplus_gym"
+
+
+def current_run_path(site: Path) -> Path:
+    return eplus_gym_dir(site) / "current_dsm_run.json"
+
+
+def last_run_path(site: Path) -> Path:
+    return eplus_gym_dir(site) / "last_dsm_run.json"
+
+
+def cancel_request_path(site: Path) -> Path:
+    return eplus_gym_dir(site) / "cancel_dsm_run.request"
+
+
+def campaign_status_path(site: Path, run_id: str) -> Path:
+    return eplus_gym_dir(site) / "runs" / run_id / "campaign_status.json"
+
+
+def atomic_write_json(path: Path, doc: dict[str, Any]) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    payload = json.dumps(doc, indent=2, default=str) + "\n"
+    tmp.write_text(payload, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def read_json(path: Path) -> dict[str, Any] | None:
+    path = Path(path)
+    if not path.is_file():
+        return None
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def pid_alive(pid: int | None) -> bool:
+    if pid is None or int(pid) <= 0:
+        return False
+    pid = int(pid)
+    try:
+        if os.name == "nt":
+            import ctypes
+
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            STILL_ACTIVE = 259
+            handle = ctypes.windll.kernel32.OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+            )
+            if not handle:
+                return False
+            try:
+                code = ctypes.c_ulong()
+                if ctypes.windll.kernel32.GetExitCodeProcess(handle, ctypes.byref(code)) == 0:
+                    return False
+                return int(code.value) == STILL_ACTIVE
+            finally:
+                ctypes.windll.kernel32.CloseHandle(handle)
+        else:
+            os.kill(pid, 0)
+            return True
+    except OSError:
+        return False
+
+
+def elapsed_seconds(doc: dict[str, Any], *, now: float | None = None) -> float:
+    """Live elapsed while running; freeze on finished_at when terminal."""
+    started = doc.get("started_at") or doc.get("created_at")
+    if not started:
+        return 0.0
+    try:
+        t0 = datetime.fromisoformat(str(started).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0.0
+    finished = doc.get("finished_at")
+    state = str(doc.get("state") or "")
+    if finished and state in TERMINAL_STATES:
+        try:
+            t1 = datetime.fromisoformat(str(finished).replace("Z", "+00:00")).timestamp()
+            return max(0.0, t1 - t0)
+        except ValueError:
+            pass
+    now_ts = time.time() if now is None else float(now)
+    return max(0.0, now_ts - t0)
+
+
+def default_strategy_selection(selected: str | None = None) -> list[str]:
+    """Baseline + one selected strategy (default deep_setback)."""
+    pick = selected or "deep_setback"
+    if pick not in DEPLOYABLE_STRATEGIES:
+        pick = "deep_setback"
+    if pick == "baseline":
+        return ["baseline"]
+    return ["baseline", pick]
+
+
+def build_jobs(
+    *,
+    strategies: list[str],
+    weather_mode: str,
+    amy: Path | None,
+    tmy: Path | None,
+    begin: str,
+    end: str,
+    max_steps: int,
+) -> list[dict[str, Any]]:
+    weathers: list[tuple[str, Path]] = []
+    mode = (weather_mode or "AMY").strip()
+    if mode == "TMY":
+        if tmy is not None:
+            weathers.append((KIND_TMY_MSN, Path(tmy)))
+        elif amy is not None:
+            weathers.append((KIND_AMY, Path(amy)))
+    elif mode == "Both":
+        if amy is not None:
+            weathers.append((KIND_AMY, Path(amy)))
+        if tmy is not None:
+            weathers.append((KIND_TMY_MSN, Path(tmy)))
+    else:
+        if amy is not None:
+            weathers.append((KIND_AMY, Path(amy)))
+    return live_run_jobs(
+        strategies=list(strategies),
+        weathers=weathers,
+        begin=begin,
+        end=end,
+        max_steps=max_steps,
+    )
+
+
+def new_campaign_doc(
+    *,
+    run_id: str,
+    site: Path,
+    idf: Path,
+    idf_sha256: str,
+    begin: str,
+    end: str,
+    max_steps: int,
+    n_days: int,
+    strategies: list[str],
+    weather_mode: str,
+    jobs: list[dict[str, Any]],
+    epw_meta: list[dict[str, Any]],
+    preset: str,
+    peak_day: str,
+    git_sha: str | None = None,
+    supervisor_pid: int | None = None,
+) -> dict[str, Any]:
+    now = utc_now_iso()
+    serial_jobs = []
+    for j in jobs:
+        serial_jobs.append(
+            {
+                "strategy_id": j["strategy_id"],
+                "weather_kind": j["weather_kind"],
+                "epw": str(j["epw"]),
+                "begin": j["begin"],
+                "end": j["end"],
+                "max_steps": int(j["max_steps"]),
+                "key": j["key"],
+                "state": "queued",
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "site": str(site),
+        "state": "preflight",
+        "created_at": now,
+        "started_at": now,
+        "finished_at": None,
+        "heartbeat_at": now,
+        "supervisor_pid": supervisor_pid or os.getpid(),
+        "child_pid": None,
+        "completed_jobs": 0,
+        "total_jobs": len(serial_jobs),
+        "jobs": serial_jobs,
+        "idf": str(idf),
+        "idf_sha256": idf_sha256,
+        "epws": epw_meta,
+        "begin": str(begin)[:10],
+        "end": str(end)[:10],
+        "n_days": int(n_days),
+        "max_steps": int(max_steps),
+        "strategies": list(strategies),
+        "weather_mode": weather_mode,
+        "preset": preset,
+        "peak_day": peak_day,
+        "git_sha": git_sha,
+        "log": None,
+        "error": None,
+        "cancel_requested": False,
+    }
+
+
+def write_campaign(site: Path, doc: dict[str, Any]) -> None:
+    doc = dict(doc)
+    doc["heartbeat_at"] = utc_now_iso()
+    atomic_write_json(current_run_path(site), doc)
+    run_id = str(doc.get("run_id") or "")
+    if run_id:
+        atomic_write_json(campaign_status_path(site, run_id), doc)
+
+
+def request_cancel(site: Path) -> Path:
+    path = cancel_request_path(site)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(utc_now_iso(), encoding="utf-8")
+    doc = read_json(current_run_path(site))
+    if doc and str(doc.get("state") or "") in ACTIVE_STATES:
+        doc["cancel_requested"] = True
+        write_campaign(site, doc)
+    return path
+
+
+def cancel_requested(site: Path) -> bool:
+    if cancel_request_path(site).is_file():
+        return True
+    doc = read_json(current_run_path(site))
+    return bool(doc and doc.get("cancel_requested"))
+
+
+def clear_cancel_request(site: Path) -> None:
+    cancel_request_path(site).unlink(missing_ok=True)
+
+
+def active_campaign_running(site: Path) -> dict[str, Any] | None:
+    doc = read_json(current_run_path(site))
+    if not doc:
+        return None
+    state = str(doc.get("state") or "")
+    if state not in ACTIVE_STATES:
+        return None
+    if pid_alive(doc.get("supervisor_pid")) or pid_alive(doc.get("child_pid")):
+        return doc
+    return None
+
+
+def reconcile_campaign(site: Path, *, now: float | None = None) -> dict[str, Any] | None:
+    """Mark stale active campaigns failed when heartbeat is dead and no PIDs."""
+    doc = read_json(current_run_path(site))
+    if not doc:
+        return None
+    state = str(doc.get("state") or "")
+    if state not in ACTIVE_STATES:
+        return doc
+    hb = doc.get("heartbeat_at") or doc.get("started_at")
+    stale = True
+    if hb:
+        try:
+            t_hb = datetime.fromisoformat(str(hb).replace("Z", "+00:00")).timestamp()
+            age = (time.time() if now is None else float(now)) - t_hb
+            stale = age > HEARTBEAT_STALE_S
+        except ValueError:
+            stale = True
+    alive = pid_alive(doc.get("supervisor_pid")) or pid_alive(doc.get("child_pid"))
+    if stale and not alive:
+        doc["state"] = "failed"
+        doc["finished_at"] = utc_now_iso()
+        doc["error"] = {
+            "type": "StaleCampaign",
+            "message": (
+                "Campaign marked failed: heartbeat stale and supervisor/E+ PIDs not alive. "
+                f"completed_jobs={doc.get('completed_jobs', 0)}/{doc.get('total_jobs', 0)}."
+            ),
+        }
+        write_campaign(site, doc)
+    return doc
+
+
+def collect_traj(out_dir: Path) -> Path | None:
+    out_dir = Path(out_dir)
+    frames = sorted(out_dir.glob("traj_*.parquet"))
+    if not frames and (out_dir / "runs").is_dir():
+        frames = sorted((out_dir / "runs").glob("*.parquet"))
+    return frames[0] if frames else None
+
+
+def validate_job_outputs(
+    out_dir: Path,
+    *,
+    max_steps: int,
+    begin: str,
+    end: str,
+) -> dict[str, Any]:
+    """BOPTEST-style gates before incrementing completed_jobs."""
+    out_dir = Path(out_dir)
+    pq = collect_traj(out_dir)
+    if pq is None:
+        raise ValueError(f"no trajectory parquet under {out_dir}")
+    df = pd.read_parquet(pq)
+    if df is None or getattr(df, "empty", True):
+        raise ValueError("trajectory is empty")
+    if "facility_kw" not in df.columns:
+        raise ValueError("trajectory missing facility_kw")
+    kw = pd.to_numeric(df["facility_kw"], errors="coerce")
+    if not kw.notna().any() or not bool((~kw.isna()).all() or kw.notna().sum() > 0):
+        raise ValueError("facility_kw has no finite values")
+    if not bool(kw.replace([float("inf"), float("-inf")], pd.NA).notna().all()):
+        # allow NaN-free finite check
+        if (~kw.apply(lambda x: x == x and abs(x) != float("inf"))).any():  # noqa: PLR0124
+            bad = (~kw.apply(lambda x: isinstance(x, (int, float)) and x == x and abs(float(x)) != float("inf"))).sum()
+            if bad:
+                raise ValueError("facility_kw has non-finite values")
+
+    n = len(df)
+    # Allow ±1 row slack for E+ boundary quirks; reject huge under/over.
+    if n < max(1, int(max_steps) - 1) or n > int(max_steps) + 4:
+        raise ValueError(
+            f"trajectory row count {n} != expected ~{max_steps} for {begin}→{end}"
+        )
+
+    # Reject design-day / synthetic contamination when day stamps exist.
+    if "day" in df.columns:
+        days = sorted({str(d)[:10] for d in df["day"].astype(str) if str(d)[:10]})
+        if days:
+            if days[0] < str(begin)[:10] or days[-1] > str(end)[:10]:
+                raise ValueError(
+                    f"trajectory day stamps {days[0]}→{days[-1]} outside requested "
+                    f"{begin}→{end} (possible design-day contamination)"
+                )
+            # Classic EnergyPlus design-day marker years
+            if any(d.startswith("1900-") or d.startswith("0001-") for d in days):
+                raise ValueError(
+                    f"trajectory day stamps look like design-day ({days[:3]}); rejecting"
+                )
+
+    peak = float(kw.max())
+    kwh = float(kw.sum() * 0.25)
+    card = out_dir / "rule_dr_scorecard.json"
+    if card.is_file():
+        try:
+            doc = json.loads(card.read_text(encoding="utf-8"))
+            rows = doc.get("strategies") or []
+            if rows:
+                sc_peak = rows[0].get("peak_kw")
+                sc_kwh = rows[0].get("kwh")
+                if sc_peak is not None and abs(float(sc_peak) - peak) > SCORECARD_TOL_KW:
+                    raise ValueError(
+                        f"scorecard peak_kw {sc_peak} != traj {peak} (tol {SCORECARD_TOL_KW})"
+                    )
+                if sc_kwh is not None and abs(float(sc_kwh) - kwh) > SCORECARD_TOL_KWH:
+                    raise ValueError(
+                        f"scorecard kwh {sc_kwh} != traj {kwh} (tol {SCORECARD_TOL_KWH})"
+                    )
+        except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            if "scorecard" in str(exc) or "traj" in str(exc):
+                raise
+            raise ValueError(f"scorecard unreadable: {exc}") from exc
+
+    return {
+        "parquet": str(pq),
+        "n_rows": n,
+        "peak_kw": peak,
+        "kwh": kwh,
+        "days": (
+            sorted({str(d)[:10] for d in df["day"].astype(str)})
+            if "day" in df.columns
+            else []
+        ),
+    }
+
+
+def mark_failed(site: Path, doc: dict[str, Any], error: dict[str, Any] | str) -> dict[str, Any]:
+    doc = dict(doc)
+    doc["state"] = "failed"
+    doc["finished_at"] = utc_now_iso()
+    if isinstance(error, str):
+        doc["error"] = {"type": "CampaignError", "message": error}
+    else:
+        doc["error"] = error
+    write_campaign(site, doc)
+    return doc
+
+
+def mark_cancelled(site: Path, doc: dict[str, Any]) -> dict[str, Any]:
+    doc = dict(doc)
+    doc["state"] = "cancelled"
+    doc["finished_at"] = utc_now_iso()
+    doc["error"] = {"type": "Cancelled", "message": "Cancel requested"}
+    write_campaign(site, doc)
+    clear_cancel_request(site)
+    return doc
+
+
+def mark_succeeded(site: Path, doc: dict[str, Any]) -> dict[str, Any]:
+    doc = dict(doc)
+    doc["state"] = "succeeded"
+    doc["finished_at"] = utc_now_iso()
+    doc["error"] = None
+    write_campaign(site, doc)
+    return doc
+
+
+def peak_day_smoke_ok(
+    site: Path,
+    *,
+    idf_sha256: str,
+    epw_sha256: str | None = None,
+) -> bool:
+    """True if a prior successful peak-day campaign matches these hashes."""
+    for path in (current_run_path(site), last_run_path(site)):
+        doc = read_json(path)
+        if not doc:
+            continue
+        if str(doc.get("state") or "") not in {"succeeded", ""} and path == current_run_path(site):
+            if str(doc.get("state") or "") != "succeeded":
+                continue
+        # last_dsm_run may lack state; treat presence of peak-day period + matching hashes
+        preset = str(doc.get("preset") or "")
+        n_days = doc.get("n_days") or doc.get("window_n")
+        if preset and preset != "Peak day" and int(n_days or 0) != 1:
+            continue
+        if doc.get("idf_sha256") and str(doc["idf_sha256"]).lower() != idf_sha256.lower():
+            continue
+        if epw_sha256:
+            epws = doc.get("epws") or []
+            hashes = [str(e.get("sha256") or "").lower() for e in epws if isinstance(e, dict)]
+            if hashes and epw_sha256.lower() not in hashes:
+                # also accept epw_sha256 field on last_dsm_run
+                if str(doc.get("epw_sha256") or "").lower() != epw_sha256.lower():
+                    continue
+        if path == last_run_path(site) or str(doc.get("state")) == "succeeded":
+            return True
+    return False

--- a/vibe_code_apps_22/eplus_gym_app/dsm_console.py
+++ b/vibe_code_apps_22/eplus_gym_app/dsm_console.py
@@ -880,8 +880,8 @@ def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
     st.caption(
         f"Champion `{bundle.dsm_champion}` · W2A_PHYSICAL_DSM · promote=False. "
         "Default: **Peak day** · **AMY** · baseline + one strategy (2 jobs). "
-        "Live E+ runs in a durable campaign supervisor (`current_dsm_run.json`); "
-        "this page only polls status."
+        "Live E+ is closed-loop (`CLOSED_LOOP_RULE_DR` / `SCH_HtgSP` every 15 min) via "
+        "durable campaign supervisor (`current_dsm_run.json`); this page only polls status."
     )
     mode, reason = resolve_dsm_mode(bundle.site)
     st.info(f"Mode: **{mode}** â€” {reason}")

--- a/vibe_code_apps_22/eplus_gym_app/dsm_console.py
+++ b/vibe_code_apps_22/eplus_gym_app/dsm_console.py
@@ -1,4 +1,4 @@
-"""BOPTEST-shaped DSM Run panel (W2A champion only)."""
+﻿"""BOPTEST-shaped DSM Run panel (W2A champion only)."""
 from __future__ import annotations
 
 import json
@@ -51,7 +51,7 @@ def pick_frame(
 
 
 def frame_map(value: Any) -> dict[str, pd.DataFrame]:
-    """Coerce session/disk payload to a str→DataFrame map (never bool(DataFrame))."""
+    """Coerce session/disk payload to a strâ†’DataFrame map (never bool(DataFrame))."""
     if not isinstance(value, dict):
         return {}
     out: dict[str, pd.DataFrame] = {}
@@ -124,7 +124,7 @@ def live_run_jobs(
     end: str,
     max_steps: int,
 ) -> list[dict[str, Any]]:
-    """One CLI job per strategy × weather. Keys are strategy:weather_kind."""
+    """One CLI job per strategy Ã— weather. Keys are strategy:weather_kind."""
     jobs: list[dict[str, Any]] = []
     for sid in strategies:
         for kind, epw in weathers:
@@ -210,8 +210,8 @@ def dsm_kpis(
 def attach_baseline_deltas(kpis_by: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
     """Window-total kW trim and kWh penalty vs the baseline strategy.
 
-    kw_trim = baseline peak kW − strategy peak kW  (+ = trimmed demand)
-    kwh_penalty = strategy kWh − baseline kWh      (+ = energy penalty)
+    kw_trim = baseline peak kW âˆ’ strategy peak kW  (+ = trimmed demand)
+    kwh_penalty = strategy kWh âˆ’ baseline kWh      (+ = energy penalty)
     Totals cover the whole selected window (peak day / month / winter / year).
     """
     base = kpis_by.get("baseline") or {}
@@ -816,9 +816,58 @@ def _collect_traj(out_dir: Path) -> Path | None:
     return frames[0] if frames else None
 
 
+def _campaign_cli() -> Path:
+    return _APP / "scripts" / "run_dsm_campaign.py"
+
+
+def start_dsm_campaign_subprocess(*, site: Path, request_path: Path) -> subprocess.Popen:
+    """Launch durable campaign supervisor (Streamlit must not import pyenergyplus)."""
+    import os
+
+    log_dir = Path(site) / "reports" / "eplus_gym"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log = log_dir / "campaign_supervisor.log"
+    handle = log.open("a", encoding="utf-8")
+    cmd = [
+        sys.executable,
+        "-u",
+        str(_campaign_cli()),
+        "--site",
+        str(site),
+        "--request",
+        str(request_path),
+    ]
+    env = os.environ.copy()
+    env["SITE_ROOT"] = str(site)
+    env["LAKESIDE_SITE_ROOT"] = str(site)
+    return subprocess.Popen(
+        cmd,
+        cwd=str(_APP),
+        stdout=handle,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+        env=env,
+    )
+
+
 def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
     import streamlit as st
+    from datetime import timedelta
 
+    from eplus_gym_app.dsm_campaign import (
+        active_campaign_running,
+        build_jobs,
+        cancel_request_path,
+        current_run_path,
+        default_strategy_selection,
+        elapsed_seconds,
+        peak_day_smoke_ok,
+        reconcile_campaign,
+        request_cancel,
+        write_campaign,  # noqa: F401 â€” imported for tests/monkeypatch
+    )
+    from eplus_gym_app.dsm_preflight import sha256_file
     from eplus_gym_app.plots import (
         COLORS,
         dsm_panel_figure,
@@ -830,31 +879,28 @@ def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
     st.subheader("Run DSM")
     st.caption(
         f"Champion `{bundle.dsm_champion}` · W2A_PHYSICAL_DSM · promote=False. "
-        "Run **all five** rule contracts on the selected window. "
-        "**AMY** = Open-Meteo actual year (M&V). **TMY** = typical Madison MSN. "
-        "Live E+ is closed-loop (`SCH_HtgSP` every 15 min) for the **whole selected window**."
+        "Default: **Peak day** · **AMY** · baseline + one strategy (2 jobs). "
+        "Live E+ runs in a durable campaign supervisor (`current_dsm_run.json`); "
+        "this page only polls status."
     )
     mode, reason = resolve_dsm_mode(bundle.site)
-    st.info(f"Mode: **{mode}** — {reason}")
+    st.info(f"Mode: **{mode}** â€” {reason}")
+
+    # Reconcile stale campaigns on every render
+    camp = reconcile_campaign(bundle.site)
 
     lib = strategy_library()
-    st.markdown("**Strategy library** (all five run on every click)")
-    st.caption(
-        "Contracts: "
-        + ", ".join(f"`{s}`" for s in DEPLOYABLE_STRATEGIES)
-        + ". PRBS is not offered on this console."
-    )
+    st.markdown("**Strategy library**")
     st.dataframe(pd.DataFrame(lib["rows"]), width="stretch", hide_index=True)
     st.plotly_chart(
         strategy_setpoint_figure(lib["series"]),
         width="stretch",
         key="dsm_strategy_sp_library",
     )
-    st.caption("Weekend heating SP repeats this 96-step profile (`weekend_sp=repeat_96_step_profile`).")
 
     inv = weather_inventory(bundle.site, published=bundle.epw)
-    wx_opts = ["AMY", "TMY", "Both"]
-    default_wx = inv.get("default_mode") or "AMY"
+    if inv.get("stale_bundle_epw"):
+        st.warning(inv.get("stale_bundle_note") or "Published bundle EPW is stale vs amy_meta.")
 
     month_opts = calendar_month_options(bundle)
     default_m = default_calendar_month(month_opts, bundle.dial_ladder.peak_day)
@@ -873,59 +919,111 @@ def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
             disabled=preset != "Calendar month",
         )
     with c3:
-        wx_mode = st.radio(
-            "Weather",
-            options=wx_opts,
-            index=wx_opts.index(default_wx) if default_wx in wx_opts else 0,
-            key="dsm_weather",
-            help="AMY = Open-Meteo actual year. TMY = Madison typical. Both = two sequential live runs per strategy.",
+        non_base = [s for s in DEPLOYABLE_STRATEGIES if s != "baseline"]
+        selected = st.selectbox(
+            "Strategy (+ baseline)",
+            options=non_base,
+            index=non_base.index("deep_setback") if "deep_setback" in non_base else 0,
+            key="dsm_strategy_pick",
+            format_func=lambda s: STRATEGY_LABELS.get(s, s),
         )
 
-    if inv.get("tmy") is None:
-        st.warning(inv.get("tmy_missing_note") or "No Madison MSN TMY on this site.")
-    if wx_mode == "TMY" and inv.get("tmy") is None:
-        st.caption("TMY missing — Run will use AMY only (Chicago screening EPW is not auto-selected).")
+    with st.expander("Advanced weather / batch", expanded=False):
+        wx_mode = st.radio(
+            "Weather",
+            options=["AMY", "TMY", "Both"],
+            index=0,
+            key="dsm_weather",
+            help="Default AMY. Both/TMY and run-all-five live here.",
+        )
+        run_all_five = st.checkbox("Run all five strategies", value=False, key="dsm_run_all")
+        if inv.get("tmy") is None:
+            st.caption(inv.get("tmy_missing_note") or "No Madison MSN TMY on this site.")
 
     ctx = pick_run_context(bundle, preset, month if preset == "Calendar month" else None)
     spec = period_run_spec(ctx, preset)
     day = spec["peak_day"]
+    strategies = (
+        list(DEPLOYABLE_STRATEGIES)
+        if run_all_five
+        else default_strategy_selection(selected)
+    )
     pairs = epws_for_mode(wx_mode, inv)
     jobs = live_run_jobs(
-        strategies=list(DEPLOYABLE_STRATEGIES),
+        strategies=strategies,
         weathers=pairs,
         begin=spec["begin"],
         end=spec["end"],
         max_steps=int(spec["max_steps"]),
     )
     epw_names = ", ".join(f"{k}={p.name}" for k, p in pairs) if pairs else "(no EPW)"
-    n_strat = len(DEPLOYABLE_STRATEGIES)
-    n_wx = max(len(pairs), 1)
-    live_note = (
-        f"**Will simulate closed-loop all {n_strat} strategies** `{spec['begin']}` → `{spec['end']}` · "
-        f"**{spec['n_days']} days** · **{spec['max_steps']} steps** (15 min) · "
-        f"**{len(jobs)} live runs** ({n_strat} × {n_wx} weather). "
-        f"Year/winter × 5 × AMY is long; Both doubles that. "
-        f"Meter-peak day inside the window: `{day}` — {ctx['why']}."
+
+    champ = bundle.champion()
+    idf = (champ.idf_path if champ else None) or bundle.idf_path
+    idf_hash = sha256_file(Path(idf)) if idf and Path(idf).is_file() else ""
+    amy_hash = None
+    if inv.get("amy") and Path(inv["amy"]).is_file():
+        amy_hash = sha256_file(Path(inv["amy"]))
+    calendar_ok = peak_day_smoke_ok(
+        bundle.site, idf_sha256=idf_hash, epw_sha256=amy_hash
     )
-    if mode == "lookup":
-        live_note = (
-            f"**Lookup is peak-day only** (`{day}`, 96 steps) for all five strategies. "
-            "Grow a W2A farm or use live E+ for the full week/month/winter/year window."
-        )
-    st.markdown(live_note)
-    st.caption(
-        f"Weather files: {epw_names}. "
-        "AMY is **not** a typical-year EPW. TMY is typical. "
-        "OAT mismatch vs BAS is station/source, not 'TMY vs actual' when only AMY is present. "
-        f"Honesty: loop=CLOSED_LOOP_RULE_DR · period={spec['period']} · "
-        "weekend_sp=repeat_96_step_profile · promote=False."
-    )
-    if ctx.get("actual_peak_kw") is not None:
-        st.caption(
-            f"BAS meter peak in this window: **{ctx['actual_peak_kw']:.0f} kW** on `{day}`."
+    if preset == "Calendar year" and not calendar_ok:
+        st.error(
+            "Calendar year is gated until a successful peak-day smoke completes "
+            "for this IDF + AMY hash. Run Peak day first."
         )
 
-    if st.button("Run all 5 strategies", key="dsm_run_btn", type="primary"):
+    st.markdown(
+        f"**Will run** `{', '.join(strategies)}` · `{spec['begin']}` â†’ `{spec['end']}` · "
+        f"**{spec['n_days']} days** · **{spec['max_steps']} steps** · "
+        f"**{len(jobs)} job(s)** · weather `{wx_mode}` ({epw_names}). "
+        f"Meter-peak day: `{day}` â€” {ctx['why']}."
+    )
+
+    @st.fragment(run_every=timedelta(seconds=1))
+    def _campaign_status_fragment() -> None:
+        doc = reconcile_campaign(bundle.site) or {}
+        state = str(doc.get("state") or "idle")
+        done = int(doc.get("completed_jobs") or 0)
+        total = int(doc.get("total_jobs") or 0)
+        elapsed = elapsed_seconds(doc) if doc else 0.0
+        err = doc.get("error") or {}
+        msg = ""
+        if isinstance(err, dict):
+            msg = str(err.get("message") or "")
+        st.markdown(
+            f"**Campaign:** `{state}` · "
+            f"**{done} / {total}** · "
+            f"elapsed **{format_hms(elapsed)}**"
+            + (f" · `{doc.get('run_id')}`" if doc.get("run_id") else "")
+        )
+        if state in {"failed", "cancelled"} and msg:
+            st.error(msg)
+        elif state == "succeeded":
+            st.success(f"Campaign succeeded ({done}/{total}) in {format_hms(elapsed)}")
+        elif state in {"preflight", "queued", "starting", "running"}:
+            st.info(msg or "Supervisor runningâ€¦")
+            if st.button("Cancel campaign", key="dsm_cancel_btn"):
+                request_cancel(bundle.site)
+                st.warning("Cancel requested")
+
+    _campaign_status_fragment()
+
+    long_campaign = len(jobs) > 2 or int(spec["n_days"]) > 7 or preset in {
+        "Winter (Decâ€“Feb)",
+        "Calendar year",
+    }
+    run_label = "Run DSM" if not run_all_five else "Run all 5 strategies"
+    if st.button(run_label, key="dsm_run_btn", type="primary"):
+        if preset == "Calendar year" and not calendar_ok:
+            st.error("Calendar year blocked until peak-day smoke succeeds.")
+            return
+        if long_campaign:
+            st.warning(
+                f"Long campaign: {len(jobs)} jobs · {preset} · {spec['period']} · "
+                f"~{spec['max_steps']} steps/job · IDF `{Path(idf).name if idf else '?'}` · "
+                f"EPW {epw_names}"
+            )
         actual_peak = ctx.get("actual_peak_kw")
         if actual_peak is None:
             actual_peak = _actual_peak(bundle, day)
@@ -933,11 +1031,13 @@ def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
         if mode == "error":
             st.error(reason)
             return
+        if active_campaign_running(bundle.site):
+            st.error("A DSM campaign is already running for this site.")
+            return
         if mode == "lookup":
             frames_by: dict[str, pd.DataFrame] = {}
             kpis_by: dict[str, Any] = {}
-            base_peak = None
-            for sid in DEPLOYABLE_STRATEGIES:
+            for sid in strategies:
                 try:
                     pack = run_dsm_lookup(
                         site_root=bundle.site,
@@ -949,10 +1049,8 @@ def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
                     continue
                 frames_by[f"{sid}:lookup"] = pack["frame"]
                 kpis_by[sid] = pack["kpis"]
-                if sid == "baseline":
-                    base_peak = pack["kpis"].get("peak_kw")
             if not frames_by:
-                st.error("No W2A farm days for any of the five strategies.")
+                st.error("No W2A farm days for the selected strategies.")
                 return
             attach_baseline_deltas(kpis_by)
             primary = pick_frame(frames_by, "baseline:lookup")
@@ -981,271 +1079,57 @@ def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
                 kpis_by_strategy=kpis_by,
             )
             st.rerun()
-        else:
-            champ = bundle.champion()
-            idf = (champ.idf_path if champ else None) or bundle.idf_path
-            if idf is None or not Path(idf).is_file():
-                st.error("No champion IDF on the published pack.")
-                return
-            if not pairs:
-                st.error(
-                    "No AMY or site TMY EPW. Agent must publish {site_slug}_amy_*.epw. "
-                    "Chicago screening is not used."
-                )
-                return
-            stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-            frames_by: dict[str, pd.DataFrame] = {}
-            parquets: dict[str, str] = {}
-            elapsed_by: dict[str, float] = {}
-            kpis_by: dict[str, Any] = {}
-            last_out = None
-            last_meta: dict[str, Any] = {}
-            campaign_t0 = time.perf_counter()
-            n_jobs = len(jobs)
-            try:
-                st.html(
-                    f"""
-<div style="font:600 1.05rem ui-monospace,Consolas,monospace;padding:0.35rem 0;line-height:1.45;">
-  <div>DSM run timer: <span id="dsm-run-timer">0s</span></div>
-  <div>E+ sims: <span id="dsm-run-sims">0 / {n_jobs}</span> complete</div>
-  <div>E+ health: <span id="dsm-run-health">starting…</span></div>
-</div>
-<script>
-(() => {{
-  const timerEl = document.getElementById('dsm-run-timer');
-  const simsEl = document.getElementById('dsm-run-sims');
-  const healthEl = document.getElementById('dsm-run-health');
-  if (!timerEl) return;
-  const t0 = Date.now();
-  const total = {n_jobs};
-  window.__dsmSimsDone = 0;
-  const fmt = (sec) => {{
-    sec = Math.max(0, sec|0);
-    const h = Math.floor(sec / 3600);
-    const m = Math.floor((sec % 3600) / 60);
-    const s = sec % 60;
-    if (h) return h + 'h ' + String(m).padStart(2,'0') + 'm ' + String(s).padStart(2,'0') + 's';
-    if (m) return m + 'm ' + String(s).padStart(2,'0') + 's';
-    return s + 's';
-  }};
-  const paint = () => {{
-    timerEl.textContent = fmt((Date.now() - t0) / 1000);
-    if (simsEl) simsEl.textContent = (window.__dsmSimsDone || 0) + ' / ' + total + ' complete';
-  }};
-  paint();
-  window.__dsmRunTimer = setInterval(paint, 250);
-  window.__dsmBumpSim = () => {{
-    window.__dsmSimsDone = Math.min(total, (window.__dsmSimsDone || 0) + 1);
-    paint();
-  }};
-  window.__dsmSetHealth = (msg) => {{
-    if (healthEl) healthEl.textContent = msg;
-  }};
-}})();
-</script>
-                    """,
-                    unsafe_allow_javascript=True,
-                )
-            except Exception:  # noqa: BLE001
-                pass
-            sims_counter = st.empty()
-            health_box = st.empty()
-            sims_counter.metric("E+ sims complete", f"0 / {n_jobs}")
-            health_box.info("E+ health: starting…")
-            progress = st.progress(0, text="Starting live EnergyPlus…")
-            with st.status("Live EnergyPlus (subprocess)…", expanded=True) as status:
-                for i, job in enumerate(jobs, start=1):
-                    sid = job["strategy_id"]
-                    kind = job["weather_kind"]
-                    key = job["key"]
-                    out_dir = (
-                        bundle.site
-                        / "reports"
-                        / "eplus_gym"
-                        / "runs"
-                        / f"{stamp}_{sid}_{kind}"
-                    )
-                    last_out = out_dir
-                    job_t0 = time.perf_counter()
-                    job_label = (
-                        f"{sid} · {kind} · {spec['begin']}→{spec['end']} · "
-                        f"{spec['max_steps']} steps"
-                    )
-                    done_before = i - 1
-                    status.update(
-                        label=(
-                            f"{job_label} · sim {i}/{n_jobs} · "
-                            f"job 0s · total {format_hms(time.perf_counter() - campaign_t0)}"
-                        ),
-                        state="running",
-                    )
-                    sims_counter.metric(
-                        "E+ sims complete",
-                        f"{done_before} / {n_jobs}",
-                        delta=f"running {sid}",
-                    )
-                    health_box.info(f"E+ health: running `{sid}` ({i}/{n_jobs})…")
-                    progress.progress(
-                        done_before / max(n_jobs, 1),
-                        text=f"Running {sid} ({i}/{n_jobs})…",
-                    )
-                    proc, log_handle, log = start_live_subprocess(
-                        site=bundle.site,
-                        strategy_id=sid,
-                        epw=Path(job["epw"]),
-                        idf=Path(idf),
-                        out_dir=out_dir,
-                        day=spec["begin"],
-                        begin=spec["begin"],
-                        end=spec["end"],
-                        max_steps=int(spec["max_steps"]),
-                    )
-                    code, elapsed_s = wait_live_subprocess(
-                        proc,
-                        status=status,
-                        job_label=job_label,
-                        campaign_t0=campaign_t0,
-                        job_t0=job_t0,
-                        job_index=i,
-                        job_total=n_jobs,
-                        log_path=log,
-                        log_handle=log_handle,
-                    )
-                    elapsed_by[key] = elapsed_s
-                    tail = live_log_tail(log, n=16)
-                    if tail:
-                        st.code(f"[{sid} {kind} {format_hms(elapsed_s)}]\n{tail}")
-                    failed = code != 0
-                    if not failed and "energyplus terminated" in tail.lower():
-                        failed = True
-                    if failed:
-                        diagnosis = summarize_eplus_failure(log, exit_code=code)
-                        progress.progress(i / max(n_jobs, 1), text=f"Failed {sid}")
-                        sims_counter.metric(
-                            "E+ sims complete",
-                            f"{done_before} / {n_jobs}",
-                            delta="failed",
-                        )
-                        health_box.error(f"E+ health: FAILED · {diagnosis}")
-                        status.update(
-                            label=(
-                                f"Live run FAILED ({sid} {kind}) after "
-                                f"{format_hms(time.perf_counter() - campaign_t0)} · {diagnosis}"
-                            ),
-                            state="error",
-                        )
-                        st.error(
-                            f"**EnergyPlus unhealthy** for `{sid}` / `{kind}`.\n\n"
-                            f"{diagnosis}\n\n"
-                            f"Log: `{log}`"
-                        )
-                        if tail:
-                            with st.expander("live.log tail", expanded=True):
-                                st.code(tail)
-                        return
-                    pq = _collect_traj(out_dir)
-                    if pq is None:
-                        diagnosis = summarize_eplus_failure(log, exit_code=code)
-                        health_box.error(
-                            f"E+ health: FAILED · finished without trajectory · {diagnosis}"
-                        )
-                        status.update(
-                            label=f"No trajectory after {sid} · {diagnosis}",
-                            state="error",
-                        )
-                        st.error(
-                            f"Live finished but no trajectory parquet under `{out_dir}`.\n\n{diagnosis}"
-                        )
-                        if tail:
-                            with st.expander("live.log tail", expanded=True):
-                                st.code(tail)
-                        return
-                    df_job = pd.read_parquet(pq)
-                    frames_by[key] = df_job
-                    parquets[key] = str(pq)
-                    card = out_dir / "rule_dr_scorecard.json"
-                    if card.is_file():
-                        try:
-                            doc = json.loads(card.read_text(encoding="utf-8"))
-                            rows = doc.get("strategies") or []
-                            if rows:
-                                last_meta = dict(rows[0])
-                        except (OSError, json.JSONDecodeError):
-                            pass
-                    st.write(
-                        f"{sid} · {kind}: {spec['n_days']} days · {spec['max_steps']} steps · "
-                        f"{format_hms(elapsed_s)} · `{pq}`"
-                    )
-                    sims_counter.metric("E+ sims complete", f"{i} / {n_jobs}")
-                    health_box.success(f"E+ health: OK · `{sid}` finished ({i}/{n_jobs})")
-                    progress.progress(
-                        i / max(n_jobs, 1),
-                        text=f"Finished {sid} ({i}/{n_jobs}) · total {format_hms(time.perf_counter() - campaign_t0)}",
-                    )
-                total_s = time.perf_counter() - campaign_t0
-                bits = " · ".join(f"{k} {format_hms(v)}" for k, v in elapsed_by.items())
-                status.update(
-                    label=f"Live EnergyPlus finished in {format_hms(total_s)} · {n_jobs}/{n_jobs} sims ({bits})",
-                    state="complete",
-                )
-                sims_counter.metric("E+ sims complete", f"{n_jobs} / {n_jobs}", delta="done")
-                health_box.success(f"E+ health: OK · all {n_jobs} sims complete · {format_hms(total_s)}")
-                progress.progress(1.0, text=f"Complete · {n_jobs} sims · {format_hms(total_s)}")
-            # fall through to KPI store (keep existing block below)
-            base_peak = None
-            for sid in DEPLOYABLE_STRATEGIES:
-                key_amy = f"{sid}:{KIND_AMY}"
-                key_tmy = f"{sid}:{KIND_TMY_MSN}"
-                df_sid = pick_frame(frames_by, key_amy, key_tmy)
-                if df_sid is None:
-                    continue
-                meta = {
-                    "honesty": last_meta.get("honesty") or "W2A_PHYSICAL_DSM",
-                    "provenance": last_meta.get("provenance") or "ENERGYPLUS_PYTHON_API",
-                    "mode": "live",
-                    "family": "w2a",
-                    "promote": False,
-                    "day": day,
-                    "strategy_id": sid,
-                    "loop": "CLOSED_LOOP_RULE_DR",
-                    "period": spec["period"],
-                    "weekend_sp": "repeat_96_step_profile",
-                }
-                kpis_by[sid] = dsm_kpis(df_sid, meta, actual_peak_kw=actual_peak)
-                if sid == "baseline":
-                    base_peak = kpis_by[sid].get("peak_kw")
-            attach_baseline_deltas(kpis_by)
-            primary_key = f"baseline:{KIND_AMY}"
-            if primary_key not in frames_by:
-                primary_key = next(iter(frames_by))
-            _store_run(
-                site=bundle.site,
-                df=frames_by[primary_key],
-                actual=actual,
-                kpis=kpis_by.get("baseline") or next(iter(kpis_by.values())),
-                strategy="all",
-                day=day,
-                preset=preset,
-                mode="live",
-                epw_name=epw_names,
-                why=str(ctx["why"]),
-                window_days=list(spec["window_days"]),
-                parquet=parquets.get(primary_key),
-                elapsed_s=sum(elapsed_by.values()),
-                out_dir=str(last_out) if last_out else None,
-                weather_mode=wx_mode,
-                period=spec["period"],
-                max_steps=int(spec["max_steps"]),
-                n_days=int(spec["n_days"]),
-                parquets=parquets,
-                elapsed_by_weather=elapsed_by,
-                tmy_note=inv.get("tmy_missing_note"),
-                weather_kind=split_frame_key(primary_key)[1] or KIND_AMY,
-                frames=frames_by,
-                strategies=list(kpis_by.keys()),
-                kpis_by_strategy=kpis_by,
+            return
+
+        if idf is None or not Path(idf).is_file():
+            st.error("No champion IDF on the published pack.")
+            return
+        if not pairs:
+            st.error(
+                "No AMY or site TMY EPW. Agent must publish {site_slug}_amy_*.epw. "
+                "Chicago screening is not used."
             )
-            st.rerun()
+            return
+
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        run_id = f"{stamp}_dsm"
+        req_dir = Path(bundle.site) / "reports" / "eplus_gym" / "runs" / run_id
+        req_dir.mkdir(parents=True, exist_ok=True)
+        request = {
+            "run_id": run_id,
+            "idf": str(idf),
+            "expected_idf_sha256": idf_hash or None,
+            "begin": spec["begin"],
+            "end": spec["end"],
+            "n_days": int(spec["n_days"]),
+            "max_steps": int(spec["max_steps"]),
+            "strategies": strategies,
+            "weather_mode": wx_mode,
+            "preset": preset,
+            "peak_day": day,
+            "jobs": [
+                {
+                    "strategy_id": j["strategy_id"],
+                    "weather_kind": j["weather_kind"],
+                    "epw": str(j["epw"]),
+                    "begin": j["begin"],
+                    "end": j["end"],
+                    "max_steps": int(j["max_steps"]),
+                    "key": j["key"],
+                }
+                for j in jobs
+            ],
+            "require_energyplus": True,
+        }
+        req_path = req_dir / "campaign_request.json"
+        req_path.write_text(json.dumps(request, indent=2), encoding="utf-8")
+        try:
+            start_dsm_campaign_subprocess(site=Path(bundle.site), request_path=req_path)
+        except OSError as exc:
+            st.error(f"Failed to start campaign supervisor: {exc}")
+            return
+        st.success(f"Started campaign `{run_id}` ({len(jobs)} jobs). Status updates above.")
+        st.rerun()
 
     last = st.session_state.get("dsm_last")
     if not isinstance(last, dict) or last.get("frame") is None:
@@ -1265,7 +1149,7 @@ def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
         st.warning(
             f"Chart below is the **last Run** (`{last.get('preset')}` · `{last.get('period')}` · "
             f"`{last.get('weather_mode')}`). "
-            f"Click **Run all 5 strategies** for `{preset}` -> `{spec['period']}`."
+            f"Click **{run_label}** for `{preset}` -> `{spec['period']}`."
         )
     kpis_by = dict(last.get("kpis_by_strategy") or {})
     if not kpis_by and last.get("kpis"):
@@ -1307,95 +1191,58 @@ def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
         f"{len(ran)} strategies ({', '.join(ran)}) · "
         f"{last.get('n_days') or last.get('window_n') or '?'} days · "
         f"{last.get('max_steps') or '?'} steps{elapsed_bit}. "
-        f"Black = **Actual BAS meter**"
-        f"{f' (peak {actual_peak_show:.0f} kW)' if actual_peak_show is not None else ''}. "
-        f"Colored lines = E+ champion strategies (AMY / TMY labeled). "
-        f"loop=`CLOSED_LOOP_RULE_DR` · weekend_sp=`repeat_96_step_profile` · promote=False. "
-        f"Files: `{last.get('epw_name')}`."
+        "Charts below."
     )
-    score_rows = []
-    for sid in ran:
-        row = kpis_by.get(sid) or {}
-        if not isinstance(row, dict):
-            row = {}
-        score_rows.append(
-            {
-                "strategy_id": sid,
-                "peak_kw": row.get("peak_kw"),
-                "kw_trim": row.get("kw_trim"),
-                "kwh": row.get("kwh"),
-                "kwh_penalty": row.get("kwh_penalty"),
-                "vs_actual_pct": row.get("vs_actual_pct"),
-                "vs_baseline_pct": row.get("vs_baseline_pct"),
-            }
-        )
-    if score_rows:
-        st.dataframe(pd.DataFrame(score_rows), width="stretch", hide_index=True)
-        st.caption(
-            "Window totals for the selected period (peak day / week / month / winter / year). "
-            "**kW trim** = baseline peak − strategy peak (+ trimmed demand). "
-            "**kWh penalty** = strategy kWh − baseline kWh (+ used more energy)."
-        )
-    paths = list((last.get("parquets") or {}).values()) or (
-        [last["parquet"]] if last.get("parquet") else []
+    _render_dsm_results_charts(
+        last=last,
+        kpis_by=kpis_by,
+        actual=actual,
+        frames=frames,
+        eplus=eplus,
+        day=str(last.get("day") or day),
+        COLORS=COLORS,
+        dsm_panel_figure=dsm_panel_figure,
+        dsm_trajectory_figure=dsm_trajectory_figure,
+        period_daily_peak_figure=period_daily_peak_figure,
     )
-    if paths:
-        st.caption("On disk: " + " · ".join(f"`{p}`" for p in paths[:8]))
 
-    window_days = list(last.get("window_days") or [])
-    show_daily = (last.get("n_days") or len(window_days) or 0) > 1 or len(window_days) > 1
-    if show_daily:
-        try:
-            from eplus_gym_app.load_profiles import load_bas_demand_oat
 
-            bas_win = load_bas_demand_oat(bundle, csv_path=bundle.bas_demand_oat_csv)
-            span = set(window_days)
-            if last.get("period"):
-                b, _, e = str(last["period"]).partition("/")
-                if b and e:
-                    spanned = {
-                        d
-                        for d in bas_win["local_day"].astype(str)
-                        if b <= d <= e
-                    }
-                    if spanned:
-                        span = spanned
-            daily = (
-                bas_win.loc[bas_win["local_day"].astype(str).isin(span)]
-                .groupby("local_day", as_index=False)["kw_avg"]
-                .max()
-                .rename(columns={"kw_avg": "peak_kw"})
-                .sort_values("local_day")
+def _render_dsm_results_charts(**kwargs):
+    import streamlit as st
+
+    last = kwargs["last"]
+    kpis_by = kwargs["kpis_by"]
+    actual = kwargs["actual"]
+    frames = kwargs["frames"]
+    eplus = kwargs["eplus"]
+    day = kwargs["day"]
+    COLORS = kwargs["COLORS"]
+    dsm_panel_figure = kwargs["dsm_panel_figure"]
+    dsm_trajectory_figure = kwargs["dsm_trajectory_figure"]
+    period_daily_peak_figure = kwargs["period_daily_peak_figure"]
+
+    if kpis_by:
+        rows = []
+        for sid, row in kpis_by.items():
+            rows.append(
+                {
+                    "strategy": sid,
+                    "peak_kw": row.get("peak_kw"),
+                    "kwh": row.get("kwh"),
+                    "kw_trim": row.get("kw_trim"),
+                    "kwh_penalty": row.get("kwh_penalty"),
+                    "vs_baseline_pct": row.get("vs_baseline_pct"),
+                    "vs_actual_pct": row.get("vs_actual_pct"),
+                }
             )
-        except Exception:  # noqa: BLE001
-            daily = pd.DataFrame()
-        eplus_daily = {}
-        for key, frame in frames.items():
-            sid, kind = split_frame_key(key)
-            wx = _WX_LABEL.get(kind, kind) if kind and kind != "lookup" else ""
-            eplus_daily[f"{sid} {wx}".strip()] = daily_peaks_from_traj(frame)
-        if (not daily.empty) or any(not v.empty for v in eplus_daily.values()):
-            st.plotly_chart(
-                period_daily_peak_figure(
-                    daily,
-                    highlight_day=str(last.get("day") or ""),
-                    title=(
-                        f"Daily peaks · {last.get('preset')} · {last.get('period')} "
-                        f"· Actual + all strategies"
-                    ),
-                    eplus_daily=eplus_daily,
-                ),
-                width="stretch",
-                key=f"dsm_period_daily_{last.get('preset')}_{last.get('period')}",
-            )
+        st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
 
-    peak_slices = {
-        key: slice_traj_for_day(_eplus_with_oat_f(frame), str(last.get("day") or day))
-        for key, frame in frames.items()
-    }
+    peak_slices = {}
+    for key, df in frames.items():
+        peak_slices[key] = slice_traj_for_day(df, day)
     extra = []
     for key, sl in peak_slices.items():
-        if sl is None or sl.empty:
+        if sl is None or getattr(sl, "empty", True):
             continue
         sid, kind = split_frame_key(key)
         wx = _WX_LABEL.get(kind, kind) if kind and kind != "lookup" else ""
@@ -1443,9 +1290,20 @@ def render_run_dsm_tab(bundle: SiteUiBundle) -> None:
         dsm_trajectory_figure(
             primary_slice if primary_slice is not None else eplus,
             actual=actual,
-            title=f"Peak-day 15-min overlay · {last.get('day')} · Actual vs all 5 strategies",
+            title=f"Peak-day 15-min overlay · {last.get('day')}",
             extra_eplus=extra if extra else None,
         ),
         width="stretch",
         key=f"dsm_overlay_{last.get('day')}_all_{last.get('preset')}_{last.get('mode')}",
     )
+    daily = daily_peaks_from_traj(eplus)
+    if daily is not None and not daily.empty:
+        st.plotly_chart(
+            period_daily_peak_figure(
+                daily,
+                highlight_day=str(day)[:10],
+                title="Daily peak kW over run window",
+            ),
+            width="stretch",
+            key=f"dsm_daily_{last.get('period')}",
+        )

--- a/vibe_code_apps_22/eplus_gym_app/dsm_preflight.py
+++ b/vibe_code_apps_22/eplus_gym_app/dsm_preflight.py
@@ -1,0 +1,186 @@
+"""Preflight checks before any EnergyPlus Popen for DSM campaigns."""
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from eplus_gym.discover import energyplus_available
+from eplus_gym.month_calendar import DEPLOYABLE_STRATEGIES
+from eplus_gym_app.open_meteo_epw import parse_epw_span
+
+
+class PreflightError(ValueError):
+    """Structured DSM preflight failure (no simulation started)."""
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details = dict(details or {})
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": "PreflightError", "message": str(self), "details": self.details}
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with Path(path).open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def inclusive_days(begin: str, end: str) -> int:
+    b = date.fromisoformat(str(begin)[:10])
+    e = date.fromisoformat(str(end)[:10])
+    if e < b:
+        raise PreflightError(
+            f"Invalid period: end {e.isoformat()} is before begin {b.isoformat()}. "
+            "No simulation started.",
+            details={"begin": str(begin), "end": str(end)},
+        )
+    return (e - b).days + 1
+
+
+def format_coverage_error(
+    *,
+    begin: str,
+    end: str,
+    epw: Path,
+    span: dict[str, Any],
+) -> str:
+    cov_start = span.get("start")
+    cov_end = span.get("end")
+    cov_s = cov_start.isoformat() if hasattr(cov_start, "isoformat") else str(cov_start)
+    cov_e = cov_end.isoformat() if hasattr(cov_end, "isoformat") else str(cov_end)
+    return (
+        f"Requested RunPeriod {str(begin)[:10]} -> {str(end)[:10]} is outside published "
+        f"EPW coverage {cov_s} -> {cov_e} ({Path(epw).name}). "
+        f"Invalid end relative to weather file. No simulation started."
+    )
+
+
+def assert_period_within_epw(begin: str, end: str, epw: Path) -> dict[str, Any]:
+    epw = Path(epw)
+    if not epw.is_file():
+        raise PreflightError(
+            f"EPW not found: {epw}. No simulation started.",
+            details={"epw": str(epw)},
+        )
+    span = parse_epw_span(epw)
+    cov_start = span.get("start")
+    cov_end = span.get("end")
+    if cov_start is None or cov_end is None:
+        raise PreflightError(
+            f"Could not parse EPW coverage from {epw}. No simulation started.",
+            details={"epw": str(epw), "span": span},
+        )
+    b = date.fromisoformat(str(begin)[:10])
+    e = date.fromisoformat(str(end)[:10])
+    if b < cov_start or e > cov_end:
+        raise PreflightError(
+            format_coverage_error(begin=begin, end=end, epw=epw, span=span),
+            details={
+                "begin": b.isoformat(),
+                "end": e.isoformat(),
+                "epw": str(epw),
+                "coverage_start": cov_start.isoformat(),
+                "coverage_end": cov_end.isoformat(),
+            },
+        )
+    return {
+        "epw": str(epw),
+        "coverage_start": cov_start.isoformat(),
+        "coverage_end": cov_end.isoformat(),
+        "n_rows": span.get("n_rows"),
+    }
+
+
+def run_preflight(
+    *,
+    idf: Path,
+    epws: list[Path],
+    begin: str,
+    end: str,
+    max_steps: int,
+    strategies: list[str],
+    out_root: Path,
+    expected_idf_sha256: str | None = None,
+    require_energyplus: bool = True,
+) -> dict[str, Any]:
+    """Validate campaign inputs. Raises PreflightError; never starts EnergyPlus."""
+    idf = Path(idf)
+    out_root = Path(out_root)
+    details: dict[str, Any] = {}
+
+    if not idf.is_file():
+        raise PreflightError(
+            f"Champion IDF not found: {idf}. No simulation started.",
+            details={"idf": str(idf)},
+        )
+    idf_hash = sha256_file(idf)
+    details["idf"] = str(idf)
+    details["idf_sha256"] = idf_hash
+    if expected_idf_sha256 and expected_idf_sha256.lower() != idf_hash.lower():
+        raise PreflightError(
+            f"IDF SHA-256 mismatch for {idf.name}: "
+            f"runtime={idf_hash[:12]}… published={expected_idf_sha256[:12]}…. "
+            "No simulation started.",
+            details={
+                "idf": str(idf),
+                "idf_sha256": idf_hash,
+                "expected_idf_sha256": expected_idf_sha256,
+            },
+        )
+
+    n_days = inclusive_days(begin, end)
+    expected_steps = n_days * 96
+    details["begin"] = str(begin)[:10]
+    details["end"] = str(end)[:10]
+    details["n_days"] = n_days
+    details["max_steps"] = int(max_steps)
+    details["expected_max_steps"] = expected_steps
+    if int(max_steps) != expected_steps:
+        raise PreflightError(
+            f"max_steps={max_steps} does not match inclusive days×96 "
+            f"({n_days}*96={expected_steps}) for {begin}→{end}. No simulation started.",
+            details=details,
+        )
+
+    bad = [s for s in strategies if s not in DEPLOYABLE_STRATEGIES]
+    if bad:
+        raise PreflightError(
+            f"Unknown strategies {bad}; allowed={list(DEPLOYABLE_STRATEGIES)}. "
+            "No simulation started.",
+            details={"strategies": list(strategies), "bad": bad},
+        )
+    details["strategies"] = list(strategies)
+
+    if not epws:
+        raise PreflightError("No EPW paths provided. No simulation started.", details=details)
+
+    epw_meta: list[dict[str, Any]] = []
+    for epw in epws:
+        epw_meta.append(assert_period_within_epw(begin, end, Path(epw)))
+    details["epws"] = epw_meta
+
+    try:
+        out_root.mkdir(parents=True, exist_ok=True)
+        probe = out_root / ".dsm_preflight_write_probe"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+    except OSError as exc:
+        raise PreflightError(
+            f"Out dir not writable: {out_root} ({exc}). No simulation started.",
+            details={"out_root": str(out_root)},
+        ) from exc
+    details["out_root"] = str(out_root)
+
+    if require_energyplus and not energyplus_available():
+        raise PreflightError(
+            "EnergyPlus is not discoverable (set ENERGYPLUS_ROOT). No simulation started.",
+            details=details,
+        )
+    details["energyplus_available"] = energyplus_available()
+    return details

--- a/vibe_code_apps_22/eplus_gym_app/open_meteo_epw.py
+++ b/vibe_code_apps_22/eplus_gym_app/open_meteo_epw.py
@@ -431,5 +431,58 @@ def refresh_amy_epw(
     meta["request_start"] = win_start
     meta["request_end"] = win_end
     meta["site_slug"] = slug
-    (weather / "amy_meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    publish_current_amy(site, final, meta)
     return meta
+
+
+def publish_current_amy(site: Path, epw_path: Path, meta: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Atomically update amy_meta.json and rewrite site_ui_bundle_v1 epw pin."""
+    import hashlib
+    import os
+
+    site = Path(site)
+    epw_path = Path(epw_path)
+    weather = site / "eplus" / "weather"
+    weather.mkdir(parents=True, exist_ok=True)
+    span = parse_epw_span(epw_path)
+    doc = dict(meta or {})
+    doc["epw"] = str(epw_path)
+    doc["kind"] = KIND_AMY
+    doc["source"] = doc.get("source") or "open-meteo-archive"
+    if span.get("start") is not None:
+        doc["start"] = span["start"].isoformat() if hasattr(span["start"], "isoformat") else str(span["start"])
+    if span.get("end") is not None:
+        doc["end"] = span["end"].isoformat() if hasattr(span["end"], "isoformat") else str(span["end"])
+    doc["n_rows"] = span.get("n_rows")
+    h = hashlib.sha256()
+    with epw_path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    doc["sha256"] = h.hexdigest()
+
+    meta_path = weather / "amy_meta.json"
+    tmp_meta = weather / f".amy_meta.{os.getpid()}.tmp"
+    tmp_meta.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp_meta, meta_path)
+
+    bundle = site / "reports" / "site_ui_bundle_v1.json"
+    if bundle.is_file():
+        try:
+            bundle_doc = json.loads(bundle.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            bundle_doc = None
+        if isinstance(bundle_doc, dict):
+            rel = f"eplus/weather/{epw_path.name}"
+            try:
+                rel = str(epw_path.resolve().relative_to(site.resolve())).replace("\\", "/")
+            except ValueError:
+                pass
+            bundle_doc["epw"] = rel
+            bundle_doc["epw_sha256"] = doc["sha256"]
+            bundle_doc["epw_coverage_start"] = doc.get("start")
+            bundle_doc["epw_coverage_end"] = doc.get("end")
+            tmp_b = bundle.with_name(f".{bundle.name}.{os.getpid()}.tmp")
+            tmp_b.write_text(json.dumps(bundle_doc, indent=2) + "\n", encoding="utf-8")
+            os.replace(tmp_b, bundle)
+            doc["bundle_epw"] = rel
+    return doc

--- a/vibe_code_apps_22/eplus_gym_app/site_pack.py
+++ b/vibe_code_apps_22/eplus_gym_app/site_pack.py
@@ -172,16 +172,58 @@ def _looks_interval_csv(path: Path) -> bool:
     return has_ts and has_kw
 
 
-def _pick_champion_idf(idfs: list[Path]) -> Path | None:
-    if not idfs:
+A04_IDF_NAME = "lakeside_w2a_a04_dual_champion.idf"
+
+
+def _pick_champion_idf(idfs: list[Path], *, site: Path | None = None) -> Path | None:
+    """Prefer exact A04 dual champion; never 'first *champion*' or E20 when A04 exists."""
+    if not idfs and site is None:
         return None
-    for p in idfs:
-        if "champion" in p.name.lower():
-            return p
-    for p in idfs:
+    pool = list(idfs)
+
+    def _exact_a04(cands: list[Path]) -> Path | None:
+        for p in cands:
+            if p.name.lower() == A04_IDF_NAME.lower():
+                return p
+        return None
+
+    hit = _exact_a04(pool)
+    if hit is not None:
+        return hit
+
+    # Site-local search only (never invent A04 from the repo into a generic pack).
+    if site is not None:
+        for root in (Path(site), Path(site) / "eplus" / "models"):
+            if not root.exists():
+                continue
+            direct = root / A04_IDF_NAME
+            if direct.is_file():
+                return direct
+            if root.is_dir():
+                for p in root.glob(A04_IDF_NAME):
+                    if p.is_file():
+                        return p
+
+    # Lakeside practice fallback: repo models/eplus A04 only when pack already looks Lakeside.
+    lakesideish = any("lakeside" in p.name.lower() or "a04" in p.name.lower() for p in pool)
+    if lakesideish:
+        app_root = Path(__file__).resolve().parents[1]
+        repo_models = app_root / "models" / "eplus"
+        if repo_models.is_dir():
+            direct = repo_models / A04_IDF_NAME
+            if direct.is_file():
+                return direct
+
+    for p in pool:
         if "a04" in p.name.lower():
             return p
-    return sorted(idfs, key=lambda p: p.name.lower())[0]
+    if pool:
+        # Prefer *champion* only among generic names (no E20 token race vs A04 — A04 already handled).
+        champs = [p for p in pool if "champion" in p.name.lower()]
+        if champs:
+            return sorted(champs, key=lambda p: p.name.lower())[0]
+        return sorted(pool, key=lambda p: p.name.lower())[0]
+    return None
 
 
 def _pick_interval(cands: list[Path]) -> Path | None:
@@ -272,7 +314,7 @@ def inventory_site_pack(root: Path) -> SitePackInventory:
     inv.campus_json = campus if campus and _try_campus(campus) else None
 
     inv.idfs = sorted(_iter_matches(root, "*.idf"))
-    inv.champion_idf = _pick_champion_idf(inv.idfs)
+    inv.champion_idf = _pick_champion_idf(inv.idfs, site=root)
 
     inv.interval_csvs = [p for p in _iter_matches(root, "*.csv") if _looks_interval_csv(p)]
     inv.interval_csv = _pick_interval(inv.interval_csvs)
@@ -431,6 +473,22 @@ def publish_site_ui_bundle(
         if cat_pin:
             idf_pin = cat_pin
         break
+    # Hard-prefer catalog A04 when present and pin matches A04 file.
+    for raw in doc.get("model_catalog") or []:
+        if not isinstance(raw, dict):
+            continue
+        if str(raw.get("id") or "").upper() != "A04":
+            continue
+        cat_pin = str(raw.get("idf_pin") or A04_IDF_NAME)
+        if inv.champion_idf is not None and inv.champion_idf.name.lower() == A04_IDF_NAME.lower():
+            model_id = "A04"
+            idf_pin = inv.champion_idf.name
+            break
+        if cat_pin.lower() == A04_IDF_NAME.lower() and inv.champion_idf is not None:
+            if "a04" in inv.champion_idf.name.lower():
+                model_id = "A04"
+                idf_pin = inv.champion_idf.name
+                break
     if inv.champion_idf is not None and (
         not any(
             isinstance(r, dict)
@@ -458,6 +516,51 @@ def publish_site_ui_bundle(
         }
     if not idf_pin and inv.champion_idf is not None:
         idf_pin = inv.champion_idf.name
+
+    # Lakeside / A04 practice pack contract: never publish E20 as DSM champion when A04 exists.
+    has_a04_file = inv.champion_idf is not None and (
+        inv.champion_idf.name.lower() == A04_IDF_NAME.lower()
+        or "a04" in inv.champion_idf.name.lower()
+    )
+    has_e20_token = any("e20" in p.name.lower() for p in inv.idfs)
+    has_a04_anywhere = has_a04_file or any(
+        p.name.lower() == A04_IDF_NAME.lower() or "a04" in p.name.lower() for p in inv.idfs
+    )
+    if has_a04_anywhere:
+        if inv.champion_idf is None or not has_a04_file:
+            raise SitePackError(
+                f"A04 champion required ({A04_IDF_NAME}); refusing to publish non-A04 DSM champion"
+            )
+        model_id = "A04"
+        idf_pin = inv.champion_idf.name
+        # Ensure catalog row points at A04
+        catalog = list(doc.get("model_catalog") or [])
+        updated = False
+        for raw in catalog:
+            if isinstance(raw, dict) and str(raw.get("id") or "").upper() == "A04":
+                raw["champion"] = True
+                raw["idf_pin"] = idf_pin
+                updated = True
+            elif isinstance(raw, dict) and raw.get("champion"):
+                raw["champion"] = False
+        if not updated:
+            catalog = [
+                {
+                    "id": "A04",
+                    "label": "A04 dual champion",
+                    "family": "W2A_PHYSICAL_DSM",
+                    "idf_pin": idf_pin,
+                    "champion": True,
+                    "dial_id": "A04",
+                }
+            ]
+        doc["model_catalog"] = catalog
+    elif has_e20_token and not has_a04_anywhere and any(
+        "lakeside" in p.name.lower() for p in inv.idfs
+    ):
+        raise SitePackError(
+            f"Lakeside pack missing {A04_IDF_NAME}; refusing E20 fallback as DSM champion"
+        )
 
     campus_rel = _rel_to(site, dest_campus) if dest_campus.is_file() else f"utilities/{dest_campus.name}"
     if dest_interval is not None and dest_interval.is_file():
@@ -494,9 +597,39 @@ def publish_site_ui_bundle(
         doc["epw"] = epw_rel.replace("\\", "/")
     doc.update(overrides)
 
+    # Post-publish A04 contract when A04 pack
+    if has_a04_anywhere:
+        if doc.get("current_model_id") != "A04" or doc.get("dsm_champion") != "A04":
+            doc["current_model_id"] = "A04"
+            doc["dsm_champion"] = "A04"
+            doc["default_model_id"] = "A04"
+        if inv.champion_idf is not None:
+            doc["idf_pin"] = inv.champion_idf.name
+            try:
+                import hashlib
+
+                h = hashlib.sha256()
+                with inv.champion_idf.open("rb") as fh:
+                    for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                        h.update(chunk)
+                doc["idf_sha256"] = h.hexdigest()
+            except OSError:
+                pass
+        if doc.get("dsm_champion") != "A04" or doc.get("idf_pin") != (
+            inv.champion_idf.name if inv.champion_idf else doc.get("idf_pin")
+        ):
+            raise SitePackError(
+                "publish assert failed: dsm_champion/current_model_id must be A04 "
+                f"with idf_pin={A04_IDF_NAME}"
+            )
+
     out = site / "reports" / "site_ui_bundle_v1.json"
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    import os
+
+    tmp = out.with_name(f".{out.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp, out)
     return out
 
 

--- a/vibe_code_apps_22/eplus_gym_app/weather_files.py
+++ b/vibe_code_apps_22/eplus_gym_app/weather_files.py
@@ -93,12 +93,35 @@ def resolve_tmy_msn_epw(site: Path) -> Path | None:
 def weather_inventory(site: Path, *, published: Path | None = None) -> dict[str, Any]:
     amy = resolve_amy_epw(site, published=published)
     tmy = resolve_tmy_msn_epw(site)
+    stale_bundle = False
+    stale_note = None
+    meta_path = _weather_dir(site) / "amy_meta.json"
+    if meta_path.is_file():
+        try:
+            import json
+
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            meta_epw = meta.get("epw")
+            if meta_epw and published is not None and Path(published).is_file():
+                try:
+                    stale_bundle = Path(meta_epw).resolve() != Path(published).resolve()
+                except OSError:
+                    stale_bundle = Path(meta_epw).name != Path(published).name
+                if stale_bundle:
+                    stale_note = (
+                        f"Published bundle EPW ({Path(published).name}) differs from "
+                        f"amy_meta current ({Path(meta_epw).name}). Republish AMY / site pack."
+                    )
+        except (OSError, json.JSONDecodeError, TypeError):
+            pass
     return {
         "amy": amy,
         "tmy": tmy,
         "amy_kind": classify_epw(amy) if amy else None,
         "tmy_kind": classify_epw(tmy) if tmy else None,
-        "default_mode": "Both" if (amy and tmy) else "AMY",
+        "default_mode": "AMY",
+        "stale_bundle_epw": stale_bundle,
+        "stale_bundle_note": stale_note,
         "tmy_missing_note": (
             None
             if tmy

--- a/vibe_code_apps_22/scripts/run_dsm_campaign.py
+++ b/vibe_code_apps_22/scripts/run_dsm_campaign.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Supervisor CLI for Streamlit DSM campaigns (only writer of campaign state)."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_APP = Path(__file__).resolve().parents[1]
+if str(_APP) not in sys.path:
+    sys.path.insert(0, str(_APP))
+
+from eplus_gym_app.dsm_campaign import (  # noqa: E402
+    DEFAULT_JOB_TIMEOUT_S,
+    active_campaign_running,
+    cancel_requested,
+    clear_cancel_request,
+    collect_traj,
+    mark_cancelled,
+    mark_failed,
+    mark_succeeded,
+    new_campaign_doc,
+    read_json,
+    validate_job_outputs,
+    write_campaign,
+)
+from eplus_gym_app.dsm_console import (  # noqa: E402
+    attach_baseline_deltas,
+    dsm_kpis,
+    last_run_pointer,
+    persist_last_run,
+    pick_frame,
+)
+from eplus_gym_app.dsm_preflight import PreflightError, run_preflight, sha256_file  # noqa: E402
+from eplus_gym_app.weather_files import KIND_AMY  # noqa: E402
+
+_CLI_RULES = _APP / "scripts" / "run_eplus_gym_rules.py"
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _git_sha() -> str | None:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(_APP),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return out.strip() or None
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _load_request(path: Path) -> dict[str, Any]:
+    doc = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(doc, dict):
+        raise SystemExit("campaign request must be a JSON object")
+    return doc
+
+
+def _launch_job(
+    *,
+    site: Path,
+    strategy_id: str,
+    epw: Path,
+    idf: Path,
+    out_dir: Path,
+    begin: str,
+    end: str,
+    max_steps: int,
+) -> tuple[subprocess.Popen, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    log = out_dir / "live.log"
+    cmd = [
+        sys.executable,
+        "-u",
+        str(_CLI_RULES),
+        "--mode",
+        "live",
+        "--family",
+        "w2a",
+        "--strategies",
+        strategy_id,
+        "--epw",
+        str(epw),
+        "--idf",
+        str(idf),
+        "--out",
+        str(out_dir),
+        "--max-steps",
+        str(int(max_steps)),
+        "--day",
+        begin,
+        "--begin",
+        begin,
+        "--end",
+        end,
+    ]
+    handle = log.open("w", encoding="utf-8")
+    env = os.environ.copy()
+    env["SITE_ROOT"] = str(site)
+    env["LAKESIDE_SITE_ROOT"] = str(site)
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(_APP),
+        stdout=handle,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+    )
+    # Keep handle open for child's lifetime; close when wait ends.
+    proc._dsm_log_handle = handle  # type: ignore[attr-defined]
+    return proc, log
+
+
+def _close_log(proc: subprocess.Popen) -> None:
+    handle = getattr(proc, "_dsm_log_handle", None)
+    if handle is not None:
+        try:
+            handle.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _wait_job(
+    site: Path,
+    doc: dict[str, Any],
+    proc: subprocess.Popen,
+    *,
+    timeout_s: float,
+) -> int:
+    t0 = time.time()
+    while proc.poll() is None:
+        if cancel_requested(site):
+            try:
+                proc.terminate()
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            _close_log(proc)
+            mark_cancelled(site, doc)
+            raise SystemExit(130)
+        if time.time() - t0 > timeout_s:
+            try:
+                proc.terminate()
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            _close_log(proc)
+            raise TimeoutError(f"job exceeded timeout {timeout_s:.0f}s")
+        doc["heartbeat_at"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+            "+00:00", "Z"
+        )
+        doc["child_pid"] = proc.pid
+        write_campaign(site, doc)
+        time.sleep(1.0)
+    _close_log(proc)
+    return int(proc.returncode if proc.returncode is not None else 0)
+
+
+def _persist_success(
+    site: Path,
+    doc: dict[str, Any],
+    *,
+    results: list[dict[str, Any]],
+) -> None:
+    """Write last_dsm_run.json only after all jobs validated."""
+    frames_meta: dict[str, str] = {}
+    kpis_by: dict[str, Any] = {}
+    elapsed_by: dict[str, float] = {}
+    for row in results:
+        key = row["key"]
+        frames_meta[key] = row["parquet"]
+        elapsed_by[key] = float(row.get("elapsed_s") or 0.0)
+        df = __import__("pandas").read_parquet(row["parquet"])
+        meta = {
+            "honesty": "W2A_PHYSICAL_DSM",
+            "provenance": "ENERGYPLUS_PYTHON_API",
+            "mode": "live",
+            "family": "w2a",
+            "promote": False,
+            "day": doc.get("peak_day"),
+            "strategy_id": row["strategy_id"],
+            "loop": "CLOSED_LOOP_RULE_DR",
+            "period": f"{doc['begin']}/{doc['end']}",
+            "weekend_sp": "repeat_96_step_profile",
+        }
+        # Aggregate per strategy (prefer AMY when both)
+        sid = row["strategy_id"]
+        if sid not in kpis_by or row["weather_kind"] == KIND_AMY:
+            kpis_by[sid] = dsm_kpis(df, meta)
+
+    attach_baseline_deltas(kpis_by)
+    primary_key = next(
+        (k for k in frames_meta if k.startswith("baseline:")),
+        next(iter(frames_meta)),
+    )
+    import pandas as pd
+
+    primary_df = pd.read_parquet(frames_meta[primary_key])
+    persist_last_run(
+        site,
+        df=primary_df,
+        actual=pd.DataFrame(),
+        kpis=kpis_by.get("baseline") or next(iter(kpis_by.values())),
+        strategy="all",
+        day=str(doc.get("peak_day") or doc["begin"]),
+        preset=str(doc.get("preset") or "Peak day"),
+        mode="live",
+        epw_name=",".join(str(e.get("epw") or "") for e in (doc.get("epws") or [])),
+        why="dsm_campaign supervisor",
+        window_days=[str(doc["begin"]), str(doc["end"])],
+        parquet=frames_meta[primary_key],
+        elapsed_s=sum(elapsed_by.values()),
+        out_dir=str(eplus_runs_root(site, doc["run_id"])),
+        weather_mode=str(doc.get("weather_mode") or "AMY"),
+        period=f"{doc['begin']}/{doc['end']}",
+        max_steps=int(doc["max_steps"]),
+        n_days=int(doc["n_days"]),
+        parquets=frames_meta,
+        elapsed_by_weather=elapsed_by,
+        weather_kind=primary_key.split(":", 1)[-1] if ":" in primary_key else KIND_AMY,
+        strategies=list(kpis_by.keys()),
+        kpis_by_strategy=kpis_by,
+    )
+    # Enrich last_dsm_run with hashes for calendar-year gate
+    ptr = last_run_pointer(site)
+    disk = read_json(ptr) or {}
+    disk["idf_sha256"] = doc.get("idf_sha256")
+    disk["epws"] = doc.get("epws")
+    disk["state"] = "succeeded"
+    disk["run_id"] = doc.get("run_id")
+    from eplus_gym_app.dsm_campaign import atomic_write_json
+
+    atomic_write_json(ptr, disk)
+
+
+def eplus_runs_root(site: Path, run_id: str) -> Path:
+    return Path(site) / "reports" / "eplus_gym" / "runs" / run_id
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Run a durable DSM EnergyPlus campaign")
+    ap.add_argument("--site", required=True, type=Path)
+    ap.add_argument("--request", required=True, type=Path, help="JSON campaign request")
+    ap.add_argument("--job-timeout-s", type=float, default=DEFAULT_JOB_TIMEOUT_S)
+    args = ap.parse_args(argv)
+
+    site = Path(args.site)
+    req = _load_request(Path(args.request))
+
+    existing = active_campaign_running(site)
+    if existing is not None:
+        print(
+            f"refuse: campaign {existing.get('run_id')} still active "
+            f"(state={existing.get('state')})",
+            file=sys.stderr,
+        )
+        return 2
+
+    clear_cancel_request(site)
+    run_id = str(req.get("run_id") or f"{_utc_stamp()}_dsm")
+    idf = Path(req["idf"])
+    begin = str(req["begin"])[:10]
+    end = str(req["end"])[:10]
+    max_steps = int(req["max_steps"])
+    strategies = list(req["strategies"])
+    weather_mode = str(req.get("weather_mode") or "AMY")
+    jobs_raw = list(req["jobs"])
+    epw_paths = [Path(j["epw"]) for j in jobs_raw]
+    # unique preserve order
+    seen: set[str] = set()
+    epws: list[Path] = []
+    for p in epw_paths:
+        key = str(p.resolve()) if p.exists() else str(p)
+        if key in seen:
+            continue
+        seen.add(key)
+        epws.append(Path(p))
+
+    out_root = eplus_runs_root(site, run_id)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    epw_meta: list[dict[str, Any]] = []
+    for p in epws:
+        meta = {"epw": str(p), "sha256": sha256_file(p) if p.is_file() else None}
+        epw_meta.append(meta)
+
+    doc = new_campaign_doc(
+        run_id=run_id,
+        site=site,
+        idf=idf,
+        idf_sha256=sha256_file(idf) if idf.is_file() else "",
+        begin=begin,
+        end=end,
+        max_steps=max_steps,
+        n_days=int(req.get("n_days") or 0),
+        strategies=strategies,
+        weather_mode=weather_mode,
+        jobs=jobs_raw,
+        epw_meta=epw_meta,
+        preset=str(req.get("preset") or "Peak day"),
+        peak_day=str(req.get("peak_day") or begin),
+        git_sha=_git_sha(),
+        supervisor_pid=os.getpid(),
+    )
+    doc["log"] = str(out_root / "campaign.log")
+    doc["state"] = "preflight"
+    write_campaign(site, doc)
+
+    try:
+        pf = run_preflight(
+            idf=idf,
+            epws=epws,
+            begin=begin,
+            end=end,
+            max_steps=max_steps,
+            strategies=strategies,
+            out_root=out_root,
+            expected_idf_sha256=req.get("expected_idf_sha256"),
+            require_energyplus=bool(req.get("require_energyplus", True)),
+        )
+        # merge coverage into epw_meta
+        by_path = {str(Path(e["epw"]).resolve()): e for e in pf.get("epws") or []}
+        for row in doc["epws"]:
+            try:
+                key = str(Path(row["epw"]).resolve())
+            except OSError:
+                key = str(row["epw"])
+            cov = by_path.get(key) or {}
+            row.update({k: v for k, v in cov.items() if k != "epw"})
+        doc["n_days"] = pf.get("n_days") or doc["n_days"]
+        doc["idf_sha256"] = pf.get("idf_sha256") or doc["idf_sha256"]
+    except PreflightError as exc:
+        mark_failed(site, doc, exc.to_dict())
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if cancel_requested(site):
+        mark_cancelled(site, doc)
+        return 130
+
+    doc["state"] = "queued"
+    write_campaign(site, doc)
+    doc["state"] = "starting"
+    write_campaign(site, doc)
+    doc["state"] = "running"
+    write_campaign(site, doc)
+
+    results: list[dict[str, Any]] = []
+    for idx, job in enumerate(doc["jobs"]):
+        if cancel_requested(site):
+            mark_cancelled(site, doc)
+            return 130
+        sid = job["strategy_id"]
+        kind = job["weather_kind"]
+        key = job["key"]
+        job_out = out_root / f"{sid}_{kind}"
+        job["state"] = "running"
+        job["out_dir"] = str(job_out)
+        write_campaign(site, doc)
+        t0 = time.time()
+        try:
+            proc, log = _launch_job(
+                site=site,
+                strategy_id=sid,
+                epw=Path(job["epw"]),
+                idf=idf,
+                out_dir=job_out,
+                begin=begin,
+                end=end,
+                max_steps=max_steps,
+            )
+            doc["child_pid"] = proc.pid
+            write_campaign(site, doc)
+            code = _wait_job(site, doc, proc, timeout_s=float(args.job_timeout_s))
+            elapsed = time.time() - t0
+            job["elapsed_s"] = elapsed
+            job["exit_code"] = code
+            job["log"] = str(log)
+            if code != 0:
+                raise RuntimeError(f"CLI exit {code}; see {log}")
+            gates = validate_job_outputs(
+                job_out, max_steps=max_steps, begin=begin, end=end
+            )
+            job["state"] = "succeeded"
+            job["gates"] = gates
+            doc["completed_jobs"] = int(doc.get("completed_jobs") or 0) + 1
+            doc["child_pid"] = None
+            write_campaign(site, doc)
+            results.append(
+                {
+                    "key": key,
+                    "strategy_id": sid,
+                    "weather_kind": kind,
+                    "parquet": gates["parquet"],
+                    "elapsed_s": elapsed,
+                }
+            )
+        except SystemExit:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            job["state"] = "failed"
+            doc["child_pid"] = None
+            mark_failed(
+                site,
+                doc,
+                {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                    "job_key": key,
+                    "completed_jobs": int(doc.get("completed_jobs") or 0),
+                },
+            )
+            print(f"job failed {key}: {exc}", file=sys.stderr)
+            return 1
+
+    mark_succeeded(site, doc)
+    try:
+        _persist_success(site, doc, results=results)
+    except Exception as exc:  # noqa: BLE001
+        print(f"warning: persist last_dsm_run failed: {exc}", file=sys.stderr)
+    print(f"campaign {run_id} succeeded ({doc['completed_jobs']}/{doc['total_jobs']})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vibe_code_apps_22/skills/eplus-gym/SKILL.md
+++ b/vibe_code_apps_22/skills/eplus-gym/SKILL.md
@@ -39,6 +39,14 @@ streamlit run eplus_gym_app\streamlit_app.py --server.port 8765
 Tabs: **Run DSM** · **Calibration** · **Fuel** · **ECMs**.  
 No IDF / campus / interval pickers. Pack comes from `ingest_site_pack.py`.
 
+## DSM campaign supervisor
+
+Live Run DSM starts `scripts/run_dsm_campaign.py` once (Popen). Streamlit only
+polls `{SITE_ROOT}/reports/eplus_gym/current_dsm_run.json` via `@st.fragment`.
+Preflight (EPW span ⊆ coverage, IDF hash, max_steps) runs **before** any EnergyPlus
+child. Defaults: Peak day · AMY · baseline + one strategy. Cancel writes
+`cancel_dsm_run.request`. `last_dsm_run.json` updates only after all jobs validate.
+
 **Weather:** AMY = Open-Meteo actual year (M&V). Refresh with
 `python -u scripts\eplus_fetch_open_meteo_epw.py`. Never auto-pick Chicago
 screening as TMY. See `open-meteo-epw`.

--- a/vibe_code_apps_22/tests/test_dsm_campaign.py
+++ b/vibe_code_apps_22/tests/test_dsm_campaign.py
@@ -1,0 +1,247 @@
+"""DSM campaign / preflight / startup error regressions."""
+from __future__ import annotations
+
+import json
+import time
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from eplus_gym.errors import EnergyPlusStartupError
+from eplus_gym.startup_diag import diagnose_startup_failure
+from eplus_gym_app.dsm_campaign import (
+    build_jobs,
+    default_strategy_selection,
+    elapsed_seconds,
+    mark_failed,
+    new_campaign_doc,
+    read_json,
+    reconcile_campaign,
+    validate_job_outputs,
+    write_campaign,
+)
+from eplus_gym_app.dsm_preflight import PreflightError, run_preflight
+from eplus_gym_app.open_meteo_epw import parse_epw_span, publish_current_amy, write_epw, to_local_standard
+from eplus_gym_app.weather_files import KIND_AMY, weather_inventory
+
+
+def _tiny_epw(path: Path, *, start: date, days: int) -> Path:
+    rows = []
+    for d in range(days):
+        day = date.fromordinal(start.toordinal() + d)
+        for h in range(24):
+            rows.append(
+                f"{day.year},{day.month},{day.day},{h + 1},0,"
+                "20.0,10.0,50,101325,0,0,0,0,0,0,0,0,0,0,3,270,0,0,0,0,0,0,0,0,0,0,0,0,0"
+            )
+    # Minimal EPW header + data (parse_epw_span skips alpha lines)
+    path.write_text(
+        "LOCATION,Test,WI,USA,TMY3,726410,43.17,-89.25,-6.0,261.0\n"
+        + "\n".join(rows)
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_no_js_hud_in_dsm_console():
+    src = Path(__file__).resolve().parents[1] / "eplus_gym_app" / "dsm_console.py"
+    text = src.read_text(encoding="utf-8")
+    assert "setInterval" not in text
+    assert "__dsmBumpSim" not in text
+    assert "st.html" not in text
+    assert "unsafe_allow_javascript" not in text
+
+
+def test_default_job_list_baseline_plus_one():
+    assert default_strategy_selection("deep_setback") == ["baseline", "deep_setback"]
+    jobs = build_jobs(
+        strategies=default_strategy_selection("deep_setback"),
+        weather_mode="AMY",
+        amy=Path("amy.epw"),
+        tmy=Path("tmy.epw"),
+        begin="2026-07-01",
+        end="2026-07-01",
+        max_steps=96,
+    )
+    assert len(jobs) == 2
+    assert {j["strategy_id"] for j in jobs} == {"baseline", "deep_setback"}
+
+
+def test_preflight_rejects_end_outside_epw(tmp_path: Path, monkeypatch):
+    start = date(2025, 8, 1)
+    end = date(2026, 7, 2)
+    days = (end - start).days + 1
+    epw = _tiny_epw(tmp_path / "amy.epw", start=start, days=days)
+    span = parse_epw_span(epw)
+    assert span["end"] == end
+    idf = tmp_path / "champ.idf"
+    idf.write_text("Version,24.2;\n", encoding="utf-8")
+    monkeypatch.setattr("eplus_gym_app.dsm_preflight.energyplus_available", lambda: True)
+    with pytest.raises(PreflightError) as ei:
+        run_preflight(
+            idf=idf,
+            epws=[epw],
+            begin="2026-01-01",
+            end="2026-07-03",
+            max_steps=((date(2026, 7, 3) - date(2026, 1, 1)).days + 1) * 96,
+            strategies=["baseline"],
+            out_root=tmp_path / "out",
+            require_energyplus=True,
+        )
+    assert "No simulation started" in str(ei.value)
+    assert "2026-07-03" in str(ei.value)
+
+
+def test_elapsed_freezes_on_terminal():
+    doc = {
+        "started_at": "2026-08-12T20:00:00Z",
+        "finished_at": "2026-08-12T20:00:10Z",
+        "state": "failed",
+    }
+    assert elapsed_seconds(doc, now=1e12) == pytest.approx(10.0)
+
+
+def test_stale_running_reconcile(tmp_path: Path):
+    from eplus_gym_app.dsm_campaign import atomic_write_json, current_run_path
+
+    doc = new_campaign_doc(
+        run_id="r1",
+        site=tmp_path,
+        idf=tmp_path / "a.idf",
+        idf_sha256="abc",
+        begin="2026-01-01",
+        end="2026-01-01",
+        max_steps=96,
+        n_days=1,
+        strategies=["baseline"],
+        weather_mode="AMY",
+        jobs=[
+            {
+                "strategy_id": "baseline",
+                "weather_kind": KIND_AMY,
+                "epw": str(tmp_path / "a.epw"),
+                "begin": "2026-01-01",
+                "end": "2026-01-01",
+                "max_steps": 96,
+                "key": "baseline:AMY_OPEN_METEO",
+            }
+        ],
+        epw_meta=[],
+        preset="Peak day",
+        peak_day="2026-01-01",
+        supervisor_pid=0,
+    )
+    doc["state"] = "running"
+    doc["heartbeat_at"] = "2020-01-01T00:00:00Z"
+    doc["supervisor_pid"] = 0
+    doc["child_pid"] = None
+    # Bypass write_campaign so heartbeat is not refreshed.
+    atomic_write_json(current_run_path(tmp_path), doc)
+    out = reconcile_campaign(tmp_path)
+    assert out["state"] == "failed"
+
+
+def test_failure_leaves_last_dsm_run_unchanged(tmp_path: Path):
+    last = tmp_path / "reports" / "eplus_gym" / "last_dsm_run.json"
+    last.parent.mkdir(parents=True)
+    last.write_text(json.dumps({"ok": True, "preset": "Peak day"}), encoding="utf-8")
+    doc = {
+        "run_id": "x",
+        "state": "running",
+        "completed_jobs": 0,
+        "total_jobs": 1,
+        "jobs": [],
+    }
+    mark_failed(tmp_path, doc, "boom")
+    assert json.loads(last.read_text(encoding="utf-8"))["ok"] is True
+
+
+def test_validate_job_rejects_design_day(tmp_path: Path):
+    out = tmp_path / "job"
+    out.mkdir()
+    df = pd.DataFrame(
+        {
+            "facility_kw": [1.0] * 96,
+            "day": ["1900-01-01"] * 96,
+        }
+    )
+    pq = out / "traj_baseline.parquet"
+    df.to_parquet(pq, index=False)
+    with pytest.raises(ValueError, match="design-day"):
+        validate_job_outputs(out, max_steps=96, begin="2026-01-26", end="2026-01-26")
+
+
+def test_validate_job_increments_only_when_valid(tmp_path: Path):
+    out = tmp_path / "job"
+    out.mkdir()
+    df = pd.DataFrame(
+        {
+            "facility_kw": [10.0] * 96,
+            "day": ["2026-01-26"] * 96,
+        }
+    )
+    df.to_parquet(out / "traj_x.parquet", index=False)
+    gates = validate_job_outputs(out, max_steps=96, begin="2026-01-26", end="2026-01-26")
+    assert gates["n_rows"] == 96
+    assert gates["peak_kw"] == pytest.approx(10.0)
+
+
+def test_energyplus_startup_error_preserves_fatal(tmp_path: Path):
+    err = tmp_path / "episode-00000001-12345" / "eplusout.err"
+    err.parent.mkdir(parents=True)
+    err.write_text(
+        "** Severe  ** Weather file does not include requested RunPeriod\n"
+        "**  Fatal  ** EnergyPlus Terminated\n",
+        encoding="utf-8",
+    )
+
+    class R:
+        handle_error = "obs queue empty"
+        sim_results = {"exit_code": 1}
+        runner_config = type("C", (), {"output": str(tmp_path)})()
+
+    diag = diagnose_startup_failure(R())
+    assert diag["err_path"]
+    assert "Fatal" in (diag["severe_or_fatal"] or "") or "Severe" in (
+        diag["severe_or_fatal"] or ""
+    )
+    exc = EnergyPlusStartupError(
+        diag["message"],
+        exit_code=1,
+        err_path=diag["err_path"],
+        severe_or_fatal=diag["severe_or_fatal"],
+        log_tail=diag["log_tail"],
+    )
+    assert "Fatal" in str(exc) or "Severe" in str(exc) or exc.severe_or_fatal
+
+
+def test_publish_current_amy_updates_bundle(tmp_path: Path):
+    weather = tmp_path / "eplus" / "weather"
+    weather.mkdir(parents=True)
+    epw = _tiny_epw(weather / "madison_amy_202508_202608.epw", start=date(2025, 8, 1), days=10)
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / "site_ui_bundle_v1.json").write_text(
+        json.dumps({"schema_version": "site_ui_bundle_v1", "epw": "eplus/weather/old.epw"}),
+        encoding="utf-8",
+    )
+    meta = publish_current_amy(tmp_path, epw, {"kind": KIND_AMY})
+    assert Path(meta["epw"]).name.startswith("madison_amy_")
+    bundle = json.loads((reports / "site_ui_bundle_v1.json").read_text(encoding="utf-8"))
+    assert bundle["epw"].endswith(epw.name)
+    assert (weather / "amy_meta.json").is_file()
+    inv = weather_inventory(tmp_path, published=tmp_path / bundle["epw"])
+    assert inv.get("stale_bundle_epw") is False
+
+
+def test_stale_bundle_detection(tmp_path: Path):
+    weather = tmp_path / "eplus" / "weather"
+    weather.mkdir(parents=True)
+    new = _tiny_epw(weather / "madison_amy_202508_202608.epw", start=date(2025, 8, 1), days=3)
+    old = _tiny_epw(weather / "madison_amy_202508_202607.epw", start=date(2025, 8, 1), days=2)
+    (weather / "amy_meta.json").write_text(json.dumps({"epw": str(new)}), encoding="utf-8")
+    inv = weather_inventory(tmp_path, published=old)
+    assert inv["stale_bundle_epw"] is True

--- a/vibe_code_apps_22/tests/test_dsm_console.py
+++ b/vibe_code_apps_22/tests/test_dsm_console.py
@@ -259,7 +259,7 @@ def test_weather_resolver_amy_found_chicago_not_auto_tmy(tmp_path: Path):
     assert classify_epw(real) == KIND_TMY_MSN
     assert resolve_tmy_msn_epw(tmp_path) == real
     inv2 = weather_inventory(tmp_path)
-    assert inv2["default_mode"] == "Both"
+    assert inv2["default_mode"] == "AMY"
     assert epws_for_mode("Both", inv2) == [(KIND_AMY, amy), (KIND_TMY_MSN, real)]
 
 

--- a/vibe_code_apps_22/tests/test_eplus_gym_app_data.py
+++ b/vibe_code_apps_22/tests/test_eplus_gym_app_data.py
@@ -226,7 +226,8 @@ def test_streamlit_apptest_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert "IDF source" not in labels
     assert "campus.json" not in labels.lower()
     assert "Demand / interval CSV" not in labels
-    assert "Strategy" not in labels
+    # Humans pick one rule strategy (+ baseline); never IDF/campus/interval.
+    assert "Strategy (+ baseline)" in labels
     assert len(at.dataframe) >= 1
     def _copy() -> str:
         blobs = []

--- a/vibe_code_apps_22/tests/test_eplus_gym_app_data.py
+++ b/vibe_code_apps_22/tests/test_eplus_gym_app_data.py
@@ -258,19 +258,16 @@ def test_streamlit_apptest_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert not at.exception
     assert not list(at.error)
     radios = [str(getattr(w, "label", "")) for w in at.radio]
-    assert any("Weather" in lab for lab in radios)
+    # Weather radio lives under Advanced expander (default AMY).
     sliders = list(at.select_slider)
     assert sliders, "expected Period select_slider"
     copy = _copy()
     assert "typical-year EPW on that date" not in copy
-    assert "Open-Meteo actual year" in copy
     assert "CLOSED_LOOP_RULE_DR" in copy
-    assert "AMY is **not** a typical-year EPW" in copy
-    assert "Will simulate closed-loop all 5 strategies" in copy
-    assert "2025-12-15" in copy
-    assert "2026-02-10" in copy
-    assert "5568 steps" in copy
-    for sid in ("baseline", "flat_24_7", "deep_setback", "stagger_preheat", "morning_all_on"):
+    assert "baseline + one strategy" in copy or "Will run" in copy
+    # Winter window still resolved in period_run_spec / caption.
+    assert "2025-12" in copy or "Winter" in copy
+    for sid in ("baseline", "deep_setback"):
         assert sid in copy
     at.session_state["lakeside_main_tabs"] = "Calibration"
     at.run(timeout=90)

--- a/vibe_code_apps_22/tests/test_site_pack.py
+++ b/vibe_code_apps_22/tests/test_site_pack.py
@@ -159,6 +159,21 @@ def test_inventory_skips_campaign_idfs(tmp_path: Path):
     assert "campaigns" not in str(inv.champion_idf)
 
 
+def test_a04_wins_over_e20_champion_name(tmp_path: Path):
+    pack = _min_pack(tmp_path / "pack", a04=True)
+    models = pack / "eplus" / "models"
+    _write_tiny_idf(models / "lakeside_w2a_e20_dual_champion.idf")
+    inv = inventory_site_pack(pack)
+    assert inv.champion_idf is not None
+    assert inv.champion_idf.name == "lakeside_w2a_a04_dual_champion.idf"
+    dest = tmp_path / "site"
+    ingest_site_pack(pack, dest)
+    doc = json.loads((dest / "reports" / "site_ui_bundle_v1.json").read_text(encoding="utf-8"))
+    assert doc["dsm_champion"] == "A04"
+    assert doc["idf_pin"] == "lakeside_w2a_a04_dual_champion.idf"
+    assert "idf_sha256" in doc
+
+
 def test_zip_slip_rejected(tmp_path: Path):
     zpath = tmp_path / "evil.zip"
     with zipfile.ZipFile(zpath, "w") as zf:

--- a/vibe_code_apps_22/vibe22_agent_spec/EPLUS_GYM.md
+++ b/vibe_code_apps_22/vibe22_agent_spec/EPLUS_GYM.md
@@ -50,8 +50,10 @@ python -u scripts\run_eplus_gym_rules.py --mode lookup --month 2026-01
 # Grow IdealLoads farm for full months (dry-run first; --execute needs EnergyPlus)
 python -u scripts\run_eplus_gym_month_farm.py --months 2026-01,2026-02 --dry-run
 
-# Streamlit DSM console (lookup in-process; live via CLI subprocess)
+# Streamlit DSM console (lookup in-process; live via durable campaign supervisor)
 streamlit run eplus_gym_app\streamlit_app.py --server.port 8765
+# Live DSM campaign (preflight → sequential run_eplus_gym_rules children)
+# python -u scripts\run_dsm_campaign.py --site %SITE_ROOT% --request path\to\campaign_request.json
 python -u scripts\run_eplus_gym_rules.py --family w2a --mode auto
 
 # Live month closed-loop (CLI only; slow)


### PR DESCRIPTION
## Summary
- Replace orphan JS DSM run HUD with disk-backed `run_dsm_campaign.py` supervisor + Streamlit fragment polling of `current_dsm_run.json`
- Preflight EPW coverage / IDF SHA-256 / max_steps before any EnergyPlus Popen; defaults Peak day + AMY + baseline+one strategy
- Publish AMY updates `amy_meta.json` and site_ui_bundle EPW pin; A04-only champion publish (no E20 name-token race)
- `EnergyPlusStartupError` preserves `eplusout.err` Severe/Fatal instead of wrapping as FileNotFoundError

## Test plan
- [x] `pytest` focused suite (54 passed): campaign/preflight/HUD absence/A04/AMY pointer
- [x] Practice pack: republish A04 + madison_amy_202508_202608
- [x] Preflight rejects Jul 3 vs EPW ending Jul 2 (0 completed jobs)
- [x] Real peak-day baseline campaign succeeded (96-row traj, scorecard gates)
- [ ] CI vibe22-ci green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable live DSM campaigns with progress tracking, cancellation, resumable status, and result reporting.
  * Added preflight checks for dates, weather coverage, model integrity, strategies, and output readiness.
  * Added KPI tables, trajectory overlays, and daily peak charts to DSM results.
  * AMY weather is now the default, with stale-bundle warnings and automatic metadata updates.
  * Improved champion model selection, prioritizing A04 configurations where available.

* **Bug Fixes**
  * EnergyPlus startup failures now provide clearer diagnostic details instead of generic errors.
  * Added validation to prevent incomplete or invalid simulation results from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->