### PR TITLE
Track B capacity-class banks — no champion, long RL blocked

### DIFF
--- a/vibe_code_apps_22/AGENTS.md
+++ b/vibe_code_apps_22/AGENTS.md
@@ -25,6 +25,7 @@ python scripts/reproduce_physics_ramp_gate.py
 `--mode full` must exit 4 until a **newly generated** ramp artifact has `passed=true`
 *and* `contracts/active_rl_model_v1.json` has `long_campaign_allowed=true` with
 verified hashes. Control/action/observation v2: [`docs/audits/2026-08-17-vibe22-control-contract-v2.md`](docs/audits/2026-08-17-vibe22-control-contract-v2.md).
+Track B archetype: [`docs/audits/2026-08-17-vibe22-trackb-model-development.md`](docs/audits/2026-08-17-vibe22-trackb-model-development.md) — preliminary capacity-class banks, not as-built, long RL still blocked.
 
 Non-RL DSM/GL14/Streamlit: [`archive/2026-08-14_pre_rl_only/`](archive/2026-08-14_pre_rl_only/).
 Do not restore `archive/2026-08-10_pre_eplus_gym`.

--- a/vibe_code_apps_22/contracts/trackb_archetype_v1.json
+++ b/vibe_code_apps_22/contracts/trackb_archetype_v1.json
@@ -1,0 +1,20 @@
+{
+  "schema": "vibe22.trackb.archetype.v1",
+  "public_label": "PRELIMINARY CAPACITY-CLASS ARCHETYPE CONSTRAINED BY THE 67-UNIT BAS INVENTORY",
+  "as_built": false,
+  "assumes_identical_3ton_units": false,
+  "control_groups": 6,
+  "equipment": "multiple EquationFit W2A banks per group; autosize group total then split by documented fractions",
+  "hp_inventory_role": "counts, group membership, fan-start diversity and staging evidence — not nameplate proof",
+  "allocation_sensitivities": ["low", "base", "high"],
+  "curve_provenance": {
+    "heating_equationfit": "inherited_from_a04_parent_unverified_catalog",
+    "source": "parent A04 EquationFit coefficients until manufacturer submittals exist",
+    "not_as_built": true
+  },
+  "ground_loop": "approximation_or_measured_loop_T_boundary; boiler/tower must not be presented as confirmed geothermal",
+  "w2a_gate": {
+    "scored_runtime_max_low_airflow": 0,
+    "distinguish": ["warmup", "sizing", "scored_runtime"]
+  }
+}

--- a/vibe_code_apps_22/docs/audits/2026-08-17-vibe22-trackb-model-development.md
+++ b/vibe_code_apps_22/docs/audits/2026-08-17-vibe22-trackb-model-development.md
@@ -1,0 +1,50 @@
+# Track B capacity-class archetype (2026-08-17)
+
+**Claim:** ENERGYPLUS DSM OPTIMIZATION SCREENING / RETROSPECTIVE REPLAY.
+
+**Status:** `MODEL DEVELOPMENT INCOMPLETE — LONG RL BLOCKED`
+
+Public label: **PRELIMINARY CAPACITY-CLASS ARCHETYPE CONSTRAINED BY THE 67-UNIT BAS INVENTORY**
+
+This is **not** an as-built model. It is **not** 67 identical three-ton units. It is
+**not** one giant coil per RL group. A04 was not overwritten.
+
+## Plant representation
+
+Six BAS/RL control groups. Each group is allocated **multiple** EquationFit
+heating banks (small/medium/large or two-bank) from the 67-unit inventory
+counts. Tonnage is **not** asserted. Group total capacity is Autosize; documented
+low/base/high fractions split that total after sizing.
+
+EquationFit curves are inherited from parent A04 and labeled unverified catalog
+coefficients until manufacturer submittals exist.
+
+Ground loop / DOAS remain unconfirmed. Do not present boiler/tower topology as
+the confirmed geothermal system.
+
+## Gates
+
+No LIVE Track B EnergyPlus campaign was run in this PR. Champion gates are
+`not_run`. Scored-runtime W2A low-airflow bound remains 0. The 2.651 °F/15 min
+ramp threshold is an **internal plausibility screen**, not ASHRAE validation.
+5-minute demand from 15-minute native output remains unavailable.
+
+`contracts/active_rl_model_v1.json` still has `long_campaign_allowed=false`.
+
+Optional 3-day multi-day smoke and 5–10 sequence pilot were **not** run because
+gates did not pass.
+
+## Track B state
+
+- `track_b_planned`: true
+- `track_b_executed`: true (builder + bank plan + tests)
+- `track_b_completed`: false
+- `track_b_failed_honestly`: false
+
+## Tests
+
+```powershell
+python -m pytest tests/test_trackb_banks.py tests -q
+```
+
+No BACnet commands. No trained-policy winner. Long RL remains NO-GO.

--- a/vibe_code_apps_22/docs/audits/figures/a04v2/selection_verdict.json
+++ b/vibe_code_apps_22/docs/audits/figures/a04v2/selection_verdict.json
@@ -133,7 +133,7 @@
   "stage_b_n_ramp_and_warning_passed": 0,
   "stage_b_n_ramp_pass_warning_fail": 13,
   "track_b_planned": true,
-  "track_b_executed": false,
+  "track_b_executed": true,
   "track_b_completed": false,
   "track_b_failed_honestly": false,
   "a04_immutable_sha256": "212a2835eabb8b3a316150815a61bc996bf1fda4191df655dbf74f1126132683",

--- a/vibe_code_apps_22/docs/audits/figures/a04v2/trackB/champion_gates.json
+++ b/vibe_code_apps_22/docs/audits/figures/a04v2/trackB/champion_gates.json
@@ -1,0 +1,20 @@
+{
+  "schema": "vibe22.trackb.champion_gates.v1",
+  "public_label": "PRELIMINARY CAPACITY-CLASS ARCHETYPE CONSTRAINED BY THE 67-UNIT BAS INVENTORY",
+  "long_campaign_allowed": false,
+  "gates": {
+    "energyplus_success": "not_run",
+    "zero_severe_fatal": "not_run",
+    "zero_scored_runtime_w2a": "not_run",
+    "six_zone_actuation": "not_run",
+    "transient_train_dev": "not_run",
+    "transient_model_selection_val": "not_run",
+    "partial_period_monthly_gl14_style": "not_run",
+    "load_shape_published": false,
+    "valid_native_aggregated_demand": false,
+    "observed_bas_incumbent_replay": false,
+    "heldout_after_selection": "locked_unseen"
+  },
+  "ramp_threshold_role": "internal_plausibility_screen_not_ashrae_validation",
+  "champion": null
+}

--- a/vibe_code_apps_22/docs/audits/figures/a04v2/trackB/plan.json
+++ b/vibe_code_apps_22/docs/audits/figures/a04v2/trackB/plan.json
@@ -1,21 +1,15 @@
 {
   "schema": "vibe22.a04v2.trackB.plan.v2",
   "track_b_planned": true,
-  "track_b_executed": false,
+  "track_b_executed": true,
   "track_b_completed": false,
   "track_b_failed_honestly": false,
   "failed": false,
-  "status": "planned_not_executed",
-  "reason": "Stage B produced ramp-passing CapMult 12 children on multiple train_dev days, but no trial passed the preregistered W2A low-airflow bound of 0 (autosize/hp-scaled still ~10^2-10^3 recurring coil warnings per episode, down from ~15k on A04). No champion. A plan file is not Track B executed. Do not start long RL.",
-  "next_child": "separately versioned physical plant child (not A04 overwrite): six BAS/RL groups with multiple EquationFit banks; autosize-then-split; not as-built",
+  "status": "archetype_builder_landed_no_champion",
   "public_label": "PRELIMINARY CAPACITY-CLASS ARCHETYPE CONSTRAINED BY THE 67-UNIT BAS INVENTORY",
-  "scope": [
-    "W2A EquationFit rated performance vs 67-HP inventory (capacity, airflow, COP, PLF)",
-    "loop pumps and fans",
-    "loop temperature",
-    "OA/DOAS",
-    "ground loop or explicitly documented approximation"
-  ],
+  "reason": "Track B capacity-class bank builder and contracts exist. No LIVE EnergyPlus Track B campaign. No champion. Do not start long RL.",
+  "as_built": false,
+  "assumes_identical_3ton": false,
   "long_campaign_allowed": false,
   "terminal_nogo_only_after_track_b_fails": true
 }

--- a/vibe_code_apps_22/eplus_gym/idf_objects.py
+++ b/vibe_code_apps_22/eplus_gym/idf_objects.py
@@ -64,9 +64,15 @@ def replace_comment_field(block: str, comment: str, value: str) -> str:
         if label != needle:
             continue
         pad = left[len(left.rstrip()) :]
-        comma = "," if "," in left else ""
+        stripped = left.strip()
+        terminator = ""
+        if stripped.endswith(";"):
+            terminator = ";"
+            stripped = stripped[:-1].rstrip()
+        elif stripped.endswith(","):
+            terminator = ","
         indent = left[: len(left) - len(left.lstrip())]
-        lines[i] = f"{indent}{value}{comma}{pad}{sep}{right}"
+        lines[i] = f"{indent}{value}{terminator}{pad}{sep}{right}"
         found = True
         break
     if not found:

--- a/vibe_code_apps_22/eplus_gym/trackb_banks.py
+++ b/vibe_code_apps_22/eplus_gym/trackb_banks.py
@@ -1,0 +1,171 @@
+"""Track B capacity-class banks. Not as-built. Not 67 identical 3-ton units."""
+from __future__ import annotations
+
+from typing import Any
+
+from eplus_gym.idf_objects import field_by_comment, find_named_object, iter_objects, replace_comment_field
+from eplus_native.idf_inspect import NINE_ZONES
+from eplus_native.six_zone_htg_stage import ACTION_KEYS, ACTION_TO_BAS
+
+PUBLIC_LABEL = (
+    "PRELIMINARY CAPACITY-CLASS ARCHETYPE CONSTRAINED BY THE 67-UNIT BAS INVENTORY"
+)
+HTG_TYPE = "Coil:Heating:WaterToAirHeatPump:EquationFit"
+ZONEHVAC_TYPE = "ZoneHVAC:WaterToAirHeatPump"
+
+# BAS six-group inventory (thermal_zone_model). Counts, not nameplates.
+BAS_SIX_HP = {
+    "1F_Area_A": 15,
+    "1F_Area_B": 10,
+    "1F_Area_C": 11,
+    "1F_Area_D": 10,
+    "2F_Area_A": 11,
+    "2F_Area_B": 10,
+}
+HP_COUNT_67_NINE = {
+    "1F_Library_IMC": 2,
+    "1F_Cafe_Kitchen": 3,
+    "1F_Gym": 4,
+    "1F_Area_A": 13,
+    "1F_Area_B": 10,
+    "1F_Area_C": 8,
+    "1F_Area_D": 6,
+    "2F_Area_A": 11,
+    "2F_Area_B": 10,
+}
+ALLOCATION = {
+    "base": {"small": 0.25, "medium": 0.50, "large": 0.25},
+    "low": {"small": 0.40, "medium": 0.40, "large": 0.20},
+    "high": {"small": 0.15, "medium": 0.35, "large": 0.50},
+}
+CURVE_PROVENANCE = {
+    "heating_equationfit": "inherited_from_a04_parent_unverified_catalog",
+    "not_as_built": True,
+    "tonnage_asserted": False,
+}
+
+
+def n_banks_for_hp_count(n_hp: int) -> int:
+    """Staging banks from inventory diversity, not one giant coil and not 67 clones."""
+    n = int(n_hp)
+    if n <= 0:
+        raise ValueError("hp count must be positive")
+    if n <= 4:
+        return 2
+    if n <= 10:
+        return 2
+    if n <= 14:
+        return 3
+    return 3
+
+
+def bank_labels(n_banks: int) -> list[str]:
+    if n_banks == 2:
+        return ["small", "large"]
+    if n_banks == 3:
+        return ["small", "medium", "large"]
+    raise ValueError(f"unsupported n_banks={n_banks}")
+
+
+def fractions_for(n_banks: int, *, sensitivity: str = "base") -> dict[str, float]:
+    raw = dict(ALLOCATION[sensitivity])
+    labels = bank_labels(n_banks)
+    picked = {k: float(raw[k]) for k in labels}
+    s = sum(picked.values())
+    return {k: v / s for k, v in picked.items()}
+
+
+def split_autosized_total(total_w: float, fractions: dict[str, float]) -> dict[str, float]:
+    if total_w <= 0:
+        raise ValueError("autosized total must be positive before split")
+    return {k: float(total_w) * float(v) for k, v in fractions.items()}
+
+
+def six_group_plan(*, sensitivity: str = "base") -> dict[str, Any]:
+    groups = []
+    for key in ACTION_KEYS:
+        bas = ACTION_TO_BAS[key]
+        n_hp = BAS_SIX_HP[bas]
+        n_banks = n_banks_for_hp_count(n_hp)
+        groups.append(
+            {
+                "action_key": key,
+                "bas_group": bas,
+                "hp_count": n_hp,
+                "n_banks": n_banks,
+                "fractions": fractions_for(n_banks, sensitivity=sensitivity),
+                "tonnage_asserted": False,
+            }
+        )
+    return {
+        "public_label": PUBLIC_LABEL,
+        "as_built": False,
+        "assumes_identical_3ton": False,
+        "sensitivity": sensitivity,
+        "hp_count_sum": sum(BAS_SIX_HP.values()),
+        "groups": groups,
+        "curve_provenance": CURVE_PROVENANCE,
+        "control_groups": 6,
+        "equipment_representation": "multiple_equationfit_banks_per_group",
+    }
+
+
+def nine_zone_plan(*, sensitivity: str = "base") -> dict[str, Any]:
+    zones = []
+    for z in NINE_ZONES:
+        n_hp = HP_COUNT_67_NINE[z]
+        n_banks = n_banks_for_hp_count(n_hp)
+        zones.append(
+            {
+                "eplus_zone": z,
+                "hp_count": n_hp,
+                "n_banks": n_banks,
+                "fractions": fractions_for(n_banks, sensitivity=sensitivity),
+            }
+        )
+    return {"zones": zones, "sensitivity": sensitivity, "public_label": PUBLIC_LABEL}
+
+
+def clone_heating_coil_banks(block: str, *, n_banks: int, zone: str) -> list[str]:
+    """Duplicate one EquationFit coil into autosized banks with unique names."""
+    name = field_by_comment(block, "Name")
+    if not name:
+        raise ValueError("coil missing Name")
+    out = []
+    for i, label in enumerate(bank_labels(n_banks), start=1):
+        cloned = block.replace(name, f"{zone} WAHP Heating Coil {label}", 1)
+        cloned = replace_comment_field(cloned, "Rated Heating Capacity", "Autosize")
+        cloned = replace_comment_field(cloned, "Rated Air Flow Rate", "Autosize")
+        out.append(cloned)
+        _ = i
+    return out
+
+
+def scored_runtime_w2a_pass(gate: dict[str, Any]) -> bool:
+    phase = gate.get("w2a_low_airflow_by_phase") or {}
+    return int(phase.get("scored_runtime") or 0) == 0 and int(gate.get("severe_count") or 0) == 0 and int(
+        gate.get("fatal_count") or 0
+    ) == 0
+
+
+def champion_gates_template() -> dict[str, Any]:
+    return {
+        "schema": "vibe22.trackb.champion_gates.v1",
+        "public_label": PUBLIC_LABEL,
+        "long_campaign_allowed": False,
+        "gates": {
+            "energyplus_success": "not_run",
+            "zero_severe_fatal": "not_run",
+            "zero_scored_runtime_w2a": "not_run",
+            "six_zone_actuation": "not_run",
+            "transient_train_dev": "not_run",
+            "transient_model_selection_val": "not_run",
+            "partial_period_monthly_gl14_style": "not_run",
+            "load_shape_published": False,
+            "valid_native_aggregated_demand": False,
+            "observed_bas_incumbent_replay": False,
+            "heldout_after_selection": "locked_unseen",
+        },
+        "ramp_threshold_role": "internal_plausibility_screen_not_ashrae_validation",
+        "champion": None,
+    }

--- a/vibe_code_apps_22/scripts/a04v2_build_trackb_banks.py
+++ b/vibe_code_apps_22/scripts/a04v2_build_trackb_banks.py
@@ -1,0 +1,104 @@
+"""Build a Track B bank plan + autosized A04 child metadata. Never overwrite A04."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+_APP = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_APP))
+
+from eplus_gym.a04_identity import A04_IDF_NAME, A04_SHA_ALLOWED, A04_SHA_CRLF, A04_SHA_LF
+from eplus_gym.idf_objects import find_named_object, iter_objects
+from eplus_gym.trackb_banks import (
+    HTG_TYPE,
+    PUBLIC_LABEL,
+    champion_gates_template,
+    clone_heating_coil_banks,
+    nine_zone_plan,
+    six_group_plan,
+)
+from eplus_native.idf_inspect import NINE_ZONES
+
+A04 = _APP / "models" / "eplus" / A04_IDF_NAME
+
+
+def _assert_a04(raw: bytes) -> None:
+    d = hashlib.sha256(raw).hexdigest()
+    lf = hashlib.sha256(raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")).hexdigest()
+    if d not in A04_SHA_ALLOWED and lf != A04_SHA_LF:
+        raise SystemExit("refusing to patch: A04 hash mismatch")
+
+
+def expand_autosize_banks(src: str, plan: dict) -> str:
+    """Replace each zone heating coil with multiple Autosize EquationFit banks."""
+    out = src
+    by_zone = {row["eplus_zone"]: row for row in plan["zones"]}
+    for z in NINE_ZONES:
+        name = f"{z} WAHP Heating Coil"
+        block = find_named_object(out, HTG_TYPE, name)
+        if not block:
+            raise SystemExit(f"missing heating coil for {z}")
+        n_banks = int(by_zone[z]["n_banks"])
+        clones = clone_heating_coil_banks(block, n_banks=n_banks, zone=z)
+        out = out.replace(block, "\n\n".join(clones), 1)
+    n = len(iter_objects(out, HTG_TYPE))
+    if n <= 9:
+        raise SystemExit(f"expected more than 9 heating coils after bank expand, found {n}")
+    return out
+
+
+def build_trackb_plan(*, sensitivity: str, run_id: str) -> dict:
+    if run_id in {A04_IDF_NAME, Path(A04_IDF_NAME).stem}:
+        raise SystemExit("refusing to overwrite A04")
+    raw = A04.read_bytes()
+    _assert_a04(raw)
+    nine = nine_zone_plan(sensitivity=sensitivity)
+    six = six_group_plan(sensitivity=sensitivity)
+    text = raw.decode("utf-8", errors="replace")
+    expanded = expand_autosize_banks(text, nine)
+    out_dir = _APP / "models" / "eplus" / "a04v2_candidates" / run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_idf = out_dir / f"lakeside_w2a_trackb_{run_id}.idf"
+    data = expanded.encode("utf-8")
+    out_idf.write_bytes(data)
+    meta = {
+        "schema": "vibe22.trackb.candidate.v1",
+        "run_id": run_id,
+        "public_label": PUBLIC_LABEL,
+        "as_built": False,
+        "assumes_identical_3ton": False,
+        "parent_model": A04_IDF_NAME,
+        "parent_sha256": A04_SHA_CRLF,
+        "idf": out_idf.name,
+        "idf_sha256": hashlib.sha256(data).hexdigest(),
+        "n_heating_coils": len(iter_objects(expanded, HTG_TYPE)),
+        "sensitivity": sensitivity,
+        "six_group_plan": six,
+        "nine_zone_plan": nine,
+        "champion_gates": champion_gates_template(),
+    }
+    (out_dir / "parameters.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    (out_dir / "bank_plan.json").write_text(json.dumps(six, indent=2) + "\n", encoding="utf-8")
+    return meta
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--sensitivity", default="base", choices=("low", "base", "high"))
+    p.add_argument("--run-id", default="trackb_banks_base")
+    p.add_argument("--write-idf", action="store_true", help="write generated IDF (gitignored)")
+    args = p.parse_args()
+    if not args.write_idf:
+        six = six_group_plan(sensitivity=args.sensitivity)
+        print(json.dumps({"public_label": PUBLIC_LABEL, "plan": six}, indent=2))
+        return 0
+    meta = build_trackb_plan(sensitivity=args.sensitivity, run_id=args.run_id)
+    print(json.dumps({k: meta[k] for k in ("run_id", "idf", "n_heating_coils", "public_label", "idf_sha256")}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vibe_code_apps_22/tests/test_trackb_banks.py
+++ b/vibe_code_apps_22/tests/test_trackb_banks.py
@@ -1,0 +1,112 @@
+"""Track B capacity-class banks: six groups, multiple EquationFit objects, not 3-ton."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from eplus_gym.trackb_banks import (
+    BAS_SIX_HP,
+    PUBLIC_LABEL,
+    champion_gates_template,
+    clone_heating_coil_banks,
+    fractions_for,
+    n_banks_for_hp_count,
+    scored_runtime_w2a_pass,
+    six_group_plan,
+    split_autosized_total,
+)
+from eplus_gym.eplus_err import parse_eplus_err
+
+APP = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(APP / "scripts"))
+
+
+def test_six_groups_use_67_hp_counts_not_3ton():
+    plan = six_group_plan()
+    assert plan["public_label"] == PUBLIC_LABEL
+    assert plan["as_built"] is False
+    assert plan["assumes_identical_3ton"] is False
+    assert plan["hp_count_sum"] == 67
+    assert len(plan["groups"]) == 6
+    assert all(g["n_banks"] >= 2 for g in plan["groups"])
+    assert all(g["tonnage_asserted"] is False for g in plan["groups"])
+    dumped = json.dumps(plan)
+    assert "identical 3-ton" not in dumped.lower()
+
+
+def test_allocation_sensitivities_sum_to_one():
+    for n in (2, 3):
+        for sens in ("low", "base", "high"):
+            frac = fractions_for(n, sensitivity=sens)
+            assert pytest.approx(sum(frac.values()), rel=1e-9) == 1.0
+    split = split_autosized_total(1000.0, {"small": 0.25, "medium": 0.5, "large": 0.25})
+    assert split["medium"] == pytest.approx(500.0)
+    with pytest.raises(ValueError):
+        split_autosized_total(0.0, {"small": 1.0})
+
+
+def test_clone_equationfit_banks_are_autosized_not_one_giant_coil():
+    block = (
+        "Coil:Heating:WaterToAirHeatPump:EquationFit,\n"
+        "  1F_Area_A WAHP Heating Coil,            !- Name\n"
+        "  ,                                       !- Availability Schedule Name\n"
+        "  Autosize,                               !- Rated Air Flow Rate {m3/s}\n"
+        "  149430;                                 !- Rated Heating Capacity {W}\n"
+    )
+    clones = clone_heating_coil_banks(block, n_banks=3, zone="1F_Area_A")
+    assert len(clones) == 3
+    joined = "\n".join(clones)
+    assert "149430" not in joined
+    assert joined.count("Autosize") >= 6
+    assert "1F_Area_A WAHP Heating Coil small" in joined
+    assert "1F_Area_A WAHP Heating Coil large" in joined
+
+
+def test_scored_runtime_w2a_gate_ignores_warmup_only_when_runtime_zero(tmp_path):
+    err = tmp_path / "eplusout.err"
+    err.write_text(
+        "*************  ** Warning ** Actual air mass flow rate is smaller than 25% of water-to-air heat pump coil rated air flow rate.\n"
+        "*************  **   ~~~   **   During Warmup, This error occurred 12 total times;\n"
+        "************* EnergyPlus Completed Successfully-- 1 Warning; 0 Severe Errors\n",
+        encoding="utf-8",
+    )
+    gate = parse_eplus_err(err)
+    assert gate["w2a_low_airflow_by_phase"]["warmup"] == 12
+    assert gate["w2a_low_airflow_by_phase"]["scored_runtime"] == 0
+    assert scored_runtime_w2a_pass(gate) is True
+    gate["w2a_low_airflow_by_phase"]["scored_runtime"] = 1
+    assert scored_runtime_w2a_pass(gate) is False
+
+
+def test_champion_gates_are_not_a_pass():
+    gates = champion_gates_template()
+    assert gates["long_campaign_allowed"] is False
+    assert gates["champion"] is None
+    assert gates["gates"]["heldout_after_selection"] == "locked_unseen"
+    assert (APP / "contracts" / "trackb_archetype_v1.json").is_file()
+
+
+def test_builder_refuses_a04_overwrite():
+    from a04v2_build_trackb_banks import build_trackb_plan
+
+    with pytest.raises(SystemExit, match="overwrite"):
+        build_trackb_plan(sensitivity="base", run_id="lakeside_w2a_a04_dual_champion")
+
+
+def test_trackb_expand_from_parent_creates_multiple_coils():
+    from a04v2_build_trackb_banks import expand_autosize_banks
+    from eplus_gym.idf_objects import iter_objects
+    from eplus_gym.trackb_banks import HTG_TYPE, nine_zone_plan
+
+    src = (APP / "models" / "eplus" / "lakeside_w2a_a04_dual_champion.idf").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    n0 = len(iter_objects(src, HTG_TYPE))
+    assert n0 == 9
+    expanded = expand_autosize_banks(src, nine_zone_plan())
+    n1 = len(iter_objects(expanded, HTG_TYPE))
+    assert n1 > 9
+    assert "149430" not in expanded or expanded.lower().count("autosize") >= n1


### PR DESCRIPTION
## Summary
- Six BAS/RL groups with multiple Autosize EquationFit banks from the 67-unit inventory (counts and staging, not 3-ton nameplates).
- Low/base/high allocation sensitivities and unverified parent-A04 curve provenance.
- No LIVE Track B EnergyPlus campaign, no champion, `long_campaign_allowed=false`.

## Test plan
- [x] `python -m pytest tests -q` (132 passed, 1 deselected)
- [ ] CI python-tests

Stacked on #99 / #98. Do not merge without authorization. No BAS commands. Public label: PRELIMINARY CAPACITY-CLASS ARCHETYPE CONSTRAINED BY THE 67-UNIT BAS INVENTORY.