### PR TITLE
Control-v2 multi-day Gym — long RL still blocked

### DIFF
--- a/vibe_code_apps_22/AGENTS.md
+++ b/vibe_code_apps_22/AGENTS.md
@@ -22,7 +22,9 @@ python scripts/vibe22_rl.py operator-pay-experiment --mode smoke --reward-name o
 python scripts/reproduce_physics_ramp_gate.py
 ```
 
-`--mode full` must exit 4 until a **newly generated** ramp artifact has `passed=true`.
+`--mode full` must exit 4 until a **newly generated** ramp artifact has `passed=true`
+*and* `contracts/active_rl_model_v1.json` has `long_campaign_allowed=true` with
+verified hashes. Control/action/observation v2: [`docs/audits/2026-08-17-vibe22-control-contract-v2.md`](docs/audits/2026-08-17-vibe22-control-contract-v2.md).
 
 Non-RL DSM/GL14/Streamlit: [`archive/2026-08-14_pre_rl_only/`](archive/2026-08-14_pre_rl_only/).
 Do not restore `archive/2026-08-10_pre_eplus_gym`.

--- a/vibe_code_apps_22/contracts/active_rl_model_v1.json
+++ b/vibe_code_apps_22/contracts/active_rl_model_v1.json
@@ -1,0 +1,18 @@
+{
+  "schema": "vibe22.active_rl_model.v1",
+  "model_id": null,
+  "idf_path": null,
+  "idf_sha256": null,
+  "epw_sha256": "87d7d9bfca7de4ac5b905ec1a65defc7622a78dac9444fc55cdef618ddf91fb2",
+  "energyplus_version": "26.1.0",
+  "control_contract_version": "control_contract_v2",
+  "observation_contract_version": "observation_contract_v3",
+  "action_contract_version": "ppo_action_contract_v2",
+  "reward_contract_version": "operator_pay_illustrative_v1",
+  "monthly_validation_artifact": null,
+  "transient_validation_artifact": "docs/audits/figures/postfix/ramp_gate.json",
+  "warning_gate_artifact": null,
+  "heldout_status": "locked_unseen",
+  "long_campaign_allowed": false,
+  "reason": "No Track B champion. A04 postfix ramp_gate.json remains passed=false. Fail closed."
+}

--- a/vibe_code_apps_22/contracts/control_contract_v2.json
+++ b/vibe_code_apps_22/contracts/control_contract_v2.json
@@ -1,0 +1,51 @@
+{
+  "contract_version": "control_contract_v2",
+  "label": "heating DualSP daily plan; not compressor command; not school occupancy",
+  "continuous_conditioning_label": "CONTINUOUS_CONDITIONING_THERMOSTATIC",
+  "layers": {
+    "A_school_occupancy": "external calendar constraint; agent must not move it",
+    "B_bas_occupied_unoccupied_mode": "BAS occ/unocc mode around the school day",
+    "C_heating_setpoint_schedule": "six 96-step DualSP heating setpoints the agent may choose inside a safe envelope",
+    "D_equipment_availability": "plant remains available for setback and freeze protection",
+    "E_fan_compressor_operation": "thermostatic cycling under BAS/thermostat safety; never direct compressor control"
+  },
+  "school_occupied_start": {
+    "weekday_local": "07:30",
+    "weekday_step": 30,
+    "source": "school_calendar_v2.doors_open"
+  },
+  "school_occupied_end": {
+    "mon_tue_wed_fri_local": "14:40",
+    "mon_tue_wed_fri_step_approx": 59,
+    "thursday_local": "13:30",
+    "thursday_step": 54
+  },
+  "readiness_check_steps": [30, 31],
+  "agent_envelope": {
+    "heating_setpoint_start_step": {"min": 20, "max": 40, "note": "05:00-10:00 DualSP occupied start; cannot move school occupancy"},
+    "heating_setpoint_end_step": {"min": 52, "max": 96, "note": "96 means midnight/end of day and must not wrap to 0"},
+    "recovery_lead_minutes": {"min": 0, "max": 180},
+    "recovery_ramp_minutes": {"min": 0, "max": 60, "default": 60},
+    "occupied_heating_setpoint_f": {"min": 68.0, "max": 72.0},
+    "unoccupied_heating_setpoint_f": {"min": 58.0, "max": 72.0, "may_equal_occupied": true},
+    "six_zone_setback_offsets_f": {"min": -3.0, "max": 1.0}
+  },
+  "equipment_availability_mode": "AVAILABLE_FOR_SETBACK_AND_FREEZE_PROTECTION",
+  "continuous_conditioning": {
+    "eligible_when": "occupied_heating_setpoint_f equals unoccupied_heating_setpoint_f, or explicit flag",
+    "emits": "identical setpoint on all 96 intervals",
+    "examples_f": [68.0, 70.0],
+    "not": "running the compressor 24/7"
+  },
+  "fixed_comparison_arms": [
+    "observed_bas_incumbent",
+    "deep_setback",
+    "shallow_setback",
+    "continuous_conditioning_68",
+    "continuous_conditioning_70",
+    "weather_rule_optimal_start",
+    "random_policy",
+    "ppo",
+    "dqn"
+  ]
+}

--- a/vibe_code_apps_22/contracts/dqn_action_contract_v2.json
+++ b/vibe_code_apps_22/contracts/dqn_action_contract_v2.json
@@ -1,0 +1,36 @@
+{
+  "contract_version": "dqn_action_contract_v2",
+  "v1_frozen_cardinality": 64,
+  "v1_note": "Discrete(64) does not offer true 70F continuous or start/end control; do not reinterpret it",
+  "cardinality": 110,
+  "decode": {
+    "0": {
+      "label": "CONTINUOUS_CONDITIONING_THERMOSTATIC_68",
+      "occupied_heating_f": 68.0,
+      "unoccupied_heating_f": 68.0,
+      "heating_setpoint_start_step": 0,
+      "heating_setpoint_end_step": 96,
+      "recovery_lead_minutes": 0,
+      "continuous_conditioning": true
+    },
+    "1": {
+      "label": "CONTINUOUS_CONDITIONING_THERMOSTATIC_70",
+      "occupied_heating_f": 70.0,
+      "unoccupied_heating_f": 70.0,
+      "heating_setpoint_start_step": 0,
+      "heating_setpoint_end_step": 96,
+      "recovery_lead_minutes": 0,
+      "continuous_conditioning": true
+    },
+    "setback_grid_index_base": 2,
+    "setback_grid": {
+      "occupied_heating_f": [68.0, 70.0],
+      "unoccupied_heating_f": [58.0, 62.0, 64.0],
+      "heating_setpoint_start_step": [24, 28, 32],
+      "recovery_lead_minutes": [0, 60, 120],
+      "shared_setback_offset_f": [-2.0, 0.0],
+      "heating_setpoint_end_step": "calendar",
+      "product": 108
+    }
+  }
+}

--- a/vibe_code_apps_22/contracts/observation_contract_v3.json
+++ b/vibe_code_apps_22/contracts/observation_contract_v3.json
@@ -1,0 +1,22 @@
+{
+  "contract_version": "observation_contract_v3",
+  "n_features_core": 78,
+  "forecast": {
+    "hourly_oat_c": 24,
+    "forecast_valid_mask": 24,
+    "source_flag": "PERFECT_EPISODE_FORECAST",
+    "note": "EPW truth labeled PERFECT_EPISODE_FORECAST; not a claim of real forecast error"
+  },
+  "calendar": ["month", "dow", "doy", "day_type", "thursday_early_dismissal", "school_occupied"],
+  "state": [
+    "six_zone_temps_f",
+    "month_to_date_peak_kw",
+    "billing_floor_kw",
+    "previous_day_peak_kw",
+    "previous_day_kwh",
+    "previous_action",
+    "continuous_conditioning_state"
+  ],
+  "optional": ["loop_entering_water_c", "loop_leaving_water_c"],
+  "no_future_weather_beyond_declared_forecast": true
+}

--- a/vibe_code_apps_22/contracts/observed_bas_incumbent_v2.json
+++ b/vibe_code_apps_22/contracts/observed_bas_incumbent_v2.json
@@ -1,0 +1,38 @@
+{
+  "schema": "vibe22.observed_bas_incumbent.v2",
+  "role": "paired operational baseline for DSM evaluation; not A04 native SCH_HtgSP; not Gym DualSP 70/65",
+  "split": "train_dev winter weekdays; Jan 25/26 and Mar 16 excluded from this snapshot",
+  "do_not_tune_to_utility_peak": true,
+  "utility_jan2026_billed_demand_kw": 284.82,
+  "occupied_heating_setpoint_f": {
+    "site_median": 68.0,
+    "per_zone_group": "see distributions when SITE_ROOT export is present"
+  },
+  "unoccupied_heating_setpoint_f": {
+    "site_median": 64.0
+  },
+  "weekday_transition": {
+    "occupancy_start_hour_median": 7.0,
+    "heating_setpoint_start_step": 28
+  },
+  "weekend": "unoccupied DualSP; school occupancy false",
+  "fan_status": {
+    "n_heat_pumps": 67,
+    "startup_distributions": "fill from BAS fan-status via scripts/vibe22_observed_bas_incumbent.py when SITE_ROOT is set",
+    "stagger_vs_simultaneous": "pending_site_export"
+  },
+  "missing_data": "pending_site_export",
+  "replay_params": {
+    "occupied_heating_f": 68.0,
+    "unoccupied_heating_f": 64.0,
+    "heating_setpoint_start_step": 28,
+    "heating_setpoint_end_step": 68,
+    "recovery_lead_minutes": 60,
+    "continuous_conditioning": false,
+    "label": "OBSERVED_BAS_INCUMBENT_REPLAY"
+  },
+  "rejected_baselines": {
+    "a04_sch_htgsp": "46F overnight, recovery ~03:15; calibration schedule, not operations",
+    "gym_dualsp_70_65": "previous Gym incumbent; not observed BAS median"
+  }
+}

--- a/vibe_code_apps_22/contracts/ppo_action_contract_v2.json
+++ b/vibe_code_apps_22/contracts/ppo_action_contract_v2.json
@@ -1,0 +1,30 @@
+{
+  "contract_version": "ppo_action_contract_v2",
+  "space": "Box",
+  "n": 11,
+  "order": [
+    "occupied_heating_f",
+    "unoccupied_heating_f",
+    "heating_setpoint_start_step",
+    "heating_setpoint_end_step",
+    "recovery_lead_minutes",
+    "offset_1F_A",
+    "offset_1F_B",
+    "offset_1F_C",
+    "offset_1F_D",
+    "offset_2F_A",
+    "offset_2F_B"
+  ],
+  "bounds": {
+    "occupied_heating_f": [68.0, 72.0],
+    "unoccupied_heating_f": [58.0, 72.0],
+    "heating_setpoint_start_step": [20, 40],
+    "heating_setpoint_end_step": [52, 96],
+    "recovery_lead_minutes": [0, 180],
+    "six_zone_setback_offsets_f": [-3.0, 1.0]
+  },
+  "continuous_conditioning": "unoccupied may equal occupied; derived CONTINUOUS_CONDITIONING_THERMOSTATIC when equal",
+  "end_step_96": "midnight / end of day; must not wrap to 0",
+  "does_not_move_school_occupancy": true,
+  "v1_frozen": "eplus_gym.rl.spaces remains Discrete/Box v1 including UNOCC_F_HI=68"
+}

--- a/vibe_code_apps_22/contracts/school_calendar_v2.json
+++ b/vibe_code_apps_22/contracts/school_calendar_v2.json
@@ -1,0 +1,63 @@
+{
+  "contract_version": "school_calendar_v2",
+  "timezone": "America/Chicago",
+  "civil_day_policy": "validation_peaks_and_occupancy_use_local_civil_days",
+  "never_fit_calendar_to_facility_kw": true,
+  "school_year_label": "2025-26_with_2026_summer_school",
+  "timestep_minutes": 15,
+  "steps_per_day": 96,
+  "regular_day": {
+    "doors_open_local": "07:30",
+    "doors_open_step": 30,
+    "attendance_local": "07:40",
+    "attendance_step_approx": 31,
+    "attendance_note": "07:40 is not on the 15-minute grid; readiness uses 07:30 and 07:45",
+    "dismissal_mon_tue_wed_fri_local": "14:40",
+    "dismissal_mon_tue_wed_fri_step_approx": 59,
+    "dismissal_thu_local": "13:30",
+    "dismissal_thu_step": 54,
+    "after_care_end_local": "18:00",
+    "after_care_end_step": 72,
+    "hvac_warmup_start_local": "05:30",
+    "hvac_warmup_start_step": 22,
+    "source": "deep-research locked hours + BAS occupancy where available",
+    "confidence": "high_for_bell_times_low_for_zone_extent"
+  },
+  "readiness_check_steps": {
+    "weekday": [30, 31],
+    "weekday_local": ["07:30", "07:45"],
+    "v1_approximation_step": 32,
+    "v1_approximation_local": "08:00",
+    "v1_note": "SCHOOL_START_STEP=32 remains on v1 paths only and is an intentional 08:00 approximation"
+  },
+  "holidays_and_breaks_local": {
+    "gaps_documented": [
+      "Exact 2025-26 district calendar holiday list not fully locked in public deep-research; use WinterBreak/Holiday placeholders below and label ASSUMED where noted"
+    ],
+    "winter_break_inclusive": ["2025-12-22", "2026-01-02"],
+    "assumed_holidays": [
+      "2025-09-01",
+      "2025-11-27",
+      "2025-11-28",
+      "2025-12-24",
+      "2025-12-25",
+      "2026-01-01",
+      "2026-01-19",
+      "2026-02-16",
+      "2026-03-27",
+      "2026-05-25"
+    ],
+    "summer_school_2026": {
+      "inclusive_start": "2026-06-24",
+      "inclusive_end": "2026-07-23",
+      "days": ["Monday", "Tuesday", "Wednesday", "Thursday"],
+      "student_contact_local": ["08:00", "13:00"],
+      "source": "deep-research summer school hours"
+    }
+  },
+  "honesty": {
+    "dsm_status": "NO-GO_until_raw_gates",
+    "calendar_not_calibrated_to_kw": true,
+    "agent_cannot_move_school_occupancy": true
+  }
+}

--- a/vibe_code_apps_22/docs/audits/2026-08-17-vibe22-control-contract-v2.md
+++ b/vibe_code_apps_22/docs/audits/2026-08-17-vibe22-control-contract-v2.md
@@ -1,0 +1,55 @@
+# Control contract v2 and multi-day daily Gym (2026-08-17)
+
+**Claim:** ENERGYPLUS DSM OPTIMIZATION SCREENING / RETROSPECTIVE REPLAY.
+
+**Status:** `MODEL DEVELOPMENT CONTINUES — LONG RL BLOCKED`
+
+This PR versions the daily control, observation, and action contracts and adds
+`MultiDayDailyEnv`. It does **not** train PPO/DQN, does not create a Track B
+champion, and does not issue BAS commands.
+
+## What changed
+
+- School occupancy is a calendar constraint (`school_calendar_v2.json`). The
+  agent cannot move doors-open / attendance / dismissal.
+- Readiness checks are 07:30 and 07:45 (steps 30 and 31). `SCHOOL_START_STEP=32`
+  (08:00) remains on v1 paths only, labeled as an approximation.
+- Heating DualSP start/end and recovery live in a safe envelope around that
+  calendar. `end_step=96` means end of day and does not wrap to 0.
+- Occupied and unoccupied setpoints may be equal.
+  `CONTINUOUS_CONDITIONING_THERMOSTATIC` emits the same setpoint for all 96
+  intervals. Equipment stays available; compressors are not commanded on.
+- PPO action contract v2 raises the unoccupied high bound to 72°F.
+- DQN action contract v2 is Discrete(110): actions 0 and 1 are 68°F and 70°F
+  continuous conditioning. Discrete(64) v1 is frozen and not reinterpreted.
+- Observation contract v3 carries 24 hourly OAT values labeled
+  `PERFECT_EPISODE_FORECAST` when taken from EPW truth, plus previous action,
+  previous-day peak/kWh, billing floor, and continuous-conditioning state.
+- `MultiDayDailyEnv` takes one action per day and does not reset the plant at
+  midnight. Unit tests use `FakeContinuityPlant` (explicitly not EnergyPlus).
+  LIVE EnergyPlus must keep one process for the episode; copying six zone
+  temperatures into a new EnergyPlus process is forbidden.
+- `contracts/active_rl_model_v1.json` is fail-closed (`long_campaign_allowed=false`).
+- Observed BAS incumbent replay is 68/64 with a 07:00 DualSP start — not A04
+  `SCH_HtgSP` and not Gym 70/65.
+
+## 24/7 representation
+
+Label: **CONTINUOUS_CONDITIONING_THERMOSTATIC**. Not “running the compressor 24/7.”
+
+## Multi-day continuity
+
+One `start_episode()` per reset. Each `step` simulates 24 hours on the same
+plant object. Month-to-date billing floor carries forward.
+
+## Track B / long RL
+
+Track B is still **planned, not executed**. Long RL remains **NO-GO**.
+
+## Tests
+
+```powershell
+python -m pytest tests/test_control_contract_v2.py tests/test_multiday_env.py tests -q
+```
+
+No BACnet writes. No trained-policy winner.

--- a/vibe_code_apps_22/eplus_gym/control_v2.py
+++ b/vibe_code_apps_22/eplus_gym/control_v2.py
@@ -1,0 +1,242 @@
+"""Control contract v2: school calendar vs DualSP schedules. Does not mutate v1."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+from eplus_native.six_zone_htg_stage import ACTION_KEYS
+
+__all__ = ["ACTION_KEYS"]
+
+STEPS_PER_DAY = 96
+END_OF_DAY_STEP = 96
+CONTINUOUS_CONDITIONING_THERMOSTATIC = "CONTINUOUS_CONDITIONING_THERMOSTATIC"
+_APP = Path(__file__).resolve().parents[1]
+
+
+def load_json_contract(name: str) -> dict[str, Any]:
+    path = _APP / "contracts" / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def local_hhmm_to_step(hhmm: str) -> int:
+    h_s, m_s = str(hhmm).split(":")
+    h, m = int(h_s), int(m_s)
+    if m % 15:
+        m = int(round(m / 15.0) * 15)
+        if m == 60:
+            h += 1
+            m = 0
+    return int(h) * 4 + int(m) // 15
+
+
+@dataclass
+class ZoneOffsetsV2:
+    setback_offset_f: float = 0.0
+
+
+@dataclass
+class SixZoneDailyParamsV2:
+    occupied_heating_f: float = 70.0
+    unoccupied_heating_f: float = 65.0
+    heating_setpoint_start_step: int = 28
+    heating_setpoint_end_step: int = 68
+    recovery_lead_minutes: int = 60
+    recovery_ramp_minutes: int = 60
+    continuous_conditioning: bool = False
+    zone_offsets: dict[str, ZoneOffsetsV2] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for key in ACTION_KEYS:
+            if key not in self.zone_offsets:
+                self.zone_offsets[key] = ZoneOffsetsV2()
+        if abs(float(self.occupied_heating_f) - float(self.unoccupied_heating_f)) < 1e-6:
+            self.continuous_conditioning = True
+            self.heating_setpoint_start_step = 0
+            self.heating_setpoint_end_step = END_OF_DAY_STEP
+            self.recovery_lead_minutes = 0
+
+    def mode_label(self) -> str:
+        if self.continuous_conditioning:
+            return CONTINUOUS_CONDITIONING_THERMOSTATIC
+        return "SETBACK_THERMOSTATIC"
+
+
+def school_windows(day: date | str, calendar: dict[str, Any] | None = None) -> dict[str, Any]:
+    cal = calendar or load_json_contract("school_calendar_v2.json")
+    d = day if isinstance(day, date) else date.fromisoformat(str(day)[:10])
+    regular = cal["regular_day"]
+    holidays = set(cal.get("holidays_and_breaks_local", {}).get("assumed_holidays") or [])
+    winter = cal.get("holidays_and_breaks_local", {}).get("winter_break_inclusive") or []
+    in_winter = False
+    if len(winter) == 2:
+        in_winter = date.fromisoformat(winter[0]) <= d <= date.fromisoformat(winter[1])
+    weekend = d.weekday() >= 5
+    holiday = d.isoformat() in holidays or in_winter
+    school = (not weekend) and (not holiday)
+    thu = d.weekday() == 3
+    start = int(regular["doors_open_step"])
+    end = int(regular["dismissal_thu_step"] if thu else regular["dismissal_mon_tue_wed_fri_step_approx"])
+    readiness = list(cal["readiness_check_steps"]["weekday"]) if school else []
+    return {
+        "day": d.isoformat(),
+        "school_occupied": school,
+        "weekend": weekend,
+        "holiday": holiday,
+        "thursday_early_dismissal": bool(school and thu),
+        "school_occupied_start_step": start if school else None,
+        "school_occupied_end_step": end if school else None,
+        "readiness_check_steps": readiness,
+        "day_type": "weekend" if weekend else ("holiday" if holiday else ("thursday" if thu else "weekday")),
+    }
+
+
+def validate_params(params: SixZoneDailyParamsV2, *, envelope: dict[str, Any] | None = None) -> None:
+    env = envelope or load_json_contract("control_contract_v2.json")["agent_envelope"]
+    occ_b = env["occupied_heating_setpoint_f"]
+    unocc_b = env["unoccupied_heating_setpoint_f"]
+    start_b = env["heating_setpoint_start_step"]
+    end_b = env["heating_setpoint_end_step"]
+    rec_b = env["recovery_lead_minutes"]
+    off_b = env["six_zone_setback_offsets_f"]
+    occ = float(params.occupied_heating_f)
+    unocc = float(params.unoccupied_heating_f)
+    if not (occ_b["min"] <= occ <= occ_b["max"]):
+        raise ValueError(f"occupied_heating_f {occ} outside envelope")
+    if not (unocc_b["min"] <= unocc <= unocc_b["max"]):
+        raise ValueError(f"unoccupied_heating_f {unocc} outside envelope")
+    if params.continuous_conditioning:
+        if abs(occ - unocc) > 1e-6:
+            raise ValueError("continuous conditioning requires equal occupied/unoccupied setpoints")
+        return
+    start = int(params.heating_setpoint_start_step)
+    end = int(params.heating_setpoint_end_step)
+    if not (start_b["min"] <= start <= start_b["max"]):
+        raise ValueError(f"heating_setpoint_start_step {start} outside envelope")
+    if not (end_b["min"] <= end <= end_b["max"]):
+        raise ValueError(f"heating_setpoint_end_step {end} outside envelope")
+    if end <= start:
+        raise ValueError("invalid start/end: end must be > start; end=96 is end of day")
+    rec = int(params.recovery_lead_minutes)
+    if not (rec_b["min"] <= rec <= rec_b["max"]):
+        raise ValueError(f"recovery_lead_minutes {rec} outside envelope")
+    for key in ACTION_KEYS:
+        off = float(params.zone_offsets[key].setback_offset_f)
+        if not (off_b["min"] <= off <= off_b["max"]):
+            raise ValueError(f"offset {key}={off} outside envelope")
+
+
+def build_zone_series_f_v2(params: SixZoneDailyParamsV2, action_key: str) -> list[float]:
+    off = params.zone_offsets.get(action_key) or ZoneOffsetsV2()
+    occ = float(params.occupied_heating_f) + 0.0
+    unocc = float(params.unoccupied_heating_f) + float(off.setback_offset_f)
+    if params.continuous_conditioning:
+        return [float(params.occupied_heating_f)] * STEPS_PER_DAY
+    start = int(params.heating_setpoint_start_step)
+    end = int(params.heating_setpoint_end_step)
+    if end == 0:
+        raise ValueError("end_step 0 is a wrap; use 96 for end of day")
+    if not (0 <= start <= 95 and 1 <= end <= END_OF_DAY_STEP):
+        raise ValueError("start/end out of range")
+    if end <= start:
+        raise ValueError("invalid start/end combination")
+    lead = max(0, int(round(params.recovery_lead_minutes / 15.0)))
+    ramp = max(0, int(round(params.recovery_ramp_minutes / 15.0)))
+    recovery_begin = max(0, start - lead)
+    series: list[float] = []
+    for t in range(STEPS_PER_DAY):
+        if start <= t < end:
+            series.append(occ)
+            continue
+        if recovery_begin <= t < start:
+            if ramp <= 0:
+                series.append(occ)
+            else:
+                progressed = t - (start - ramp)
+                if progressed <= 0:
+                    series.append(unocc)
+                else:
+                    frac = min(1.0, progressed / float(ramp))
+                    series.append(unocc + frac * (occ - unocc))
+            continue
+        series.append(unocc)
+    return series
+
+
+def build_six_schedules_f(params: SixZoneDailyParamsV2) -> dict[str, list[float]]:
+    return {k: build_zone_series_f_v2(params, k) for k in ACTION_KEYS}
+
+
+def observed_bas_incumbent_params() -> SixZoneDailyParamsV2:
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=68.0,
+        unoccupied_heating_f=64.0,
+        heating_setpoint_start_step=28,
+        heating_setpoint_end_step=68,
+        recovery_lead_minutes=60,
+        recovery_ramp_minutes=60,
+        continuous_conditioning=False,
+    )
+
+
+def continuous_params(setpoint_f: float) -> SixZoneDailyParamsV2:
+    sp = float(setpoint_f)
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=sp,
+        unoccupied_heating_f=sp,
+        heating_setpoint_start_step=0,
+        heating_setpoint_end_step=END_OF_DAY_STEP,
+        recovery_lead_minutes=0,
+        recovery_ramp_minutes=0,
+        continuous_conditioning=True,
+    )
+
+
+def deep_setback_params() -> SixZoneDailyParamsV2:
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=70.0,
+        unoccupied_heating_f=58.0,
+        heating_setpoint_start_step=28,
+        heating_setpoint_end_step=68,
+        recovery_lead_minutes=180,
+        recovery_ramp_minutes=60,
+    )
+
+
+def shallow_setback_params() -> SixZoneDailyParamsV2:
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=70.0,
+        unoccupied_heating_f=66.0,
+        heating_setpoint_start_step=28,
+        heating_setpoint_end_step=68,
+        recovery_lead_minutes=30,
+        recovery_ramp_minutes=60,
+    )
+
+
+def weather_rule_optimal_start_params(*, oat_min_c: float) -> SixZoneDailyParamsV2:
+    """Lead longer when colder. Not a learned policy."""
+    if oat_min_c <= -15.0:
+        lead = 180
+    elif oat_min_c <= -5.0:
+        lead = 120
+    elif oat_min_c <= 0.0:
+        lead = 60
+    else:
+        lead = 30
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=68.0,
+        unoccupied_heating_f=64.0,
+        heating_setpoint_start_step=28,
+        heating_setpoint_end_step=68,
+        recovery_lead_minutes=lead,
+        recovery_ramp_minutes=60,
+    )
+
+
+def chronological_days(start: str, n: int) -> list[str]:
+    d0 = date.fromisoformat(str(start)[:10])
+    return [(d0 + timedelta(days=i)).isoformat() for i in range(int(n))]

--- a/vibe_code_apps_22/eplus_gym/eplus_err.py
+++ b/vibe_code_apps_22/eplus_gym/eplus_err.py
@@ -38,16 +38,34 @@ def parse_eplus_err(err_path: Path, end_path: Path | None = None) -> dict[str, A
     first_severe = next((ln.strip() for ln in text.splitlines() if _SEVERE_RE.search(ln)), None)
     first_fatal = next((ln.strip() for ln in text.splitlines() if _FATAL_RE.search(ln)), None)
     kinds: Counter[str] = Counter()
+    phase_air = {"warmup": 0, "sizing": 0, "scored_runtime": 0}
+    coil_hits: list[dict[str, Any]] = []
     lines = text.splitlines()
     for i, ln in enumerate(lines):
         if "mass flow rate is smaller than 25%" in ln.lower():
             n = 1
+            ctx = "\n".join(lines[i : i + 6])
             for nxt in lines[i + 1 : i + 6]:
                 m = re.search(r"This error occurred\s+(\d+)\s+total times", nxt, re.I)
                 if m:
                     n = int(m.group(1))
                     break
             kinds["w2a_low_airflow"] += n
+            blob = ctx.lower()
+            if "during warmup" in blob or "warmup" in ln.lower():
+                phase = "warmup"
+            elif "during sizing" in blob or "sizing period" in blob:
+                phase = "sizing"
+            else:
+                phase = "scored_runtime"
+            phase_air[phase] += n
+            coil = None
+            for nxt in lines[i : i + 8]:
+                mcoil = re.search(r"Coil:Heating:WaterToAirHeatPump:EquationFit[=:]?\s*([^\s,;]+)", nxt)
+                if mcoil:
+                    coil = mcoil.group(1)
+                    break
+            coil_hits.append({"phase": phase, "n": n, "coil": coil, "line": ln.strip()[:240]})
         if "GetActuatorHandle" in ln or "Actuator Handle" in ln:
             kinds["actuator_handle"] += 1
         if "DATA PERIOD" in ln and "year" in ln.lower():
@@ -63,6 +81,8 @@ def parse_eplus_err(err_path: Path, end_path: Path | None = None) -> dict[str, A
         "first_severe": first_severe,
         "first_fatal": first_fatal,
         "recurring": dict(kinds),
+        "w2a_low_airflow_by_phase": phase_air,
+        "w2a_low_airflow_events": coil_hits,
         "err_path": str(err_path) if err_path.is_file() else None,
     }
 

--- a/vibe_code_apps_22/eplus_gym/rl/active_model.py
+++ b/vibe_code_apps_22/eplus_gym/rl/active_model.py
@@ -1,0 +1,56 @@
+"""Fail-closed active RL model manifest. A missing champion cannot unlock long training."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from eplus_gym.site_pins import sha256_file
+
+MANIFEST_NAME = "active_rl_model_v1.json"
+
+
+class ActiveModelError(ValueError):
+    """Champion manifest failed closed."""
+
+
+def load_active_model(app_root: Path) -> dict[str, Any]:
+    path = Path(app_root) / "contracts" / MANIFEST_NAME
+    if not path.is_file():
+        raise ActiveModelError("missing contracts/active_rl_model_v1.json")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def verify_active_model(app_root: Path, *, site_epw: Path | None = None) -> dict[str, Any]:
+    body = load_active_model(app_root)
+    if body.get("long_campaign_allowed") is not True:
+        raise ActiveModelError(
+            body.get("reason") or "long_campaign_allowed is false; long RL remains blocked"
+        )
+    idf_rel = body.get("idf_path")
+    want_idf = body.get("idf_sha256")
+    want_epw = body.get("epw_sha256")
+    if not idf_rel or not want_idf:
+        raise ActiveModelError("champion idf_path/idf_sha256 missing")
+    idf = Path(app_root) / str(idf_rel)
+    if not idf.is_file():
+        raise ActiveModelError(f"champion IDF missing: {idf_rel}")
+    got = sha256_file(idf)
+    if got != want_idf:
+        raise ActiveModelError(f"champion IDF hash mismatch: {got} != {want_idf}")
+    if site_epw is not None and want_epw:
+        got_epw = sha256_file(Path(site_epw))
+        if got_epw != want_epw:
+            raise ActiveModelError(f"EPW hash mismatch: {got_epw} != {want_epw}")
+    for key in (
+        "control_contract_version",
+        "observation_contract_version",
+        "action_contract_version",
+        "reward_contract_version",
+        "transient_validation_artifact",
+        "warning_gate_artifact",
+        "monthly_validation_artifact",
+    ):
+        if not body.get(key):
+            raise ActiveModelError(f"manifest missing {key}")
+    return body

--- a/vibe_code_apps_22/eplus_gym/rl/multiday_env.py
+++ b/vibe_code_apps_22/eplus_gym/rl/multiday_env.py
@@ -1,0 +1,257 @@
+"""Multi-day daily-decision env. One EnergyPlus process per episode; one action per day."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any, Sequence
+
+import gymnasium as gym
+import numpy as np
+
+from eplus_gym.control_v2 import (
+    SixZoneDailyParamsV2,
+    build_six_schedules_f,
+    chronological_days,
+    school_windows,
+)
+from eplus_gym.rl.billing_state import BillingState
+from eplus_gym.rl.obs_v3 import (
+    N_OBS_V3,
+    build_observation_v3,
+    observation_space_v3,
+    params_to_prev_action,
+)
+from eplus_gym.rl.reward import FAIL_REWARD, INFEASIBLE_TRAIN_REWARD
+from eplus_gym.rl.spaces_v2 import (
+    continuous_action_space_v2,
+    decode_continuous_v2,
+    decode_discrete_v2,
+    discrete_action_space_v2,
+    encode_continuous_v2,
+)
+from eplus_gym.objective import DT_H
+
+DEMAND_RATE = 15.0
+ENERGY_RATE = 0.12
+
+
+def incremental_monthly_demand_cost(
+    *,
+    demand_rate: float,
+    billing_floor_kw: float,
+    candidate_day_peak_kw: float,
+    baseline_day_peak_kw: float,
+) -> float:
+    return float(demand_rate) * (
+        max(float(billing_floor_kw), float(candidate_day_peak_kw))
+        - max(float(billing_floor_kw), float(baseline_day_peak_kw))
+    )
+
+
+@dataclass
+class FakeContinuityPlant:
+    """Carries thermal and billing-relevant state across days without restarting.
+
+    This is a test double for MultiDayDailyEnv bookkeeping. It is not EnergyPlus
+    and must not be used as a surrogate trajectory in scored campaigns.
+    """
+
+    zone_temps_f: list[float] = field(default_factory=lambda: [64.0] * 6)
+    n_process_starts: int = 0
+    n_days: int = 0
+    last_schedules: dict[str, list[float]] | None = None
+    morning_peak_kw: float = 0.0
+    daily_kwh: float = 0.0
+    live_energyplus: bool = False
+
+    def start_episode(self) -> None:
+        self.n_process_starts += 1
+        self.n_days = 0
+
+    def simulate_day(self, schedules: dict[str, list[float]], *, oat_c: Sequence[float]) -> dict[str, Any]:
+        if self.n_process_starts < 1:
+            raise RuntimeError("start_episode() first; refusing a per-day EnergyPlus restart")
+        self.n_days += 1
+        self.last_schedules = {k: list(v) for k, v in schedules.items()}
+        first = next(iter(schedules.values()))
+        continuous = max(first) - min(first) < 1e-6
+        mean_sp = float(np.mean(first))
+        oat = [float(x) for x in oat_c]
+        # Carry overnight temps: setback cools the mass; continuous holds it.
+        if continuous:
+            self.zone_temps_f = [mean_sp] * 6
+            recovery_kw = 40.0
+        else:
+            night = min(first)
+            self.zone_temps_f = [0.7 * t + 0.3 * night for t in self.zone_temps_f]
+            recovery_kw = 40.0 + max(0.0, 70.0 - float(np.mean(self.zone_temps_f))) * 8.0
+            self.zone_temps_f = [0.4 * t + 0.6 * max(first) for t in self.zone_temps_f]
+        self.morning_peak_kw = recovery_kw + max(0.0, -min(oat)) * 1.5
+        self.daily_kwh = (mean_sp / 70.0) * (80.0 if continuous else 55.0)
+        return {
+            "start_zone_temps_f": list(self.zone_temps_f),
+            "peak_kw": float(self.morning_peak_kw),
+            "daily_kwh": float(self.daily_kwh),
+            "n_process_starts": self.n_process_starts,
+            "live_energyplus": self.live_energyplus,
+        }
+
+
+class MultiDayDailyEnv(gym.Env):
+    """One RL step = one civil day. EnergyPlus (or the test double) is not reset at midnight."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(self, env_config: dict[str, Any] | None = None):
+        super().__init__()
+        cfg = dict(env_config or {})
+        self.cfg = cfg
+        self.n_days = int(cfg.get("n_days") or 3)
+        self.start_day = str(cfg.get("start_day") or "2026-01-12")
+        self.days = list(cfg.get("days") or chronological_days(self.start_day, self.n_days))
+        self.algo_space = str(cfg.get("action_kind") or "continuous")
+        self.plant: FakeContinuityPlant = cfg.get("plant") or FakeContinuityPlant()
+        self.hourly_oat: dict[str, list[float]] = dict(cfg.get("hourly_oat") or {})
+        self._billing = BillingState(
+            floor_kw=float(cfg.get("billing_floor_kw") or 0.0),
+            ratchet_kw=float(cfg.get("ratchet_kw") or 0.0),
+            contract_kw=float(cfg.get("contract_demand_kw") or 0.0),
+        )
+        self._baseline_billing = BillingState(
+            floor_kw=float(cfg.get("billing_floor_kw") or 0.0),
+            ratchet_kw=float(cfg.get("ratchet_kw") or 0.0),
+            contract_kw=float(cfg.get("contract_demand_kw") or 0.0),
+        )
+        self._day_i = 0
+        self._prev_action = [0.0] * 11
+        self._prev_peak = 0.0
+        self._prev_kwh = 0.0
+        self._prev_cc = 0.0
+        self._episode_return = 0.0
+        if self.algo_space == "discrete":
+            self.action_space = discrete_action_space_v2()
+        else:
+            self.action_space = continuous_action_space_v2()
+        self.observation_space = observation_space_v3()
+
+    def _oat(self, day: str) -> list[float]:
+        if day in self.hourly_oat:
+            vals = [float(x) for x in self.hourly_oat[day]]
+            if len(vals) != 24:
+                raise ValueError("hourly OAT must be 24 values")
+            return vals
+        # Deterministic placeholder when no EPW is supplied (unit tests).
+        return [-10.0] * 24
+
+    def _obs(self, day: str):
+        floor = self._billing.start_of_day(day)
+        return build_observation_v3(
+            day=day,
+            hourly_oat_c=self._oat(day),
+            zone_temps_f=self.plant.zone_temps_f,
+            billing_floor_kw=floor,
+            mtd_peak_kw=floor,
+            previous_day_peak_kw=self._prev_peak,
+            previous_day_kwh=self._prev_kwh,
+            previous_action=self._prev_action,
+            continuous_conditioning_state=self._prev_cc,
+        )
+
+    def reset(self, *, seed: int | None = None, options: dict | None = None):
+        super().reset(seed=seed)
+        self.plant.start_episode()
+        self._day_i = 0
+        self._prev_action = [0.0] * 11
+        self._prev_peak = 0.0
+        self._prev_kwh = 0.0
+        self._prev_cc = 0.0
+        self._episode_return = 0.0
+        init = dict(
+            floor_kw=float(self.cfg.get("billing_floor_kw") or 0.0),
+            ratchet_kw=float(self.cfg.get("ratchet_kw") or 0.0),
+            contract_kw=float(self.cfg.get("contract_demand_kw") or 0.0),
+        )
+        self._billing = BillingState(**init)
+        self._baseline_billing = BillingState(**init)
+        day = self.days[0]
+        obs, ctx = self._obs(day)
+        info = {
+            "day": day,
+            "school": school_windows(day),
+            "n_process_starts": self.plant.n_process_starts,
+            "obs_ctx": ctx,
+            "live_energyplus": self.plant.live_energyplus,
+        }
+        return obs, info
+
+    def _decode(self, action) -> SixZoneDailyParamsV2:
+        day = self.days[min(self._day_i, len(self.days) - 1)]
+        if self.algo_space == "discrete":
+            return decode_discrete_v2(int(np.asarray(action).reshape(-1)[0]), day=day)
+        return decode_continuous_v2(action)
+
+    def step(self, action):
+        if self._day_i >= len(self.days):
+            raise RuntimeError("episode already done")
+        day = self.days[self._day_i]
+        params = self._decode(action)
+        schedules = build_six_schedules_f(params)
+        payload = self.plant.simulate_day(schedules, oat_c=self._oat(day))
+        peak = float(payload["peak_kw"])
+        kwh = float(payload["daily_kwh"])
+        floor = self._billing.start_of_day(day)
+        base_floor = self._baseline_billing.start_of_day(day)
+        energy_cost = ENERGY_RATE * kwh
+        demand_cost = incremental_monthly_demand_cost(
+            demand_rate=DEMAND_RATE,
+            billing_floor_kw=floor,
+            candidate_day_peak_kw=peak,
+            baseline_day_peak_kw=float(self.cfg.get("baseline_day_peak_kw") or peak),
+        )
+        win = school_windows(day)
+        readiness_fail = False
+        if win["readiness_check_steps"]:
+            mean_t = float(np.mean(self.plant.zone_temps_f))
+            readiness_fail = mean_t < 67.5
+        if payload.get("failed"):
+            reward = FAIL_REWARD
+            display = float("nan")
+        elif readiness_fail:
+            reward = INFEASIBLE_TRAIN_REWARD
+            display = 0.0
+        else:
+            reward = -(energy_cost + demand_cost)
+            display = -(energy_cost + demand_cost)
+        self._billing.observe_peak(peak)
+        self._baseline_billing.observe_peak(float(self.cfg.get("baseline_day_peak_kw") or peak))
+        self._prev_action = encode_continuous_v2(params).astype(float).tolist()
+        self._prev_peak = peak
+        self._prev_kwh = kwh
+        self._prev_cc = 1.0 if params.continuous_conditioning else 0.0
+        self._episode_return += float(reward)
+        self._day_i += 1
+        terminated = self._day_i >= len(self.days)
+        if terminated:
+            obs = np.zeros(N_OBS_V3, dtype=np.float32)
+            next_day = None
+        else:
+            next_day = self.days[self._day_i]
+            obs, _ctx = self._obs(next_day)
+        info = {
+            "day": day,
+            "next_day": next_day,
+            "energy_cost": energy_cost,
+            "incremental_demand_cost": demand_cost,
+            "display_paycheck_usd": display,
+            "peak_kw": peak,
+            "daily_kwh": kwh,
+            "readiness_fail": readiness_fail,
+            "continuous_conditioning": params.continuous_conditioning,
+            "n_process_starts": self.plant.n_process_starts,
+            "n_days_simulated": self.plant.n_days,
+            "episode_return": self._episode_return,
+            "billing_floor_kw": self._billing.billing_floor_kw(),
+            "live_energyplus": self.plant.live_energyplus,
+            "dt_h": DT_H,
+        }
+        return obs, float(reward), terminated, False, info

--- a/vibe_code_apps_22/eplus_gym/rl/obs_v3.py
+++ b/vibe_code_apps_22/eplus_gym/rl/obs_v3.py
@@ -1,0 +1,136 @@
+"""Observation contract v3: 24-hour hourly forecast + carry-forward state."""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+
+from eplus_gym.control_v2 import SixZoneDailyParamsV2, school_windows
+from eplus_gym.rl.midnight_forecast import FORECAST_HOURS, forecast_from_epw_replay
+
+OBS_SCHEMA_V3 = "vibe22.obs.v3"
+PERFECT_EPISODE_FORECAST = "PERFECT_EPISODE_FORECAST"
+N_PREV_ACTION = 11
+# 24 oat + 24 mask + 6 calendar + 6 zones + 4 billing + 11 prev action + 1 cc + 2 optional loop
+N_OBS_V3 = 24 + 24 + 6 + 6 + 4 + N_PREV_ACTION + 1 + 2
+
+
+def observation_space_v3():
+    import gymnasium as gym
+
+    return gym.spaces.Box(low=-np.inf, high=np.inf, shape=(N_OBS_V3,), dtype=np.float32)
+
+
+def build_observation_v3(
+    *,
+    day: str,
+    hourly_oat_c: Sequence[float],
+    forecast_valid_mask: Sequence[float] | None = None,
+    forecast_source: str = PERFECT_EPISODE_FORECAST,
+    zone_temps_f: Sequence[float],
+    billing_floor_kw: float,
+    mtd_peak_kw: float,
+    previous_day_peak_kw: float = 0.0,
+    previous_day_kwh: float = 0.0,
+    previous_action: Sequence[float] | None = None,
+    continuous_conditioning_state: float = 0.0,
+    loop_entering_water_c: float | None = None,
+    loop_leaving_water_c: float | None = None,
+) -> tuple[np.ndarray, dict[str, Any]]:
+    oat = [float(x) for x in hourly_oat_c]
+    if len(oat) != FORECAST_HOURS:
+        raise ValueError(f"need {FORECAST_HOURS} hourly OAT values, got {len(oat)}")
+    mask = [1.0] * FORECAST_HOURS
+    if forecast_valid_mask is not None:
+        mask = [float(x) for x in forecast_valid_mask]
+        if len(mask) != FORECAST_HOURS:
+            raise ValueError("forecast_valid_mask must be length 24")
+    temps = [float(x) for x in zone_temps_f]
+    if len(temps) != 6:
+        raise ValueError("need 6 zone temps")
+    prev = [0.0] * N_PREV_ACTION
+    if previous_action is not None:
+        prev = [float(x) for x in previous_action]
+        if len(prev) != N_PREV_ACTION:
+            raise ValueError(f"previous_action must have {N_PREV_ACTION} values")
+    win = school_windows(day)
+    d = date.fromisoformat(str(day)[:10])
+    vec = np.asarray(
+        oat
+        + mask
+        + [
+            d.month / 12.0,
+            d.weekday() / 6.0,
+            int(d.strftime("%j")) / 366.0,
+            1.0 if win["school_occupied"] else 0.0,
+            1.0 if win["thursday_early_dismissal"] else 0.0,
+            1.0 if win["weekend"] else 0.0,
+        ]
+        + [t / 100.0 for t in temps]
+        + [
+            float(billing_floor_kw) / 500.0,
+            float(mtd_peak_kw) / 500.0,
+            float(previous_day_peak_kw) / 500.0,
+            float(previous_day_kwh) / 5000.0,
+        ]
+        + prev
+        + [float(continuous_conditioning_state)]
+        + [
+            float(loop_entering_water_c) / 40.0 if loop_entering_water_c is not None else 0.0,
+            float(loop_leaving_water_c) / 40.0 if loop_leaving_water_c is not None else 0.0,
+        ],
+        dtype=np.float32,
+    )
+    if vec.size != N_OBS_V3:
+        raise ValueError(f"obs v3 size {vec.size} != {N_OBS_V3}")
+    ctx = {
+        "obs_schema": OBS_SCHEMA_V3,
+        "forecast_source": forecast_source,
+        "hourly_oat_c": oat,
+        "forecast_valid_mask": mask,
+        "day": win,
+        "zone_temps_f": temps,
+        "billing_floor_kw": float(billing_floor_kw),
+        "mtd_peak_kw": float(mtd_peak_kw),
+        "previous_day_peak_kw": float(previous_day_peak_kw),
+        "previous_day_kwh": float(previous_day_kwh),
+        "previous_action": prev,
+        "continuous_conditioning_state": float(continuous_conditioning_state),
+        "no_future_weather_beyond_declared_forecast": True,
+    }
+    return vec, ctx
+
+
+def observation_from_epw_truth(
+    *,
+    day: str,
+    epw: Path,
+    zone_temps_f: Sequence[float],
+    billing_floor_kw: float,
+    mtd_peak_kw: float,
+    previous_day_peak_kw: float = 0.0,
+    previous_day_kwh: float = 0.0,
+    previous_action: Sequence[float] | None = None,
+    continuous_conditioning_state: float = 0.0,
+) -> tuple[np.ndarray, dict[str, Any]]:
+    fc = forecast_from_epw_replay(Path(epw), day)
+    return build_observation_v3(
+        day=day,
+        hourly_oat_c=fc.temps_c,
+        forecast_source=PERFECT_EPISODE_FORECAST,
+        zone_temps_f=zone_temps_f,
+        billing_floor_kw=billing_floor_kw,
+        mtd_peak_kw=mtd_peak_kw,
+        previous_day_peak_kw=previous_day_peak_kw,
+        previous_day_kwh=previous_day_kwh,
+        previous_action=previous_action,
+        continuous_conditioning_state=continuous_conditioning_state,
+    )
+
+
+def params_to_prev_action(params: SixZoneDailyParamsV2) -> list[float]:
+    from eplus_gym.rl.spaces_v2 import encode_continuous_v2
+
+    return encode_continuous_v2(params).astype(float).tolist()

--- a/vibe_code_apps_22/eplus_gym/rl/operator_pay_experiment.py
+++ b/vibe_code_apps_22/eplus_gym/rl/operator_pay_experiment.py
@@ -107,15 +107,30 @@ def full_mode_allowed(ramp: Mapping[str, Any]) -> bool:
 
 
 def refuse_full_campaign(app_root: Path) -> dict[str, Any]:
+    from eplus_gym.rl.active_model import ActiveModelError, verify_active_model
+
     ramp = load_ramp_gate(app_root)
-    if full_mode_allowed(ramp):
-        return {"allowed": True, "ramp": ramp}
-    return {
-        "allowed": False,
-        "ramp": ramp,
-        "verdict": str(ramp.get("verdict") or VERDICT_FAIL),
-        "reason": "physics-ramp gate is not PASS; long campaign refused",
-    }
+    try:
+        manifest = verify_active_model(app_root)
+    except ActiveModelError as exc:
+        extra = ""
+        if not full_mode_allowed(ramp):
+            extra = "; A04 postfix physics-ramp gate is also not PASS"
+        return {
+            "allowed": False,
+            "ramp": ramp,
+            "verdict": str(ramp.get("verdict") or VERDICT_FAIL),
+            "reason": f"{exc}{extra}",
+        }
+    if not full_mode_allowed(ramp) and not manifest.get("transient_validation_artifact"):
+        return {
+            "allowed": False,
+            "ramp": ramp,
+            "manifest": manifest,
+            "verdict": str(ramp.get("verdict") or VERDICT_FAIL),
+            "reason": "physics-ramp gate is not PASS; long campaign refused",
+        }
+    return {"allowed": True, "ramp": ramp, "manifest": manifest}
 
 
 def no_setback_params() -> SixZoneDailyParams:

--- a/vibe_code_apps_22/eplus_gym/rl/spaces_v2.py
+++ b/vibe_code_apps_22/eplus_gym/rl/spaces_v2.py
@@ -1,0 +1,150 @@
+"""PPO/DQN action contract v2. Does not reinterpret Discrete(64) v1."""
+from __future__ import annotations
+
+from typing import Sequence
+
+import gymnasium as gym
+import numpy as np
+
+from eplus_gym.control_v2 import (
+    ACTION_KEYS,
+    END_OF_DAY_STEP,
+    SixZoneDailyParamsV2,
+    ZoneOffsetsV2,
+    continuous_params,
+    school_windows,
+)
+from eplus_native.six_zone_htg_stage import ACTION_KEYS as _KEYS
+
+assert ACTION_KEYS == _KEYS
+
+N_CONT_V2 = 5 + len(ACTION_KEYS)
+OCC_F_LO, OCC_F_HI = 68.0, 72.0
+UNOCC_F_LO, UNOCC_F_HI = 58.0, 72.0
+START_LO, START_HI = 20, 40
+END_LO, END_HI = 52, 96
+REC_LO, REC_HI = 0.0, 180.0
+SETBACK_LO, SETBACK_HI = -3.0, 1.0
+
+DQN_V2_OCC = (68.0, 70.0)
+DQN_V2_UNOCC = (58.0, 62.0, 64.0)
+DQN_V2_START = (24, 28, 32)
+DQN_V2_REC = (0, 60, 120)
+DQN_V2_OFFSET = (-2.0, 0.0)
+DQN_V2_N_CONTINUOUS = 2
+
+
+def _clip(v: float, lo: float, hi: float) -> float:
+    return float(min(hi, max(lo, v)))
+
+
+def continuous_action_space_v2() -> gym.spaces.Box:
+    low = np.asarray(
+        [OCC_F_LO, UNOCC_F_LO, float(START_LO), float(END_LO), REC_LO]
+        + [SETBACK_LO] * len(ACTION_KEYS),
+        dtype=np.float32,
+    )
+    high = np.asarray(
+        [OCC_F_HI, UNOCC_F_HI, float(START_HI), float(END_HI), REC_HI]
+        + [SETBACK_HI] * len(ACTION_KEYS),
+        dtype=np.float32,
+    )
+    return gym.spaces.Box(low=low, high=high, shape=(N_CONT_V2,), dtype=np.float32)
+
+
+def discrete_n_v2() -> int:
+    return DQN_V2_N_CONTINUOUS + (
+        len(DQN_V2_OCC) * len(DQN_V2_UNOCC) * len(DQN_V2_START) * len(DQN_V2_REC) * len(DQN_V2_OFFSET)
+    )
+
+
+def discrete_action_space_v2() -> gym.spaces.Discrete:
+    return gym.spaces.Discrete(discrete_n_v2())
+
+
+def decode_continuous_v2(action: Sequence[float] | np.ndarray) -> SixZoneDailyParamsV2:
+    a = np.asarray(action, dtype=np.float64).reshape(-1)
+    if a.size != N_CONT_V2:
+        raise ValueError(f"expected action len {N_CONT_V2}, got {a.size}")
+    occ = _clip(float(a[0]), OCC_F_LO, OCC_F_HI)
+    unocc = _clip(float(a[1]), UNOCC_F_LO, UNOCC_F_HI)
+    start = int(round(_clip(float(a[2]), START_LO, START_HI)))
+    end = int(round(_clip(float(a[3]), END_LO, END_HI)))
+    rec = int(round(_clip(float(a[4]), REC_LO, REC_HI) / 15.0) * 15)
+    zo = {
+        key: ZoneOffsetsV2(setback_offset_f=_clip(float(a[5 + i]), SETBACK_LO, SETBACK_HI))
+        for i, key in enumerate(ACTION_KEYS)
+    }
+    continuous = abs(occ - unocc) < 1e-6
+    if continuous:
+        start, end, rec = 0, END_OF_DAY_STEP, 0
+    elif end <= start:
+        raise ValueError("invalid start/end combination")
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=occ,
+        unoccupied_heating_f=unocc,
+        heating_setpoint_start_step=start,
+        heating_setpoint_end_step=end,
+        recovery_lead_minutes=rec,
+        recovery_ramp_minutes=60,
+        continuous_conditioning=continuous,
+        zone_offsets=zo,
+    )
+
+
+def encode_continuous_v2(params: SixZoneDailyParamsV2) -> np.ndarray:
+    zo = [float(params.zone_offsets[k].setback_offset_f) for k in ACTION_KEYS]
+    return np.asarray(
+        [
+            params.occupied_heating_f,
+            params.unoccupied_heating_f,
+            float(params.heating_setpoint_start_step),
+            float(params.heating_setpoint_end_step),
+            float(params.recovery_lead_minutes),
+            *zo,
+        ],
+        dtype=np.float32,
+    )
+
+
+def decode_discrete_v2(index: int, *, day: str | None = None) -> SixZoneDailyParamsV2:
+    n = discrete_n_v2()
+    idx = int(index) % n
+    if idx == 0:
+        return continuous_params(68.0)
+    if idx == 1:
+        return continuous_params(70.0)
+    idx -= DQN_V2_N_CONTINUOUS
+    n_off = len(DQN_V2_OFFSET)
+    n_rec = len(DQN_V2_REC)
+    n_start = len(DQN_V2_START)
+    n_unocc = len(DQN_V2_UNOCC)
+    off_i = idx % n_off
+    idx //= n_off
+    rec_i = idx % n_rec
+    idx //= n_rec
+    start_i = idx % n_start
+    idx //= n_start
+    unocc_i = idx % n_unocc
+    idx //= n_unocc
+    occ_i = idx % len(DQN_V2_OCC)
+    occ = DQN_V2_OCC[occ_i]
+    unocc = DQN_V2_UNOCC[unocc_i]
+    start = DQN_V2_START[start_i]
+    rec = DQN_V2_REC[rec_i]
+    off = DQN_V2_OFFSET[off_i]
+    end = 68
+    if day is not None:
+        win = school_windows(day)
+        if win["school_occupied"] and win["school_occupied_end_step"] is not None:
+            end = int(win["school_occupied_end_step"])
+    zo = {k: ZoneOffsetsV2(setback_offset_f=float(off)) for k in ACTION_KEYS}
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=float(occ),
+        unoccupied_heating_f=float(unocc),
+        heating_setpoint_start_step=int(start),
+        heating_setpoint_end_step=int(end),
+        recovery_lead_minutes=int(rec),
+        recovery_ramp_minutes=60,
+        zone_offsets=zo,
+    )

--- a/vibe_code_apps_22/tests/test_control_contract_v2.py
+++ b/vibe_code_apps_22/tests/test_control_contract_v2.py
@@ -1,0 +1,199 @@
+"""Control contract v2, 24/7 schedules, DQN/PPO v2, obs v3, fail-closed campaign."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from eplus_gym.control_v2 import (
+    END_OF_DAY_STEP,
+    SixZoneDailyParamsV2,
+    ZoneOffsetsV2,
+    build_six_schedules_f,
+    build_zone_series_f_v2,
+    continuous_params,
+    deep_setback_params,
+    observed_bas_incumbent_params,
+    school_windows,
+    shallow_setback_params,
+    validate_params,
+)
+from eplus_gym.rl.active_model import ActiveModelError, load_active_model, verify_active_model
+from eplus_gym.rl.obs_v3 import N_OBS_V3, PERFECT_EPISODE_FORECAST, build_observation_v3
+from eplus_gym.rl.operator_pay_experiment import refuse_full_campaign
+from eplus_gym.rl.spaces_v2 import (
+    decode_continuous_v2,
+    decode_discrete_v2,
+    discrete_n_v2,
+    encode_continuous_v2,
+)
+
+APP = Path(__file__).resolve().parents[1]
+
+
+def test_school_calendar_separated_from_control_schedule():
+    thu = school_windows("2026-01-15")
+    assert thu["thursday_early_dismissal"] is True
+    assert thu["school_occupied_start_step"] == 30
+    assert thu["school_occupied_end_step"] == 54
+    assert thu["readiness_check_steps"] == [30, 31]
+    weekend = school_windows("2026-01-17")
+    assert weekend["school_occupied"] is False
+    assert weekend["readiness_check_steps"] == []
+    params = observed_bas_incumbent_params()
+    assert params.heating_setpoint_start_step == 28
+    assert params.heating_setpoint_start_step != thu["school_occupied_start_step"]
+
+
+def test_end_step_96_does_not_wrap():
+    p = SixZoneDailyParamsV2(
+        occupied_heating_f=70.0,
+        unoccupied_heating_f=64.0,
+        heating_setpoint_start_step=28,
+        heating_setpoint_end_step=96,
+        recovery_lead_minutes=60,
+    )
+    series = build_zone_series_f_v2(p, "1F_A")
+    assert len(series) == 96
+    assert series[95] == pytest.approx(70.0)
+    assert series[0] == pytest.approx(64.0)
+
+
+def test_continuous_68_and_70_emit_constant_schedules():
+    for sp in (68.0, 70.0):
+        p = continuous_params(sp)
+        sched = build_six_schedules_f(p)
+        for series in sched.values():
+            assert series == [sp] * 96
+        assert p.mode_label() == "CONTINUOUS_CONDITIONING_THERMOSTATIC"
+
+
+def test_setback_variants_and_recovery_bounds():
+    deep = build_zone_series_f_v2(deep_setback_params(), "1F_A")
+    shallow = build_zone_series_f_v2(shallow_setback_params(), "1F_A")
+    assert min(deep) == pytest.approx(58.0)
+    assert min(shallow) == pytest.approx(66.0)
+    early = SixZoneDailyParamsV2(
+        occupied_heating_f=70.0,
+        unoccupied_heating_f=64.0,
+        heating_setpoint_start_step=20,
+        heating_setpoint_end_step=68,
+        recovery_lead_minutes=180,
+    )
+    late = SixZoneDailyParamsV2(
+        occupied_heating_f=70.0,
+        unoccupied_heating_f=64.0,
+        heating_setpoint_start_step=40,
+        heating_setpoint_end_step=80,
+        recovery_lead_minutes=0,
+    )
+    validate_params(early)
+    validate_params(late)
+    with pytest.raises(ValueError, match="invalid start/end"):
+        build_zone_series_f_v2(
+            SixZoneDailyParamsV2(
+                occupied_heating_f=70.0,
+                unoccupied_heating_f=64.0,
+                heating_setpoint_start_step=40,
+                heating_setpoint_end_step=20,
+            ),
+            "1F_A",
+        )
+    with pytest.raises(ValueError, match="offset"):
+        validate_params(
+            SixZoneDailyParamsV2(
+                occupied_heating_f=70.0,
+                unoccupied_heating_f=64.0,
+                zone_offsets={"1F_A": ZoneOffsetsV2(setback_offset_f=-9.0)},
+            )
+        )
+
+
+def test_ppo_v2_round_trip_and_bounds():
+    p = SixZoneDailyParamsV2(
+        occupied_heating_f=70.0,
+        unoccupied_heating_f=70.0,
+        heating_setpoint_start_step=0,
+        heating_setpoint_end_step=96,
+        continuous_conditioning=True,
+    )
+    encoded = encode_continuous_v2(p)
+    decoded = decode_continuous_v2(encoded)
+    again = encode_continuous_v2(decoded)
+    assert decoded.continuous_conditioning is True
+    np.testing.assert_allclose(encoded, again, atol=1e-5)
+    space = __import__("eplus_gym.rl.spaces_v2", fromlist=["continuous_action_space_v2"]).continuous_action_space_v2()
+    assert float(space.high[1]) == pytest.approx(72.0)
+    assert float(space.high[3]) == pytest.approx(96.0)
+
+
+def test_dqn_v2_has_explicit_continuous_actions():
+    assert discrete_n_v2() == 110
+    a0 = decode_discrete_v2(0)
+    a1 = decode_discrete_v2(1)
+    assert a0.occupied_heating_f == 68.0 and a0.unoccupied_heating_f == 68.0
+    assert a1.occupied_heating_f == 70.0 and a1.unoccupied_heating_f == 70.0
+    assert build_zone_series_f_v2(a1, "1F_A") == [70.0] * 96
+    setback = decode_discrete_v2(2, day="2026-01-15")
+    assert setback.heating_setpoint_end_step == 54
+    from eplus_gym.rl.spaces import discrete_n
+
+    assert discrete_n() == 64
+
+
+def test_obs_v3_has_24_hourly_forecast_and_previous_action():
+    oat = list(range(24))
+    prev = [70.0, 64.0, 28.0, 68.0, 60.0] + [0.0] * 6
+    vec, ctx = build_observation_v3(
+        day="2026-01-12",
+        hourly_oat_c=oat,
+        zone_temps_f=[68.0] * 6,
+        billing_floor_kw=200.0,
+        mtd_peak_kw=210.0,
+        previous_day_peak_kw=180.0,
+        previous_day_kwh=1200.0,
+        previous_action=prev,
+        continuous_conditioning_state=1.0,
+    )
+    assert vec.shape == (N_OBS_V3,)
+    assert ctx["hourly_oat_c"] == [float(x) for x in oat]
+    assert ctx["forecast_source"] == PERFECT_EPISODE_FORECAST
+    assert ctx["previous_action"] == prev
+    assert ctx["no_future_weather_beyond_declared_forecast"] is True
+    with pytest.raises(ValueError, match="24"):
+        build_observation_v3(
+            day="2026-01-12",
+            hourly_oat_c=list(range(48)),
+            zone_temps_f=[68.0] * 6,
+            billing_floor_kw=0.0,
+            mtd_peak_kw=0.0,
+        )
+
+
+def test_fail_closed_active_model_and_campaign():
+    body = load_active_model(APP)
+    assert body["long_campaign_allowed"] is False
+    with pytest.raises(ActiveModelError):
+        verify_active_model(APP)
+    decision = refuse_full_campaign(APP)
+    assert decision["allowed"] is False
+
+
+def test_contracts_exist_and_observed_incumbent_is_not_sch_htgsp():
+    names = [
+        "control_contract_v2.json",
+        "school_calendar_v2.json",
+        "observation_contract_v3.json",
+        "ppo_action_contract_v2.json",
+        "dqn_action_contract_v2.json",
+        "active_rl_model_v1.json",
+        "observed_bas_incumbent_v2.json",
+    ]
+    for name in names:
+        assert (APP / "contracts" / name).is_file()
+    obs = json.loads((APP / "contracts" / "observed_bas_incumbent_v2.json").read_text(encoding="utf-8"))
+    assert obs["replay_params"]["occupied_heating_f"] == 68.0
+    assert "46" not in str(obs["replay_params"])
+    assert obs["do_not_tune_to_utility_peak"] is True

--- a/vibe_code_apps_22/tests/test_multiday_env.py
+++ b/vibe_code_apps_22/tests/test_multiday_env.py
@@ -1,0 +1,128 @@
+"""Multi-day env: one process, billing carryover, no fabricated fallback."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eplus_gym.control_v2 import continuous_params
+from eplus_gym.rl.multiday_env import (
+    FakeContinuityPlant,
+    MultiDayDailyEnv,
+    incremental_monthly_demand_cost,
+)
+from eplus_gym.rl.reward import FAIL_REWARD
+from eplus_gym.rl.spaces_v2 import encode_continuous_v2
+from eplus_gym.eplus_err import parse_eplus_err
+
+
+def test_incremental_demand_uses_billing_floor():
+    c = incremental_monthly_demand_cost(
+        demand_rate=15.0,
+        billing_floor_kw=200.0,
+        candidate_day_peak_kw=180.0,
+        baseline_day_peak_kw=190.0,
+    )
+    assert c == pytest.approx(0.0)
+    c2 = incremental_monthly_demand_cost(
+        demand_rate=15.0,
+        billing_floor_kw=200.0,
+        candidate_day_peak_kw=220.0,
+        baseline_day_peak_kw=190.0,
+    )
+    assert c2 == pytest.approx(15.0 * 20.0)
+
+
+def test_multiday_does_not_restart_plant_at_midnight():
+    plant = FakeContinuityPlant()
+    env = MultiDayDailyEnv(
+        {
+            "n_days": 3,
+            "start_day": "2026-01-12",
+            "plant": plant,
+            "hourly_oat": {
+                "2026-01-12": [-18.0] * 24,
+                "2026-01-13": [-20.0] * 24,
+                "2026-01-14": [-12.0] * 24,
+            },
+        }
+    )
+    obs, info = env.reset()
+    assert info["n_process_starts"] == 1
+    assert obs.shape[0] == 78
+    action = encode_continuous_v2(continuous_params(68.0))
+    _, _, term, _, info1 = env.step(action)
+    assert term is False
+    assert info1["n_process_starts"] == 1
+    assert info1["n_days_simulated"] == 1
+    assert info1["continuous_conditioning"] is True
+    _, _, term, _, info2 = env.step(action)
+    assert info2["n_process_starts"] == 1
+    assert info2["previous_day"] if False else info2["n_days_simulated"] == 2
+    assert info2["billing_floor_kw"] >= info1["peak_kw"]
+    _, _, term, _, info3 = env.step(action)
+    assert term is True
+    assert info3["n_process_starts"] == 1
+    assert plant.n_process_starts == 1
+
+
+def test_cold_snap_carryover_changes_next_morning_peak():
+    oat = {"2026-01-12": [-18.0] * 24, "2026-01-13": [-18.0] * 24}
+
+    def _run(cc: bool):
+        plant = FakeContinuityPlant()
+        env = MultiDayDailyEnv({"n_days": 2, "start_day": "2026-01-12", "plant": plant, "hourly_oat": oat})
+        env.reset()
+        from eplus_gym.control_v2 import deep_setback_params
+
+        a = encode_continuous_v2(continuous_params(70.0) if cc else deep_setback_params())
+        env.step(a)
+        _obs, _r, _d, _tr, info = env.step(a)
+        return info["peak_kw"], plant.n_process_starts
+
+    peak_cc, starts_cc = _run(True)
+    peak_sb, starts_sb = _run(False)
+    assert starts_cc == starts_sb == 1
+    assert peak_cc != peak_sb
+
+
+def test_paired_envs_share_initial_state():
+    cfg = {"n_days": 3, "start_day": "2026-01-12", "hourly_oat": {"2026-01-12": [-10.0] * 24}}
+    e1 = MultiDayDailyEnv({**cfg, "plant": FakeContinuityPlant()})
+    e2 = MultiDayDailyEnv({**cfg, "plant": FakeContinuityPlant()})
+    o1, _ = e1.reset()
+    o2, _ = e2.reset()
+    np.testing.assert_allclose(o1[:24], o2[:24])
+    np.testing.assert_allclose(e1.plant.zone_temps_f, e2.plant.zone_temps_f)
+
+
+def test_failed_day_is_integrity_failure_not_fabricated():
+    plant = FakeContinuityPlant()
+    orig = plant.simulate_day
+
+    def boom(schedules, *, oat_c):
+        out = orig(schedules, oat_c=oat_c)
+        out["failed"] = True
+        return out
+
+    plant.simulate_day = boom  # type: ignore[method-assign]
+    env = MultiDayDailyEnv({"n_days": 1, "start_day": "2026-01-12", "plant": plant})
+    env.reset()
+    _obs, reward, _t, _tr, info = env.step(encode_continuous_v2(continuous_params(68.0)))
+    assert reward == FAIL_REWARD
+    assert info["live_energyplus"] is False
+
+
+def test_w2a_warning_phases_warmup_vs_runtime(tmp_path):
+    err = tmp_path / "eplusout.err"
+    err.write_text(
+        "*************  ** Warning ** Actual air mass flow rate is smaller than 25% of water-to-air heat pump coil rated air flow rate.\n"
+        "*************  **   ~~~   **   During Warmup, This error occurred 10 total times;\n"
+        "*************  ** Warning ** Actual air mass flow rate is smaller than 25% of water-to-air heat pump coil rated air flow rate.\n"
+        "*************  **   ~~~   **   This error occurred 4 total times;\n"
+        "************* EnergyPlus Completed Successfully-- 2 Warning; 0 Severe Errors\n",
+        encoding="utf-8",
+    )
+    gate = parse_eplus_err(err)
+    assert gate["w2a_low_airflow_by_phase"]["warmup"] == 10
+    assert gate["w2a_low_airflow_by_phase"]["scored_runtime"] == 4
+    assert gate["recurring"]["w2a_low_airflow"] == 14


### PR DESCRIPTION
## Summary
- Version school calendar, DualSP control, PPO/DQN actions, and 24-hour forecast observations without mutating v1.
- Allow thermostatic continuous conditioning (occupied = unoccupied; end_step=96 does not wrap).
- Add MultiDayDailyEnv with one plant process per episode and fail-closed `active_rl_model_v1.json`.

## Test plan
- [x] `python -m pytest tests -q` in vibe_code_apps_22 (125 passed, 1 deselected)
- [ ] CI python-tests

Stacked on #98. Do not merge #96/#97/#98 or this PR without explicit authorization. Long RL remains blocked. No BAS commands.