### PR TITLE
Pin Vibe19 on OpenFDD 4.4.1 and export dump_tables CSVs

### DIFF
--- a/vibe_code_apps_19/AGENTS.md
+++ b/vibe_code_apps_19/AGENTS.md
@@ -8,7 +8,7 @@ Codex / Claude / Cursor: paste this file as the session brief. For **Cloud zip p
 
 ## Mission
 
-Maintain Vibe App 19 as an **educational Streamlit demo** consuming the **pinned PyPI OpenFDD cookbook** (`open-fdd[reporting]==4.4.0`, 62 diagnostic rules; catalog version string remains `59-diagnostics+4-sql-analytics`):
+Maintain Vibe App 19 as an **educational Streamlit demo** consuming the **pinned PyPI OpenFDD cookbook** (`open-fdd[reporting]==4.4.1`, 62 diagnostic rules; catalog version string remains `59-diagnostics+4-sql-analytics`):
 
 - `app/rules/` — thin shims to `open_fdd` (do not fork fault equations)
 - `app/vav_health.py` — thin adapter for `open_fdd.analytics.vav_health`
@@ -26,7 +26,7 @@ Maintain Vibe App 19 as an **educational Streamlit demo** consuming the **pinned
 
 ## Hard rules
 
-1. **Pinned OpenFDD catalog (62 diagnostics on 4.4.0)** — never silently omit; use `SKIPPED_MISSING_ROLES`, `SKIPPED_EQUIPMENT_OFF`, or `NOT_APPLICABLE_EQUIPMENT_TYPE`. Agent extras use `CUSTOM-*` ids via `custom_rules.py` (see CUSTOM_RULES.md). Do not reimplement VAV-health math in Vibe19.
+1. **Pinned OpenFDD catalog (62 diagnostics on 4.4.1)** — never silently omit; use `SKIPPED_MISSING_ROLES`, `SKIPPED_EQUIPMENT_OFF`, or `NOT_APPLICABLE_EQUIPMENT_TYPE`. Agent extras use `CUSTOM-*` ids via `custom_rules.py` (see CUSTOM_RULES.md). Do not reimplement VAV-health math in Vibe19.
 2. **No Rust / DataFusion / FastAPI / Flask / Haystack RDF / Oxigraph**
 3. **No client historian trees in git** — local: browse folder; Cloud/shared: upload zip only (see package spec). Demo zip `data/demo_package_v1.zip` is OK
 4. **Do not recreate** `haystack_rdf/`, `fdd_app/`, `fdd_dashboard_model/`

--- a/vibe_code_apps_19/README.md
+++ b/vibe_code_apps_19/README.md
@@ -1,6 +1,6 @@
 # Vibe Code App 19 — Open FDD Vibe Coder
 
-Educational **Streamlit + pandas** lab for the [Open-FDD Pandas Cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/pandas-cookbook.html) via **PyPI `open-fdd[reporting]==4.4.0`** (62 diagnostics; Overview VAV health matrix from `open_fdd.analytics.vav_health`). Historian CSVs stay as-is; you map columns to logical roles, tune thresholds, run rules, and review **FDD Plots** validation cards / RCx / FDD DOCX.
+Educational **Streamlit + pandas** lab for the [Open-FDD Pandas Cookbook](https://bbartling.github.io/open-fdd/rules/cookbook/pandas-cookbook.html) via **PyPI `open-fdd[reporting]==4.4.1`** (62 diagnostics; Overview VAV health matrix from `open_fdd.analytics.vav_health`). Historian CSVs stay as-is; you map columns to logical roles, tune thresholds, run rules, and review **FDD Plots** validation cards / RCx / FDD DOCX.
 
 **This is not the Rust Open-FDD engine.** Production stack: [Open-FDD](https://github.com/bbartling/open-fdd).
 

--- a/vibe_code_apps_19/app/agent_api.py
+++ b/vibe_code_apps_19/app/agent_api.py
@@ -613,6 +613,7 @@ def export_agent_bundle(
             run.summary = summary
 
     # Long-format findings + profile-aware evidence + shared telemetry
+    findings = pd.DataFrame()
     if run.results:
         findings = fdd_findings_table(run.results)
         if isinstance(findings, pd.DataFrame) and not findings.empty:
@@ -633,6 +634,21 @@ def export_agent_bundle(
         for ts_path in export_counts.written:
             rel = ts_path.relative_to(out).as_posix()
             written[f"fdd_timeseries:{rel}"] = ts_path
+
+    if export_profile in ("diagnostic", "forensic"):
+        from open_fdd.analytics import dump_tables
+
+        dumped = dump_tables(
+            out,
+            frames=dataset.frames,
+            role_map=dataset.role_map,
+            rule_results=findings if isinstance(findings, pd.DataFrame) and not findings.empty else None,
+            weather=dataset.weather,
+            building_id=dataset.building_id,
+            unit_system=dataset.unit_system,
+        )
+        for name, path in dumped.items():
+            written[Path(name).stem] = path
 
     for eq_id, tel_path in write_shared_telemetry(
         dataset.frames,

--- a/vibe_code_apps_19/app/wattlab_dump.py
+++ b/vibe_code_apps_19/app/wattlab_dump.py
@@ -1011,6 +1011,21 @@ _MANIFEST_HINTS: dict[str, dict[str, str]] = {
         "purpose": "Weekly motor run hours",
         "how_to_use": "Evidence for schedule-align ECMs",
     },
+    "motor_hours.csv": {
+        "kind": "runtime",
+        "purpose": "Motor run hours (OpenFDD dump_tables)",
+        "how_to_use": "Compare dump-vs-dump motor totals",
+    },
+    "mech_cooling_oat_bins.csv": {
+        "kind": "runtime",
+        "purpose": "Mechanical cooling hours by OAT bin",
+        "how_to_use": "Compare dump-vs-dump compressor OAT bins",
+    },
+    "vav_health_matrix.csv": {
+        "kind": "analytics",
+        "purpose": "Canonical VAV health matrix (OpenFDD dump_tables)",
+        "how_to_use": "Same CSV OpenFDD dump-vs-dump scripts compare; Overview table is presentation only",
+    },
     "economizer_weather.csv": {
         "kind": "runtime",
         "purpose": "Economizer opportunity / compliance",

--- a/vibe_code_apps_19/constraints.txt
+++ b/vibe_code_apps_19/constraints.txt
@@ -1,5 +1,5 @@
 # Reproducible pins for the OpenFDD consumer (CI: pip install -c constraints.txt)
-open-fdd==4.4.0
+open-fdd==4.4.1
 pandas>=2.0,<3
 pyarrow>=14.0
 pyyaml>=6.0

--- a/vibe_code_apps_19/pyproject.toml
+++ b/vibe_code_apps_19/pyproject.toml
@@ -9,7 +9,7 @@ description = "Educational pandas/Streamlit FDD demo for BUILDING_100-style CSV 
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "open-fdd[reporting]==4.4.0",
+    "open-fdd[reporting]==4.4.1",
     "pandas>=2.0",
     "pyarrow>=14.0",
     "pyyaml>=6.0",

--- a/vibe_code_apps_19/requirements.txt
+++ b/vibe_code_apps_19/requirements.txt
@@ -11,7 +11,7 @@ python-docx>=1.1
 openpyxl>=3.1
 kaleido>=0.2.1
 matplotlib>=3.8
-# Pandas oracle + reporting. PyPI 4.4.0 includes vav_health_matrix_v1.
+# Pandas oracle + reporting. PyPI 4.4.1 dump_tables writes vav_health_matrix.csv.
 # GHCR :latest tracks develop after merge via .github/workflows/vibe19-ghcr.yml.
-open-fdd[reporting]==4.4.0
+open-fdd[reporting]==4.4.1
 pyarrow>=14.0

--- a/vibe_code_apps_19/tests/golden/expected_catalog.json
+++ b/vibe_code_apps_19/tests/golden/expected_catalog.json
@@ -1,5 +1,5 @@
 {
-  "open_fdd_version": "4.4.0",
+  "open_fdd_version": "4.4.1",
   "diagnostic_count": 62,
   "rule_catalog_version": "59-diagnostics+4-sql-analytics",
   "catalog_schema_version": "open-fdd-catalog-v1",

--- a/vibe_code_apps_19/tests/golden/export_revision.json
+++ b/vibe_code_apps_19/tests/golden/export_revision.json
@@ -1,9 +1,9 @@
 {
   "application": "vibe19-fdd-demo",
   "application_version": "0.2.0",
-  "open_fdd_version": "4.4.0",
+  "open_fdd_version": "4.4.1",
   "bundle_schema": "openfdd_engineering_bundle_v1",
   "legacy_bundle_schema": "wattlab_dump_v3",
   "rule_catalog_hash": "2e684dbb8f3188f06942c3cb0155aef4149713e7244b9f7733262f182465cba9",
-  "note": "Pin PyPI open-fdd[reporting]==4.4.0 (vav_health_matrix_v1). Manifest catalog_version string is still 59-diagnostics+4-sql-analytics; live RULES length is 62."
+  "note": "Pin PyPI open-fdd[reporting]==4.4.1 (dump_tables writes vav_health_matrix.csv). Manifest catalog_version string is still 59-diagnostics+4-sql-analytics; live RULES length is 62."
 }

--- a/vibe_code_apps_19/tests/test_wattlab_export_profiles.py
+++ b/vibe_code_apps_19/tests/test_wattlab_export_profiles.py
@@ -22,6 +22,7 @@ from profile_wattlab_export import (  # noqa: E402
     measure_export,
 )
 
+from app.agent_api import export_agent_bundle
 from app.rules.base import RuleResult
 from app.wattlab_dump import write_fdd_evidence, write_shared_telemetry
 
@@ -356,3 +357,26 @@ def test_shared_telemetry_one_file_per_equipment_deterministic(tmp_path: Path):
     forensic_df = pd.read_csv(forensic["AHU_A"])
     assert "extra" in forensic_df.columns
     assert list(forensic_df.columns).count("timestamp") == 1
+
+
+_DIAGNOSTIC_ORACLE_CSVS = {
+    "vav_health_matrix.csv",
+    "mech_cooling_oat_bins.csv",
+    "motor_hours.csv",
+    "motor_weekly.csv",
+}
+
+
+def test_diagnostic_dump_tables_oracle_csvs(tmp_path: Path):
+    dataset, run = build_profile_fixture()
+    export_agent_bundle(
+        dataset, run, tmp_path, include_bootstrap=False, profile="diagnostic"
+    )
+    names = {p.name for p in tmp_path.rglob("*") if p.is_file()}
+    assert _DIAGNOSTIC_ORACLE_CSVS <= names
+    for name in _DIAGNOSTIC_ORACLE_CSVS:
+        df = pd.read_csv(tmp_path / name)
+        assert not df.empty, name
+    manifest = json.loads((tmp_path / "MANIFEST.json").read_text(encoding="utf-8"))
+    man_paths = {e.get("path") for e in manifest.get("files") or []}
+    assert _DIAGNOSTIC_ORACLE_CSVS <= man_paths

--- a/vibe_code_apps_19/vibe19_agent_spec/AGENTS.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/AGENTS.md
@@ -29,7 +29,7 @@ session. Production Rust Open-FDD is a **separate** repo.
 ## AI agent quick rules (read first)
 
 1. **Never commit client CSV history** — browse/paste a local building folder; keep trees out of git.
-2. **62 canonical diagnostics on OpenFDD 4.4.0** — never silently omit; use `SKIPPED_MISSING_ROLES` / `SKIPPED_EQUIPMENT_OFF` / `NOT_APPLICABLE_EQUIPMENT_TYPE`. (Manifest `rule_catalog_version` may still read `59-diagnostics+4-sql-analytics`.)
+2. **62 canonical diagnostics on OpenFDD 4.4.1** — never silently omit; use `SKIPPED_MISSING_ROLES` / `SKIPPED_EQUIPMENT_OFF` / `NOT_APPLICABLE_EQUIPMENT_TYPE`. (Manifest `rule_catalog_version` may still read `59-diagnostics+4-sql-analytics`.)
 3. **No Rust / DataFusion / FastAPI / Flask / Haystack RDF / Oxigraph** in this app.
 4. **Rules follow Open-FDD pandas cookbook** — raw mask → optional operational gate → `confirm_fault()` → rollup hours.
 5. **Operational gates** — most rules require fan/pump/compressor proof; see `docs/OPERATIONAL_GATES.md`. Prefer `fan_status` over `fan_cmd`.

--- a/vibe_code_apps_19/vibe19_agent_spec/SESSION_LOG.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/SESSION_LOG.md
@@ -8,6 +8,13 @@ For onboarding your own site, start with [`TEMPLATE.md`](TEMPLATE.md) and [`docs
 
 ---
 
+## 2026-08-15 — PyPI OpenFDD 4.4.1 dump_tables + GHCR
+
+- Pin `open-fdd[reporting]==4.4.1`. Diagnostic/forensic WattLab dump calls `open_fdd.analytics.dump_tables` so `vav_health_matrix.csv` (plus motor/mech CSVs) land in the Engineering Bundle and MANIFEST.
+- Runtime floor stays `>=4.4.0,<5`. Do not reimplement VAV-health math in Vibe19.
+
+---
+
 ## 2026-08-14 — PyPI OpenFDD 4.4.0 + VAV health matrix
 
 - Pin `open-fdd[reporting]==4.4.0` (pyproject / requirements / constraints). Drop GitHub ZIP overlay in CI.

--- a/vibe_code_apps_19/vibe19_agent_spec/skills/vibe19-streamlit-demo/SKILL.md
+++ b/vibe_code_apps_19/vibe19_agent_spec/skills/vibe19-streamlit-demo/SKILL.md
@@ -2,13 +2,13 @@
 name: vibe19-streamlit-demo
 description: >-
   Use when working on Open FDD Vibe Coder Streamlit FDD demo: streamlit_app.py,
-  OpenFDD pandas cookbook (PyPI 4.4.0), building folder browse, Haystack-like column map JSON,
+  OpenFDD pandas cookbook (PyPI 4.4.1), building folder browse, Haystack-like column map JSON,
   Plots validation cards, Data Model, FDD DOCX, RCx Plots, analytics, occupancy
   calendar, unit toggle. Triggers on: Streamlit, streamlit_app, BUILDING tree,
   Haystack points, column map, RCx, Plots, DOCX, cookbook rules.
 ---
 
-# Vibe19 — Streamlit pandas FDD demo (OpenFDD 4.4.0)
+# Vibe19 — Streamlit pandas FDD demo (OpenFDD 4.4.1)
 
 **Brand:** Open FDD Vibe Coder (`shared/branding.py`).
 


### PR DESCRIPTION
## Summary
- Pin `open-fdd[reporting]==4.4.1` (catalog hash unchanged `2e684dbb`).
- Diagnostic/forensic Engineering Bundle calls `open_fdd.analytics.dump_tables` so `vav_health_matrix.csv`, `mech_cooling_oat_bins.csv`, `motor_hours.csv`, and `motor_weekly.csv` appear in the dump and MANIFEST.
- GHCR `:latest` / `:develop` rebuild on merge to develop.

## Test plan
- [x] Local vibe19-pytest focused list (201 passed)
- [ ] GitHub vibe19-pytest green
- [ ] GitHub vibe19-ghcr PR smoke green, then develop push multi-arch
- [ ] After merge: docker pull ghcr.io/bbartling/vibe19:latest on bensbench

Made with [Cursor](https://cursor.com)