### PR TITLE
Vibe22 research-long launch (stack on #106)

### DIFF
--- a/vibe_code_apps_22/AGENTS.md
+++ b/vibe_code_apps_22/AGENTS.md
@@ -14,8 +14,12 @@ across **37** reports (superseded two-pass tree **3,780** scored kept on disk);
 CLI instrumented Track B day **738 scored / 4,657 warmup**, active invalid-domain
 **759**. Track C1/C2 one-W2A-per-zone children also failed scored-runtime W2A=0.
 Terminal **B**: `RESEARCH_POC_ALLOWED` on A04 only; `SIMULATION_TRAINING_READY`
-and `OPERATIONAL_DSM_READY` remain false. Audit:
+and `OPERATIONAL_DSM_READY` remain false. `research-long` is a labeled overnight
+research CLI (`RESEARCH_LONG_ALLOWED`) stacked on that PoC — still not a champion.
+Audit:
 [`docs/audits/2026-08-18-vibe22-final-physics-and-rl-poc.md`](docs/audits/2026-08-18-vibe22-final-physics-and-rl-poc.md).
+Research-long launch:
+[`docs/audits/2026-08-18-vibe22-research-long-launch.md`](docs/audits/2026-08-18-vibe22-research-long-launch.md).
 Prior Track B readiness:
 [`docs/audits/2026-08-18-vibe22-live-trackb-long-rl.md`](docs/audits/2026-08-18-vibe22-live-trackb-long-rl.md).
 See [`docs/audits/2026-08-17-vibe22-trackb-physics-validity-v2.md`](docs/audits/2026-08-17-vibe22-trackb-physics-validity-v2.md)
@@ -37,13 +41,16 @@ python scripts/vibe22_instrumented_day.py --site-root $env:SITE_ROOT
 python scripts/a04v2_trackc_one_w2a.py --variant c1 --site-root $env:SITE_ROOT
 python scripts/vibe22_rl.py operator-pay-experiment --mode smoke --reward-name operator_pay_2x_v1 --run-id oppay2x_smoke_20260816 --site-root $env:SITE_ROOT
 python scripts/vibe22_rl.py research-poc --confirm-simulation-only-physics-limits --max-wall-hours 6 --site-root $env:SITE_ROOT
+python scripts/vibe22_rl.py research-long --confirm-simulation-only-physics-limits --confirm-a04-not-transient-validated --micro-gate --site-root $env:SITE_ROOT
+python scripts/vibe22_rl.py research-long --confirm-simulation-only-physics-limits --confirm-a04-not-transient-validated --execute-live --max-wall-hours 30 --site-root $env:SITE_ROOT
 python scripts/reproduce_physics_ramp_gate.py
 ```
 
 `--mode full` must exit 4 until a **newly generated** ramp artifact has `passed=true`
 *and* `contracts/active_rl_model_v1.json` has `long_campaign_allowed=true` with
 verified hashes. `research-poc` is a **separate subcommand**, not an operator-pay
-`--mode`. Missing `--confirm-simulation-only-physics-limits` exits 4. The research
+`--mode`. `research-long` is another separate subcommand (not an alias of
+`campaign`). Missing either research-long confirm flag exits 4. The research
 contract cannot set `long_campaign_allowed=true`. EnergyPlus MCP (`user-energyplus`)
 is for IDF/RDD inspection before edits; it cannot rewrite W2A banks. Track C stays
 in Python. Control/action/observation v2: [`docs/audits/2026-08-17-vibe22-control-contract-v2.md`](docs/audits/2026-08-17-vibe22-control-contract-v2.md).

--- a/vibe_code_apps_22/README.md
+++ b/vibe_code_apps_22/README.md
@@ -9,6 +9,8 @@ Gym/runner is **rllib-shaped and local** (`eplus_gym`). Pin generic helpers to r
 
 **2026-08-18 final physics + research PoC:** Terminal **B**. No champion. Track B LIVE matrix **2,106 scored / 5,332 warmup** (37 reports). CLI instrumented Track B **738 / 4,657** plus active invalid-domain **759**. Track C sequential failed W2A=0. Long RL remains blocked. Bounded A04 `research-poc` is labeled `SIMULATION-ONLY RESEARCH POC`, not `SIMULATION_TRAINING_READY`. Audit: [`docs/audits/2026-08-18-vibe22-final-physics-and-rl-poc.md`](docs/audits/2026-08-18-vibe22-final-physics-and-rl-poc.md).
 
+**2026-08-18 research-long launch:** Stacked on the research PoC. Normalized PPO `Box(9)` (`research_action_contract_v2`), real SB3 checkpoints, chronological Nov 1–Dec 14 train / Dec 15–31 val. Still not a champion. `long_campaign_allowed` remains false. Audit: [`docs/audits/2026-08-18-vibe22-research-long-launch.md`](docs/audits/2026-08-18-vibe22-research-long-launch.md).
+
 **Physics-ramp gate (A04 parent):** still FAIL on evening DualSP — [`docs/audits/2026-08-16-vibe22-physics-ramp-nogo.md`](docs/audits/2026-08-16-vibe22-physics-ramp-nogo.md).
 
 ## Where results live

--- a/vibe_code_apps_22/contracts/research_rl_model_v1.json
+++ b/vibe_code_apps_22/contracts/research_rl_model_v1.json
@@ -14,22 +14,27 @@
     "track_b_w2a_scored_runtime_2106",
     "no_physics_champion"
   ],
-  "action_contract_version": "research_action_contract_v1",
+  "action_contract_version": "research_action_contract_v2",
   "action_space_restrictions": [
+    "normalized_ppo_box9",
     "continuous_68F",
     "continuous_70F",
-    "shallow_unoccupied_setback_only",
-    "deep_setback_excluded",
+    "occupied_heating_68_72F",
+    "unoccupied_heating_60F_through_occupied",
+    "recovery_0_180_minutes",
+    "six_zone_offsets_effective_60_to_occupied",
     "school_calendar_frozen",
-    "recovery_lead_and_gradual_ramp_allowed",
-    "six_zone_offsets_conservative"
+    "heating_dualsp_only",
+    "cooling_not_in_action_space"
   ],
-  "max_wall_hours": 6,
+  "max_wall_hours": 30,
   "claim_labels": [
+    "SIMULATION_ONLY_RL_RESEARCH",
     "SIMULATION_ONLY_RESEARCH_POC",
     "NOT VALIDATED FOR OPERATIONAL DSM",
     "NO BACNET COMMAND AUTHORITY",
-    "A04_RESEARCH_POC_NOT_TRANSIENT_VALIDATED"
+    "A04_RESEARCH_POC_NOT_TRANSIENT_VALIDATED",
+    "RESEARCH_LONG_ALLOWED"
   ],
   "bacnet_authority": false,
   "reason": "No physics champion. Bounded real-EnergyPlus RL is allowed only as a labeled research PoC."

--- a/vibe_code_apps_22/docs/audits/2026-08-18-vibe22-research-long-launch.md
+++ b/vibe_code_apps_22/docs/audits/2026-08-18-vibe22-research-long-launch.md
@@ -1,0 +1,103 @@
+# Vibe22 research-long launch (2026-08-18)
+
+Stacked on PR #106 tip `3be739ad` (`feat/vibe22-final-physics-rl-poc`). Isolation: worktree `C:\wt\v22rll`, branch `feat/vibe22-research-long-launch`. Scope `vibe_code_apps_22/` only. **Do not merge.** This is not a physics champion and does not unlock `campaign` / `operator-pay-experiment --mode full`.
+
+**Claim labels (must remain true as labels, not as operational readiness):**
+
+- `SIMULATION_ONLY_RL_RESEARCH`
+- `A04_RESEARCH_POC_NOT_TRANSIENT_VALIDATED`
+- `RESEARCH_LONG_ALLOWED` (label only)
+- `SIMULATION_TRAINING_READY=false`
+- `OPERATIONAL_DSM_READY=false`
+- `long_campaign_allowed=false`
+- `NO_BACNET_COMMAND_AUTHORITY` / `bacnet_commands=0`
+
+Machine-readable launch contract: [`figures/vibe22_research_long/campaign_manifest.json`](figures/vibe22_research_long/campaign_manifest.json).
+
+## Why PPO collapsed on the 6-hour PoC
+
+`research_action_contract_v1` used a **physical-unit** `Box(9)` with bounds `[68, 66, 0, −1×6]…[70, 70, 120, +1×6]`. Untrained PPO’s Gaussian (mean ~0) was clipped to occupied=68, unoccupied=66, recovery=0. That contract is **frozen** and must never be reinterpreted.
+
+`research_action_contract_v2` is a normalized `Box(low=-1, high=1, shape=(9,), float32)` with affine decode:
+
+1. occupied 68–72°F
+2. unoccupied 60°F through occupied (never above occupied)
+3. recovery 0–180 min, rounded to 15
+4–9. offsets −1…+1°F, then `effective = clip(unoccupied + offset, 60, occupied)`
+
+Continuous 68 (`x0=-1, x1=+1`) and continuous 70 (`x0=0, x1=+1`) are reachable. School occupancy stays calendar v2 (not in the Box). DQN is a unique 38-action table (no index wrap). Obs v3 stays dim 80; `previous_action` remains the control-v2 11-vector.
+
+Cooling is **not** in the action space. LIVE Gym still writes six heating DualSP schedules. Occupied/unoccupied cooling remain A04 `SCH_ClgSP` (~74°F / 85°F). Heating intervals are clamped so `htg + 2°F ≤ clg`. Learned cooling is a future contract.
+
+## Policy artifacts
+
+Chosen honesty path **B**: research-long **does not write** `daily_policy.pkl`. The SB3 `.zip` is canonical. Loading a zip whose `action_contract_version` ≠ `research_action_contract_v2` is refused. Metadata-only `checkpoint_manifest.json` is **not** a checkpoint.
+
+Real checkpoints are written at episode-block boundaries (`done=true`): model zip, DQN replay buffer, hashes, contract versions, RNG provenance, UTC, explicit resume command. Resume restores the zip (+ replay for DQN) and refuses contract/hash mismatch.
+
+## Day pool
+
+| Fold | Dates | Notes |
+| --- | --- | --- |
+| Train | 2025-11-01 through 2025-12-14 | Weekdays, weekends, holidays kept |
+| Validation | 2025-12-15 through 2025-12-31 ∩ EPW | Chronological; not a locked test |
+| January 2026 | unused | **NO LOCKED UNSEEN TEST AVAILABLE** |
+
+Episodes are contiguous 7-civil-day EnergyPlus blocks (last block shorter). `BillingState` carries across days inside a block and across blocks in the same calendar month. Candidate and paired baseline use **separate** `BillingState` objects. Unique `output/` per algo/seed.
+
+Budget: 8,192 **valid** daily transitions per algo/seed, or 30 h wall, whichever first. Sequential: PPO seed0 → PPO seed1 → DQN seed0 → DQN seed1. Named SB3 config `research_long` (`n_steps=7`). Do not reuse `research_poc` timesteps=4.
+
+## CLI
+
+```text
+python scripts/vibe22_rl.py research-long
+  --confirm-simulation-only-physics-limits
+  --confirm-a04-not-transient-validated
+  --simulator LIVE_ENERGYPLUS
+  [--micro-gate | --execute-live]
+  --max-wall-hours 30
+  --site-root ...
+```
+
+Missing either confirm → exit 4. Must not call `cmd_campaign` or set `long_campaign_allowed`. `research-poc` remains the 6-hour / v1 PoC.
+
+Eval arms on validation: incumbent, continuous 68, continuous 70, shallow setback, random v2, untrained PPO/DQN, trained PPO, trained DQN. Winner only from deterministic validation + readiness + both seeds of an algorithm beating those baselines; otherwise `winner=none`. **Never** crown from training mean reward. Plots after eval only; learning curves labeled **TRAINING ONLY**.
+
+## Micro-gate (LIVE, required before `--execute-live`)
+
+PPO and DQN, ≥8 valid transitions each, ≥2 train days, normalized PPO not collapsed to occupied=68, reload saved zip + `predict` on obs dim 80, action-contract v2, 96 scored intervals/day, 0 EnergyPlus severe/fatal, paired baseline provenance, chronological billing-state, W2A warmup + scored-runtime parsed (warnings do not block). Fail → fix once → retry once. If still fail, do not start the night job.
+
+## Micro-gate (LIVE, 2026-08-18)
+
+Host CLI EnergyPlus, not Docker. Site `SITE_ROOT=C:\Users\ben\OneDrive\Desktop\testing\sp_creekside`.
+
+| Check | Result |
+| --- | --- |
+| Exit | **0** |
+| Wall | **36.1 s** |
+| Train days | 2025-11-01, 2025-11-02 |
+| Val days | 2025-12-15, 2025-12-16 |
+| PPO seed0 valid transitions | **8** |
+| DQN seed0 valid transitions | **8** |
+| `daily_policy.pkl` | **not written** (`policy_pack_skipped=research_sb3_zip_canonical`) |
+| Action contract | `research_action_contract_v2` |
+| Obs | v3 dim 80 |
+| EnergyPlus severe/fatal | **0 / 0** |
+| Failures | none |
+| Winner | **none** (single seed; never training mean reward) |
+| A04 SHA-256 | `212a2835eabb8b3a316150815a61bc996bf1fda4191df655dbf74f1126132683` |
+| Site EPW SHA-256 | `dbfd1148a6627b53a1c6d5ba5e7b5fe7c4733fbe03865873d707d04ee22608d3` |
+| W2A | warmup + scored-runtime parsed; warnings do not block |
+| `long_campaign_allowed` | false |
+| BACnet | 0 |
+
+Run root: site `reports/eplus_gym/rl/research_long_20260818T193913Z`. Chronological billing: incumbent val opening MTD 0 then closing ~193 kW carried into day 2. PPO actions were not collapsed to occupied=68.
+
+Local pytest: `249 passed, 3 deselected` (`-k "not trackb_research_child"`). The Track B child hash test is gitignore/line-ending noise and is **not** part of this patch. `vibe22-ci.yml` only runs on PRs to `develop`/`main`.
+
+## Overnight
+
+`--execute-live` is a hidden PowerShell process after this stacked PR is pushed (not merged). Heartbeat JSON carries PID, hashes, current algo/seed, valid transitions, latest checkpoint. Report “started” only after the process is alive **and** ≥3 valid transitions. Do not wait 30 h. If later pytest/CI fails, set `contaminated=true` on the heartbeat and do not present results as valid.
+
+
+Frozen ramp remains **2.651 °F / 15 min**. `contracts/active_rl_model_v1.json` stays fail-closed. A04 IDF is not edited. `FakeContinuityPlant` stays refused on live paths. Vibe 19 untouched. Docker is not used (host CLI EnergyPlus 26.1).

--- a/vibe_code_apps_22/docs/audits/figures/vibe22_research_long/campaign_manifest.json
+++ b/vibe_code_apps_22/docs/audits/figures/vibe22_research_long/campaign_manifest.json
@@ -1,0 +1,32 @@
+{
+  "schema": "vibe22.research_long.v1",
+  "command": "research-long",
+  "claim_labels": [
+    "SIMULATION_ONLY_RL_RESEARCH",
+    "A04_RESEARCH_POC_NOT_TRANSIENT_VALIDATED",
+    "RESEARCH_LONG_ALLOWED",
+    "NO_BACNET_COMMAND_AUTHORITY"
+  ],
+  "SIMULATION_TRAINING_READY": false,
+  "OPERATIONAL_DSM_READY": false,
+  "long_campaign_allowed": false,
+  "RESEARCH_LONG_ALLOWED": true,
+  "bacnet_commands": 0,
+  "locked_unseen": "NO LOCKED UNSEEN TEST AVAILABLE",
+  "action_contract_version": "research_action_contract_v2",
+  "observation_contract": "vibe22.obs.v3",
+  "observation_dim": 80,
+  "policy_pack": null,
+  "policy_canonical": "sb3_zip",
+  "stacked_on": "3be739ad",
+  "base_branch": "feat/vibe22-final-physics-rl-poc",
+  "train_window": "2025-11-01:2025-12-14",
+  "validation_window": "2025-12-15:2025-12-31",
+  "block_size_days": 7,
+  "target_transitions": 8192,
+  "max_wall_hours": 30,
+  "winner_rule": "deterministic_validation_plus_readiness_multi_seed; never training mean_reward",
+  "heating_only": true,
+  "cooling_action_space": false,
+  "cooling_note": "LIVE Gym actuates six heating DualSP schedules only; A04 SCH_ClgSP remains ~74/85 F."
+}

--- a/vibe_code_apps_22/eplus_gym/rl/multiday_env.py
+++ b/vibe_code_apps_22/eplus_gym/rl/multiday_env.py
@@ -249,7 +249,14 @@ class MultiDayDailyEnv(gym.Env):
         self.start_day = str(cfg.get("start_day") or "2026-01-12")
         self.days = list(cfg.get("days") or chronological_days(self.start_day, self.n_days))
         self.algo_space = str(cfg.get("action_kind") or "continuous")
-        self._research = str(cfg.get("action_contract_version") or "") == "research_action_contract_v1"
+        self._research_contract = str(cfg.get("action_contract_version") or "")
+        self._research_v1 = self._research_contract == "research_action_contract_v1"
+        self._research_v2 = self._research_contract == "research_action_contract_v2"
+        self._research = self._research_v1 or self._research_v2
+        self._all_days = list(self.days)
+        self._block_size = int(cfg.get("block_size") or 0)
+        self._block_cursor = int(cfg.get("block_cursor") or 0)
+        self._persist_billing = bool(cfg.get("persist_billing"))
         self.plant = cfg.get("plant") or FakeContinuityPlant()
         if cfg.get("require_live_energyplus"):
             assert_live_campaign_plant(self.plant)
@@ -279,7 +286,17 @@ class MultiDayDailyEnv(gym.Env):
         self._episode_return = 0.0
         self._closed = False
         self._quality_evidence: dict[str, Any] | None = None
-        if self._research:
+        if self._research_v2:
+            from eplus_gym.rl.research_spaces import (
+                continuous_action_space_research_v2,
+                discrete_action_space_research_v2,
+            )
+
+            if self.algo_space == "discrete":
+                self.action_space = discrete_action_space_research_v2()
+            else:
+                self.action_space = continuous_action_space_research_v2()
+        elif self._research:
             from eplus_gym.rl.research_spaces import (
                 continuous_action_space_research,
                 discrete_action_space_research,
@@ -330,8 +347,22 @@ class MultiDayDailyEnv(gym.Env):
             continuous_conditioning_state=self._prev_cc,
         )
 
+    def _select_block(self) -> None:
+        if int(self._block_size or 0) <= 0 or not self._all_days:
+            return
+        start = int(self._block_cursor)
+        if start >= len(self._all_days):
+            start = 0
+        self.days = list(self._all_days[start : start + int(self._block_size)])
+        if not self.days:
+            start = 0
+            self.days = list(self._all_days[: int(self._block_size)])
+        nxt = start + len(self.days)
+        self._block_cursor = 0 if nxt >= len(self._all_days) else nxt
+
     def reset(self, *, seed: int | None = None, options: dict | None = None):
         super().reset(seed=seed)
+        self._select_block()
         self.plant.start_episode()
         self._day_i = 0
         self._prev_action = [0.0] * 11
@@ -346,8 +377,9 @@ class MultiDayDailyEnv(gym.Env):
             ratchet_kw=float(self.cfg.get("ratchet_kw") or 0.0),
             contract_kw=float(self.cfg.get("contract_demand_kw") or 0.0),
         )
-        self._billing = BillingState(**init)
-        self._baseline_billing = BillingState(**init)
+        if not (self._persist_billing and getattr(self, "_billing", None) is not None):
+            self._billing = BillingState(**init)
+            self._baseline_billing = BillingState(**init)
         day = self.days[0]
         obs, ctx = self._obs(day)
         info = {
@@ -361,6 +393,15 @@ class MultiDayDailyEnv(gym.Env):
 
     def _decode(self, action) -> SixZoneDailyParamsV2:
         day = self.days[min(self._day_i, len(self.days) - 1)]
+        if getattr(self, "_research_v2", False):
+            from eplus_gym.rl.research_spaces import (
+                decode_continuous_research_v2,
+                decode_discrete_research_v2,
+            )
+
+            if self.algo_space == "discrete":
+                return decode_discrete_research_v2(int(np.asarray(action).reshape(-1)[0]), day=day)
+            return decode_continuous_research_v2(action, day=day)
         if getattr(self, "_research", False):
             from eplus_gym.rl.research_spaces import decode_continuous_research, decode_discrete_research
 
@@ -411,7 +452,12 @@ class MultiDayDailyEnv(gym.Env):
             raise RuntimeError("episode already done")
         day = self.days[self._day_i]
         params = self._decode(action)
-        schedules = build_six_schedules_f(params)
+        if getattr(self, "_research_v2", False):
+            from eplus_gym.rl.research_spaces import research_build_six_schedules_f
+
+            schedules = research_build_six_schedules_f(params, day)
+        else:
+            schedules = build_six_schedules_f(params)
         oat, _src = self._oat(day)
         try:
             payload = self.plant.simulate_day(schedules, oat_c=oat)

--- a/vibe_code_apps_22/eplus_gym/rl/plots.py
+++ b/vibe_code_apps_22/eplus_gym/rl/plots.py
@@ -323,3 +323,79 @@ def plot_recovery_hist(
     fig.savefig(out, dpi=140)
     plt.close(fig)
     return out
+
+
+def plot_validation_arm_bars(
+    rows: Sequence[Mapping[str, Any]],
+    plots_dir: Path,
+    *,
+    filename: str = "validation_reward_by_arm.png",
+) -> Path:
+    """Validation-only bars. Training curves must stay labeled TRAINING ONLY."""
+    out = _ensure(plots_dir) / filename
+    df = pd.DataFrame(list(rows))
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+    if df.empty:
+        for ax in axes:
+            ax.text(0.5, 0.5, "no eval rows", ha="center")
+    else:
+        g = df.groupby("arm", sort=True)
+        rew = g["training_reward"].mean()
+        axes[0].bar(list(rew.index), rew.values)
+        axes[0].set_title("validation reward by arm")
+        axes[0].tick_params(axis="x", rotation=45)
+        peak = g["peak_kw"].mean()
+        axes[1].bar(list(peak.index), peak.values)
+        axes[1].set_title("validation peak kW")
+        axes[1].tick_params(axis="x", rotation=45)
+        ready = g["readiness_ok"].mean()
+        axes[2].bar(list(ready.index), ready.values)
+        axes[2].set_title("readiness rate")
+        axes[2].tick_params(axis="x", rotation=45)
+    for ax in axes:
+        ax.grid(True, axis="y", alpha=0.3)
+    fig.suptitle("SIMULATION-ONLY RESEARCH — validation, not a champion")
+    fig.tight_layout()
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    return out
+
+
+def plot_paired_val_delta(
+    rows: Sequence[Mapping[str, Any]],
+    plots_dir: Path,
+    *,
+    filename: str = "paired_candidate_minus_baseline.png",
+) -> Path:
+    """Per-day candidate minus incumbent on chronological validation."""
+    out = _ensure(plots_dir) / filename
+    df = pd.DataFrame(list(rows))
+    fig, ax = plt.subplots(figsize=(9, 4.2))
+    if df.empty or "arm" not in df.columns:
+        ax.text(0.5, 0.5, "no paired rows", ha="center")
+    else:
+        base = df.loc[df["arm"] == "incumbent", ["day", "training_reward"]].rename(
+            columns={"training_reward": "incumbent_reward"}
+        )
+        trained = df.loc[df["arm"].astype(str).str.startswith("trained_")]
+        plotted = False
+        for arm, g in trained.groupby("arm"):
+            m = g.merge(base, on="day", how="inner")
+            if m.empty:
+                continue
+            delta = m["training_reward"] - m["incumbent_reward"]
+            ax.plot(m["day"].astype(str), delta.values, marker="o", linewidth=1.4, label=str(arm))
+            plotted = True
+        if not plotted:
+            ax.text(0.5, 0.5, "no trained vs incumbent pairs", ha="center")
+        else:
+            ax.axhline(0.0, color="#333333", linewidth=0.8)
+            ax.legend(loc="best", fontsize=8)
+            ax.tick_params(axis="x", rotation=45)
+    ax.set_ylabel("candidate − incumbent reward")
+    ax.set_title("Paired validation (TRAINING ONLY curves are elsewhere)")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    return out

--- a/vibe_code_apps_22/eplus_gym/rl/research_checkpoint.py
+++ b/vibe_code_apps_22/eplus_gym/rl/research_checkpoint.py
@@ -1,0 +1,160 @@
+"""Block-boundary SB3 checkpoints. Metadata-only JSON is not resumable."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from eplus_gym.rl.obs_v3 import N_OBS_V3, OBS_SCHEMA_V3
+from eplus_gym.rl.research_spaces import (
+    DECODER_VERSION_V2,
+    RESEARCH_ACTION_CONTRACT_V2,
+    ActionContractMismatch,
+    assert_research_v2_contract,
+)
+from eplus_gym.site_pins import sha256_file
+
+SCHEMA = "vibe22.research_checkpoint.v2"
+OBS_DIM = N_OBS_V3
+
+
+class CheckpointError(ValueError):
+    """Checkpoint is missing, mismatched, or metadata-only."""
+
+
+def _sha256(path: Path) -> str:
+    return sha256_file(Path(path))
+
+
+def checkpoint_resumable(manifest: Mapping[str, Any] | None, *, root: Path | None = None) -> bool:
+    if not isinstance(manifest, Mapping):
+        return False
+    if str(manifest.get("schema") or "") != SCHEMA:
+        return False
+    zip_name = manifest.get("model_zip")
+    if not zip_name:
+        return False
+    base = Path(root) if root is not None else Path(str(manifest.get("root") or "."))
+    zpath = base / str(zip_name)
+    if not zpath.is_file():
+        return False
+    want = str(manifest.get("model_sha256") or "")
+    if not want or _sha256(zpath) != want:
+        return False
+    try:
+        assert_research_v2_contract(manifest)
+    except ActionContractMismatch:
+        return False
+    if int(manifest.get("observation_dim") or 0) != OBS_DIM:
+        return False
+    if str(manifest.get("observation_contract") or "") != OBS_SCHEMA_V3:
+        return False
+    algo = str(manifest.get("algo") or "").upper()
+    if algo == "DQN":
+        replay = base / str(manifest.get("replay_buffer") or "replay_buffer.pkl")
+        if not replay.is_file():
+            return False
+    return True
+
+
+def write_block_checkpoint(
+    *,
+    root: Path,
+    model: Any,
+    algo: str,
+    seed: int,
+    valid_transition_count: int,
+    block_id: str,
+    day: str | None,
+    idf_sha256: str,
+    epw_sha256: str,
+    rng_hex: str,
+) -> dict[str, Any]:
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    algo_u = str(algo).upper()
+    zip_name = f"{algo_u.lower()}_block.zip"
+    zpath = root / zip_name
+    model.save(str(zpath))
+    replay_name = None
+    if algo_u == "DQN":
+        replay_name = "replay_buffer.pkl"
+        model.save_replay_buffer(str(root / replay_name))
+    resume = (
+        f"python scripts/vibe22_rl.py research-long --resume {root.as_posix()} "
+        "--confirm-simulation-only-physics-limits --confirm-a04-not-transient-validated"
+    )
+    body = {
+        "schema": SCHEMA,
+        "algo": algo_u,
+        "seed": int(seed),
+        "valid_transition_count": int(valid_transition_count),
+        "block_id": str(block_id),
+        "day": None if day is None else str(day)[:10],
+        "action_contract_version": RESEARCH_ACTION_CONTRACT_V2,
+        "decoder_version": DECODER_VERSION_V2,
+        "observation_contract": OBS_SCHEMA_V3,
+        "observation_dim": OBS_DIM,
+        "idf_sha256": str(idf_sha256),
+        "epw_sha256": str(epw_sha256),
+        "model_zip": zip_name,
+        "model_sha256": _sha256(zpath),
+        "replay_buffer": replay_name,
+        "rng": str(rng_hex),
+        "utc": datetime.now(timezone.utc).isoformat(),
+        "resume_command": resume,
+        "long_campaign_allowed": False,
+        "SIMULATION_TRAINING_READY": False,
+        "OPERATIONAL_DSM_READY": False,
+        "metadata_only": False,
+    }
+    (root / "checkpoint.json").write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+    return body
+
+
+def load_checkpoint_manifest(root: Path) -> dict[str, Any]:
+    path = Path(root) / "checkpoint.json"
+    if not path.is_file():
+        raise CheckpointError("missing checkpoint.json")
+    body = json.loads(path.read_text(encoding="utf-8"))
+    if not checkpoint_resumable(body, root=Path(root)):
+        raise CheckpointError("checkpoint is not resumable (missing zip, hash, or contract mismatch)")
+    return body
+
+
+def refuse_metadata_only(manifest: Mapping[str, Any]) -> None:
+    if not manifest.get("model_zip") or manifest.get("metadata_only") is True:
+        raise CheckpointError("refusing metadata-only JSON as a checkpoint")
+
+
+def rng_hex(*, seed: int, idf_sha256: str, epw_sha256: str, algo: str) -> str:
+    payload = f"research-long:{algo}:{int(seed)}:{idf_sha256}:{epw_sha256}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def restore_checkpoint(
+    root: Path,
+    *,
+    idf_sha256: str | None = None,
+    epw_sha256: str | None = None,
+) -> tuple[dict[str, Any], Any]:
+    """Load SB3 zip (+ DQN replay). Refuse metadata-only JSON or hash/contract mismatch."""
+    body = load_checkpoint_manifest(root)
+    refuse_metadata_only(body)
+    if idf_sha256 is not None and str(body.get("idf_sha256")) != str(idf_sha256):
+        raise CheckpointError("idf sha256 mismatch; refusing resume")
+    if epw_sha256 is not None and str(body.get("epw_sha256")) != str(epw_sha256):
+        raise CheckpointError("epw sha256 mismatch; refusing resume")
+    from eplus_gym.rl.research_eval import load_sb3_model
+
+    zpath = Path(root) / str(body["model_zip"])
+    model = load_sb3_model(zpath, algo=str(body.get("algo") or "PPO"), contract=body)
+    if str(body.get("algo") or "").upper() == "DQN":
+        replay = Path(root) / str(body.get("replay_buffer") or "replay_buffer.pkl")
+        if not replay.is_file():
+            raise CheckpointError("DQN resume requires replay_buffer.pkl")
+        if hasattr(model, "load_replay_buffer"):
+            model.load_replay_buffer(str(replay))
+    return body, model

--- a/vibe_code_apps_22/eplus_gym/rl/research_eval.py
+++ b/vibe_code_apps_22/eplus_gym/rl/research_eval.py
@@ -1,0 +1,260 @@
+"""Deterministic saved-policy evaluation. Training mean reward cannot crown a winner."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+import numpy as np
+
+from eplus_gym.control_v2 import (
+    SixZoneDailyParamsV2,
+    continuous_params,
+    observed_bas_incumbent_params,
+)
+from eplus_gym.rl.multiday_env import MultiDayDailyEnv
+from eplus_gym.rl.obs_v3 import N_OBS_V3
+from eplus_gym.rl.research_spaces import (
+    RESEARCH_ACTION_CONTRACT_V2,
+    assert_research_v2_contract,
+    decode_continuous_research_v2,
+    decode_discrete_research_v2,
+    encode_continuous_research_v2,
+    sample_random_params_v2,
+)
+
+CLAIM = (
+    "SIMULATION_ONLY_RL_RESEARCH",
+    "A04_RESEARCH_POC_NOT_TRANSIENT_VALIDATED",
+    "RESEARCH_LONG_ALLOWED",
+    "NO_BACNET_COMMAND_AUTHORITY",
+)
+
+
+class PolicyReloadError(ValueError):
+    """Saved SB3 zip could not be loaded under the training contract."""
+
+
+def _shallow() -> SixZoneDailyParamsV2:
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=70.0,
+        unoccupied_heating_f=66.0,
+        heating_setpoint_start_step=30,
+        heating_setpoint_end_step=59,
+        recovery_lead_minutes=60,
+        recovery_ramp_minutes=60,
+    )
+
+
+def load_sb3_model(zip_path: Path, *, algo: str, contract: Mapping[str, Any] | None = None):
+    from stable_baselines3 import DQN, PPO
+
+    if contract is not None:
+        assert_research_v2_contract(contract)
+    algo_u = str(algo).upper()
+    cls = PPO if algo_u == "PPO" else DQN
+    if not Path(zip_path).is_file():
+        raise PolicyReloadError(f"missing SB3 zip {zip_path}")
+    return cls.load(str(zip_path), device="cpu")
+
+
+def make_untrained_models(*, seed: int = 0) -> dict[str, Any]:
+    """Seeded untrained PPO/DQN on the v2 spaces (no EnergyPlus)."""
+    import gymnasium as gym
+    from stable_baselines3 import DQN, PPO
+
+    from eplus_gym.rl.research_spaces import (
+        continuous_action_space_research_v2,
+        discrete_action_space_research_v2,
+    )
+
+    class _Stub(gym.Env):
+        metadata = {"render_modes": []}
+
+        def __init__(self, action_space):
+            super().__init__()
+            self.action_space = action_space
+            self.observation_space = gym.spaces.Box(
+                low=-np.inf, high=np.inf, shape=(N_OBS_V3,), dtype=np.float32
+            )
+
+        def reset(self, *, seed=None, options=None):
+            super().reset(seed=seed)
+            return np.zeros(N_OBS_V3, dtype=np.float32), {}
+
+        def step(self, action):
+            return np.zeros(N_OBS_V3, dtype=np.float32), 0.0, True, False, {}
+
+    ppo = PPO("MlpPolicy", _Stub(continuous_action_space_research_v2()), seed=int(seed), n_steps=8, batch_size=8)
+    dqn = DQN("MlpPolicy", _Stub(discrete_action_space_research_v2()), seed=int(seed), learning_starts=2, buffer_size=64)
+    return {
+        "untrained_ppo": {"model": ppo, "algo": "PPO"},
+        "untrained_dqn": {"model": dqn, "algo": "DQN"},
+    }
+
+
+def predict_params(
+    *,
+    model: Any,
+    obs: np.ndarray,
+    algo: str,
+    day: str,
+    deterministic: bool = True,
+) -> SixZoneDailyParamsV2:
+    obs = np.asarray(obs, dtype=np.float32).reshape(-1)
+    if obs.size != N_OBS_V3:
+        raise PolicyReloadError(f"observation dim {obs.size} != {N_OBS_V3}")
+    action, _ = model.predict(obs, deterministic=bool(deterministic))
+    if str(algo).upper() == "DQN":
+        return decode_discrete_research_v2(int(np.asarray(action).reshape(-1)[0]), day=day)
+    return decode_continuous_research_v2(action, day=day)
+
+
+def _fixed_params(arm: str, day: str, rng: np.random.Generator) -> SixZoneDailyParamsV2:
+    if arm == "incumbent":
+        return observed_bas_incumbent_params()
+    if arm == "continuous_68":
+        return continuous_params(68.0)
+    if arm == "continuous_70":
+        return continuous_params(70.0)
+    if arm == "shallow_setback":
+        return _shallow()
+    if arm == "random":
+        return sample_random_params_v2(rng, day=day)
+    raise KeyError(arm)
+
+
+def evaluate_validation_arms(
+    *,
+    env_factory: Callable[[], MultiDayDailyEnv],
+    days: Sequence[str],
+    models: Mapping[str, Any],
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Run each arm through a fresh env. Candidate/baseline BillingState stay separate inside the env."""
+    rng = np.random.default_rng(int(seed))
+    rows: list[dict[str, Any]] = []
+    models = {**make_untrained_models(seed=int(seed)), **dict(models)}
+    arms = ["incumbent", "continuous_68", "continuous_70", "shallow_setback", "random"]
+    for name, spec in models.items():
+        arms.append(name)
+    for arm in arms:
+        env = env_factory()
+        obs, info = env.reset(seed=int(seed))
+        if int(np.asarray(obs).reshape(-1).size) != N_OBS_V3:
+            raise PolicyReloadError("eval observation is not dim 80")
+        done = False
+        while not done:
+            day = str(info.get("day") or env.days[env._day_i])
+            if arm in models:
+                spec = models[arm]
+                params = predict_params(
+                    model=spec["model"],
+                    obs=obs,
+                    algo=spec["algo"],
+                    day=day,
+                    deterministic=True,
+                )
+            else:
+                params = _fixed_params(arm, day, rng)
+            # Eval env is always the v2 Box(9) decoder path (DQN predicts Discrete then affine-encodes).
+            action = encode_continuous_research_v2(params)
+            obs, reward, terminated, truncated, info = env.step(action)
+            done = bool(terminated or truncated)
+            rows.append(
+                {
+                    "arm": arm,
+                    "day": info.get("day"),
+                    "training_reward": float(reward),
+                    "peak_kw": info.get("peak_kw"),
+                    "daily_kwh": info.get("daily_kwh"),
+                    "readiness_ok": bool((info.get("readiness") or {}).get("readiness_ok")),
+                    "energy_cost": info.get("energy_cost"),
+                    "incremental_demand_cost": info.get("incremental_demand_cost"),
+                    "decoded_schedule_fingerprint": info.get("decoded_schedule_fingerprint"),
+                    "trajectory_sha256": info.get("trajectory_sha256"),
+                    "opening_mtd_kw": info.get("opening_mtd_kw"),
+                    "closing_mtd_kw": info.get("closing_mtd_kw"),
+                    "billing_floor_kw": info.get("billing_floor_kw"),
+                    "seed": int(seed),
+                }
+            )
+        env.close()
+    winner = select_winner(rows)
+    return {
+        "schema": "vibe22.research_long_eval.v1",
+        "claim_labels": list(CLAIM),
+        "action_contract_version": RESEARCH_ACTION_CONTRACT_V2,
+        "observation_dim": N_OBS_V3,
+        "days": [str(d)[:10] for d in days],
+        "rows": rows,
+        "winner": winner,
+        "winner_rule": "deterministic_validation_plus_readiness_multi_seed; never training mean_reward",
+        "SIMULATION_TRAINING_READY": False,
+        "OPERATIONAL_DSM_READY": False,
+        "long_campaign_allowed": False,
+        "locked_unseen": "NO LOCKED UNSEEN TEST AVAILABLE",
+        "bacnet_commands": 0,
+    }
+
+
+def select_winner(rows: Sequence[Mapping[str, Any]]) -> str | None:
+    by_arm: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        by_arm.setdefault(str(row.get("arm")), []).append(row)
+
+    def stats(arm: str) -> tuple[float, float] | None:
+        xs = by_arm.get(arm) or []
+        if not xs:
+            return None
+        rew = float(np.nanmean([float(r.get("training_reward") or 0.0) for r in xs]))
+        ready = float(np.nanmean([1.0 if r.get("readiness_ok") else 0.0 for r in xs]))
+        return rew, ready
+
+    baselines = [
+        "incumbent",
+        "continuous_68",
+        "continuous_70",
+        "shallow_setback",
+        "random",
+        "untrained_ppo",
+        "untrained_dqn",
+    ]
+    present_baselines = [a for a in baselines if a in by_arm]
+    required = ["incumbent", "continuous_68", "continuous_70", "shallow_setback", "random"]
+    if any(a not in by_arm for a in required):
+        return None
+    base_stats = [stats(a) for a in present_baselines]
+    if any(s is None for s in base_stats):
+        return None
+
+    def beats_all(arm: str) -> bool:
+        st = stats(arm)
+        if st is None:
+            return False
+        rew, ready = st
+        return all(rew > (bs[0] + 1e-9) and ready + 1e-9 >= bs[1] for bs in base_stats if bs is not None)
+
+    grouped: dict[str, list[str]] = {}
+    for arm in by_arm:
+        if not str(arm).startswith("trained_"):
+            continue
+        algo = "ppo" if "ppo" in arm else ("dqn" if "dqn" in arm else arm)
+        grouped.setdefault(algo, []).append(arm)
+    qualifying: list[str] = []
+    for _algo, seeds in grouped.items():
+        if len(seeds) < 2:
+            continue
+        if all(beats_all(a) for a in seeds):
+            qualifying.extend(seeds)
+    if not qualifying:
+        return None
+    best_name = None
+    best_rew = float("-inf")
+    for arm in qualifying:
+        st = stats(arm)
+        if st is None:
+            continue
+        if st[0] > best_rew:
+            best_rew = st[0]
+            best_name = arm
+    return best_name

--- a/vibe_code_apps_22/eplus_gym/rl/research_long.py
+++ b/vibe_code_apps_22/eplus_gym/rl/research_long.py
@@ -1,0 +1,561 @@
+"""Labeled A04 research-long campaign. Never sets long_campaign_allowed."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from eplus_gym.a04_identity import A04_IDF_NAME
+from eplus_gym.control_v2 import observed_bas_incumbent_params
+from eplus_gym.date_use_ledger import NO_LOCKED_UNSEEN
+from eplus_gym.rl.campaign_bundle import forecasts_from_epw
+from eplus_gym.rl.campaign_preflight import dates_are_contiguous
+from eplus_gym.rl.continuity_plant import EnergyPlusContinuityPlant
+from eplus_gym.rl.day_pool import unique_dates_from_epw
+from eplus_gym.rl.multiday_env import (
+    MultiDayDailyEnv,
+    schedule_fingerprint,
+    trajectory_hash,
+)
+from eplus_gym.rl.obs_v3 import N_OBS_V3, PERFECT_EPISODE_FORECAST
+from eplus_gym.rl.research_checkpoint import rng_hex, write_block_checkpoint
+from eplus_gym.rl.research_eval import evaluate_validation_arms, load_sb3_model
+from eplus_gym.rl.research_model import ResearchModelError, verify_research_model
+from eplus_gym.rl.research_poc import refuse_fake_plant, reject_candidate_as_baseline
+from eplus_gym.rl.research_spaces import (
+    RESEARCH_ACTION_CONTRACT_V2,
+    decode_continuous_research_v2,
+    research_build_six_schedules_f,
+    research_continuous_70,
+)
+from eplus_gym.rl.split_manifest import TRAIN_END, VAL_END, assert_train_fold_only
+from eplus_gym.rl.train_sb3 import make_env, train_sb3
+from eplus_gym.site_pins import resolve_site_epw, sha256_file
+
+CLAIM_LABELS = (
+    "SIMULATION_ONLY_RL_RESEARCH",
+    "A04_RESEARCH_POC_NOT_TRANSIENT_VALIDATED",
+    "RESEARCH_LONG_ALLOWED",
+    "NO_BACNET_COMMAND_AUTHORITY",
+)
+TRAIN_START = date(2025, 11, 1)
+VAL_START = date(2025, 12, 15)
+BLOCK_SIZE = 7
+TARGET_TRANSITIONS = 8192
+MAX_WALL_HOURS = 30.0
+
+
+class ResearchLongError(ValueError):
+    """research-long refused."""
+
+
+def _locked_flags() -> dict[str, Any]:
+    return {
+        "claim_labels": list(CLAIM_LABELS),
+        "SIMULATION_TRAINING_READY": False,
+        "OPERATIONAL_DSM_READY": False,
+        "long_campaign_allowed": False,
+        "RESEARCH_LONG_ALLOWED": True,
+        "bacnet_commands": 0,
+        "locked_unseen": NO_LOCKED_UNSEEN,
+        "action_contract_version": RESEARCH_ACTION_CONTRACT_V2,
+        "observation_dim": N_OBS_V3,
+        "observation_contract": "vibe22.obs.v3",
+    }
+
+
+def freeze_research_long_days(epw: Path) -> dict[str, Any]:
+    dates = unique_dates_from_epw(Path(epw))
+    train = [d.isoformat() for d in dates if TRAIN_START <= d <= TRAIN_END]
+    val = [d.isoformat() for d in dates if VAL_START <= d <= VAL_END]
+    if any(date.fromisoformat(x).year == 2026 and date.fromisoformat(x).month == 1 for x in train):
+        raise ResearchLongError("January 2026 must not enter the research-long train pool")
+    assert_train_fold_only(train)
+    return {
+        "train": train,
+        "validation": val,
+        "train_contiguous": dates_are_contiguous(train) if len(train) > 1 else bool(train),
+        "validation_contiguous": dates_are_contiguous(val) if len(val) > 1 else bool(val),
+        "locked_unseen": NO_LOCKED_UNSEEN,
+        "epw": str(epw),
+    }
+
+
+def write_heartbeat(path: Path, body: Mapping[str, Any]) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        **_locked_flags(),
+        "pid": os.getpid(),
+        "contaminated": False,
+        **dict(body),
+        "heartbeat_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _payload_baseline(
+    *,
+    day: str,
+    payload: Mapping[str, Any],
+    idf_sha: str,
+    epw_sha: str,
+    lookback_fp: str,
+    baseline_fp: str,
+    days: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "day": day,
+        "idf_sha256": idf_sha,
+        "epw_sha256": epw_sha,
+        "energyplus_version": "26.1.0",
+        "run_period": f"{days[0]}:{days[-1]}",
+        "lookback_schedule_fingerprint": lookback_fp,
+        "baseline_schedule_fingerprint": baseline_fp,
+        "initial_state_id": "lookback_continuous_70",
+        "trajectory_hash": trajectory_hash(payload),
+        "n_intervals": int(payload.get("n_intervals") or 96),
+        "facility_kw": list(payload["facility_kw"]),
+        "zone_temps_series_f": payload["zone_temps_series_f"],
+        "live_energyplus": True,
+    }
+
+
+def cache_incumbent_payloads(
+    *,
+    site: Path,
+    epw: Path,
+    idf: Path,
+    output: Path,
+    days: Sequence[str],
+    oat: Mapping[str, Sequence[float]],
+    idf_sha: str,
+    epw_sha: str,
+) -> dict[str, Any]:
+    days = [str(d)[:10] for d in days]
+    plant = EnergyPlusContinuityPlant(
+        site_root=site, epw=epw, idf=idf, output=output, days=list(days), queue_timeout_s=600.0
+    )
+    refuse_fake_plant(plant)
+    plant.start_episode()
+    incumbent = observed_bas_incumbent_params()
+    lookback_fp = schedule_fingerprint(research_build_six_schedules_f(research_continuous_70(), days[0]))
+    baseline_fp = schedule_fingerprint(research_build_six_schedules_f(incumbent, days[0]))
+    out: dict[str, dict[str, Any]] = {}
+    for day in days:
+        sched = research_build_six_schedules_f(incumbent, day)
+        payload = plant.simulate_day(sched, oat_c=list(oat[day]))
+        reject_candidate_as_baseline(
+            {"sha": trajectory_hash(payload) + "-cand"},
+            {"sha": trajectory_hash(payload)},
+        )
+        out[day] = _payload_baseline(
+            day=day,
+            payload=payload,
+            idf_sha=idf_sha,
+            epw_sha=epw_sha,
+            lookback_fp=lookback_fp,
+            baseline_fp=baseline_fp,
+            days=days,
+        )
+    quality = plant.finish_quality()
+    return {"payloads": out, "quality": quality, "lookback_fp": lookback_fp, "baseline_fp": baseline_fp}
+
+
+def _env_cfg(
+    *,
+    site: Path,
+    epw: Path,
+    idf: Path,
+    days: Sequence[str],
+    oat: Mapping[str, Sequence[float]],
+    payloads: Mapping[str, Mapping[str, Any]],
+    idf_sha: str,
+    epw_sha: str,
+    output: Path,
+    algo: str,
+    block_size: int,
+    persist_billing: bool,
+) -> dict[str, Any]:
+    first = next(iter(payloads.values())) if payloads else {}
+    return {
+        "site_root": str(site),
+        "epw": str(epw),
+        "champion_idf": str(idf),
+        "idf": str(idf),
+        "days": [str(d)[:10] for d in days],
+        "n_days": len(days),
+        "start_day": str(days[0])[:10],
+        "action_kind": "discrete" if str(algo).upper() == "DQN" else "continuous",
+        "action_contract_version": RESEARCH_ACTION_CONTRACT_V2,
+        "hourly_oat": {k: list(v) for k, v in oat.items()},
+        "forecast_source": PERFECT_EPISODE_FORECAST,
+        "baseline_payloads": dict(payloads),
+        "idf_sha256": idf_sha,
+        "epw_sha256": epw_sha,
+        "energyplus_version": "26.1.0",
+        "model_id": "A04_RESEARCH_POC_NOT_TRANSIENT_VALIDATED",
+        "weather_id": Path(epw).name,
+        "require_live_energyplus": True,
+        "require_baseline": True,
+        "write_policy_pack": False,
+        "save_replay_buffer": True,
+        "block_size": int(block_size),
+        "persist_billing": bool(persist_billing),
+        "output_root": str(output),
+        "lookback_schedule_fingerprint": first.get("lookback_schedule_fingerprint") or "",
+        "baseline_schedule_fingerprint": first.get("baseline_schedule_fingerprint") or "",
+    }
+
+
+def run_research_long(
+    *,
+    app_root: Path,
+    site_root: Path,
+    confirm_simulation_only_physics_limits: bool,
+    confirm_a04_not_transient_validated: bool,
+    max_wall_hours: float = MAX_WALL_HOURS,
+    micro_gate: bool = False,
+    execute_live: bool = False,
+    heartbeat_path: Path | None = None,
+    seed: int = 0,
+) -> dict[str, Any]:
+    if not confirm_simulation_only_physics_limits or not confirm_a04_not_transient_validated:
+        raise ResearchLongError(
+            "missing --confirm-simulation-only-physics-limits and/or --confirm-a04-not-transient-validated"
+        )
+    if float(max_wall_hours) > MAX_WALL_HOURS + 1e-9:
+        raise ResearchLongError("research-long wall clock cap is 30 hours")
+    manifest = verify_research_model(app_root)
+    if manifest.get("long_campaign_allowed") is True:
+        raise ResearchModelError("research contract must not set long_campaign_allowed=true")
+    flags = _locked_flags()
+    if not execute_live and not micro_gate:
+        return {
+            "command": "research-long",
+            "allowed": True,
+            **flags,
+            "max_wall_hours": float(max_wall_hours),
+            "model_id": manifest.get("model_id"),
+        }
+
+    idf = Path(app_root) / str(manifest.get("idf_path") or f"models/eplus/{A04_IDF_NAME}")
+    try:
+        epw = resolve_site_epw(Path(site_root))
+    except FileNotFoundError as exc:
+        raise ResearchLongError(str(exc)) from exc
+    idf_sha = sha256_file(idf)
+    epw_sha = sha256_file(epw)
+    pool = freeze_research_long_days(epw)
+    train_days = list(pool["train"])
+    val_days = list(pool["validation"])
+    if micro_gate:
+        train_days = train_days[:2]
+        val_days = val_days[:2] if val_days else train_days[:2]
+        target = 8
+        seeds = [int(seed)]
+        wall = min(float(max_wall_hours), 2.0)
+        block_size = min(BLOCK_SIZE, max(1, len(train_days)))
+    else:
+        target = TARGET_TRANSITIONS
+        seeds = [int(seed), int(seed) + 1]
+        wall = float(max_wall_hours)
+        block_size = BLOCK_SIZE
+    if len(train_days) < 2:
+        raise ResearchLongError("need at least two train days in EPW coverage")
+    oat = forecasts_from_epw(epw, train_days + val_days)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_root = Path(site_root) / "reports" / "eplus_gym" / "rl" / f"research_long_{stamp}"
+    out_root.mkdir(parents=True, exist_ok=True)
+    hb = Path(heartbeat_path) if heartbeat_path is not None else out_root / "heartbeat.json"
+    write_heartbeat(
+        hb,
+        {
+            "command": "research-long",
+            "phase": "start",
+            "pid": None,
+            "idf_sha256": idf_sha,
+            "epw_sha256": epw_sha,
+            "target_transitions": int(target),
+            "current_algo": None,
+            "current_seed": None,
+            "valid_transitions": 0,
+            "failures": [],
+            "latest_checkpoint": None,
+            "run_root": str(out_root),
+            "train_days": train_days,
+            "validation_days": val_days,
+            "micro_gate": bool(micro_gate),
+        },
+    )
+    cache = cache_incumbent_payloads(
+        site=Path(site_root),
+        epw=epw,
+        idf=idf,
+        output=out_root / "incumbent_cache",
+        days=train_days,
+        oat=oat,
+        idf_sha=idf_sha,
+        epw_sha=epw_sha,
+    )
+    val_cache = cache_incumbent_payloads(
+        site=Path(site_root),
+        epw=epw,
+        idf=idf,
+        output=out_root / "val_incumbent_cache",
+        days=val_days,
+        oat=oat,
+        idf_sha=idf_sha,
+        epw_sha=epw_sha,
+    )
+    deadline = time.monotonic() + float(wall) * 3600.0
+    results: dict[str, Any] = {}
+    failures: list[str] = []
+    t0 = time.monotonic()
+    algos = ("PPO", "DQN")
+    for algo in algos:
+        for sd in seeds:
+            if time.monotonic() >= deadline:
+                results[f"{algo}_{sd}"] = {"skipped": True, "reason": "wall_clock"}
+                continue
+            sub = out_root / f"{algo.lower()}_seed{sd}"
+            sub.mkdir(parents=True, exist_ok=True)
+            extra = _env_cfg(
+                site=Path(site_root),
+                epw=epw,
+                idf=idf,
+                days=train_days,
+                oat=oat,
+                payloads=cache["payloads"],
+                idf_sha=idf_sha,
+                epw_sha=epw_sha,
+                output=sub / "eplus",
+                algo=algo,
+                block_size=block_size,
+                persist_billing=True,
+            )
+
+            from stable_baselines3.common.callbacks import BaseCallback
+
+            class _BlockCb(BaseCallback):
+                def __init__(self):
+                    super().__init__()
+                    self.valid = 0
+
+                def _on_step(self) -> bool:
+                    infos = self.locals.get("infos") or []
+                    dones = self.locals.get("dones")
+                    for info in infos:
+                        if not isinstance(info, dict):
+                            continue
+                        if info.get("learnable") and not info.get("failed"):
+                            self.valid += 1
+                            write_heartbeat(
+                                hb,
+                                {
+                                    "command": "research-long",
+                                    "phase": "train",
+                                    "idf_sha256": idf_sha,
+                                    "epw_sha256": epw_sha,
+                                    "target_transitions": int(target),
+                                    "current_algo": algo,
+                                    "current_seed": int(sd),
+                                    "valid_transitions": int(self.valid),
+                                    "failures": list(failures),
+                                    "latest_checkpoint": str(sub / "checkpoints" / "checkpoint.json"),
+                                    "run_root": str(out_root),
+                                    "day": info.get("day"),
+                                },
+                            )
+                            if self.valid >= int(target):
+                                return False
+                        if info.get("failed"):
+                            failures.append(str(info.get("day")))
+                    if dones is not None and np.any(dones) and self.model is not None:
+                        write_block_checkpoint(
+                            root=sub / "checkpoints",
+                            model=self.model,
+                            algo=algo,
+                            seed=int(sd),
+                            valid_transition_count=self.valid,
+                            block_id=str((infos[0] or {}).get("block_id") if infos else ""),
+                            day=str((infos[0] or {}).get("day") if infos else ""),
+                            idf_sha256=idf_sha,
+                            epw_sha256=epw_sha,
+                            rng_hex=rng_hex(
+                                seed=int(sd), idf_sha256=idf_sha, epw_sha256=epw_sha, algo=algo
+                            ),
+                        )
+                    if time.monotonic() >= deadline:
+                        return False
+                    return True
+
+            try:
+                summary = train_sb3(
+                    site_root=Path(site_root),
+                    epw=epw,
+                    champion_idf=idf,
+                    days=train_days,
+                    algo=algo,
+                    timesteps=int(target),
+                    run_root=sub,
+                    seed=int(sd),
+                    reward_name="reward_v2",
+                    sb3_config="research_long",
+                    extra_env_cfg=extra,
+                    extra_callback=_BlockCb(),
+                )
+                results[f"{algo}_{sd}"] = summary
+            except Exception as exc:  # noqa: BLE001
+                failures.append(f"{algo}_{sd}:{exc}")
+                results[f"{algo}_{sd}"] = {"failed": True, "reason": str(exc), "algo": algo, "seed": sd}
+
+    models: dict[str, Any] = {}
+    for algo in algos:
+        for sd in seeds:
+            zpath = out_root / f"{algo.lower()}_seed{sd}" / "models" / f"{algo.lower()}_final.zip"
+            if zpath.is_file():
+                models[f"trained_{algo.lower()}_seed{sd}"] = {
+                    "model": load_sb3_model(
+                        zpath,
+                        algo=algo,
+                        contract={"action_contract_version": RESEARCH_ACTION_CONTRACT_V2},
+                    ),
+                    "algo": algo,
+                }
+
+    eval_out: dict[str, Any] | None = None
+    if models and val_days:
+
+        def _factory() -> MultiDayDailyEnv:
+            cfg = _env_cfg(
+                site=Path(site_root),
+                epw=epw,
+                idf=idf,
+                days=val_days,
+                oat=oat,
+                payloads=val_cache["payloads"],
+                idf_sha=idf_sha,
+                epw_sha=epw_sha,
+                output=out_root / "eval_eplus" / str(time.time_ns()),
+                algo="PPO",
+                block_size=0,
+                persist_billing=True,
+            )
+            return make_env(cfg)
+
+        try:
+            eval_out = evaluate_validation_arms(
+                env_factory=_factory,
+                days=val_days,
+                models=models,
+                seed=int(seed),
+            )
+            (out_root / "eval.json").write_text(
+                json.dumps(eval_out, indent=2, default=str) + "\n", encoding="utf-8"
+            )
+            from eplus_gym.rl.plots import plot_paired_val_delta, plot_validation_arm_bars
+
+            plots_dir = out_root / "plots"
+            plot_validation_arm_bars(eval_out.get("rows") or [], plots_dir)
+            plot_paired_val_delta(eval_out.get("rows") or [], plots_dir)
+        except Exception as exc:  # noqa: BLE001
+            failures.append(f"eval:{exc}")
+            eval_out = {"failed": True, "reason": str(exc), "winner": None}
+
+    severe = int((cache.get("quality") or {}).get("severe_count") or 0) + int(
+        (val_cache.get("quality") or {}).get("severe_count") or 0
+    )
+    fatal = int((cache.get("quality") or {}).get("fatal_count") or 0) + int(
+        (val_cache.get("quality") or {}).get("fatal_count") or 0
+    )
+    summary = {
+        "command": "research-long",
+        "schema": "vibe22.research_long.v1",
+        **flags,
+        "micro_gate": bool(micro_gate),
+        "model_id": manifest.get("model_id"),
+        "idf_sha256": idf_sha,
+        "epw_sha256": epw_sha,
+        "train_days": train_days,
+        "validation_days": val_days,
+        "target_transitions": int(target),
+        "results": results,
+        "eval": eval_out,
+        "w2a": {"incumbent_train": cache.get("quality"), "incumbent_val": val_cache.get("quality")},
+        "energyplus_severe": severe,
+        "energyplus_fatal": fatal,
+        "failures": failures,
+        "run_root": str(out_root),
+        "heartbeat": str(hb),
+        "elapsed_s": time.monotonic() - t0,
+        "heating_only": True,
+        "cooling_action_space": False,
+        "cooling_note": "LIVE Gym actuates six heating DualSP schedules only; A04 SCH_ClgSP remains ~74/85 F.",
+    }
+    if micro_gate:
+        _assert_micro_gate(summary, results, models, cache)
+    (out_root / "campaign_manifest.json").write_text(
+        json.dumps(summary, indent=2, default=str) + "\n", encoding="utf-8"
+    )
+    write_heartbeat(
+        hb,
+        {
+            "command": "research-long",
+            "phase": "done",
+            "idf_sha256": idf_sha,
+            "epw_sha256": epw_sha,
+            "target_transitions": int(target),
+            "valid_transitions": max(
+                (int(v.get("n_episodes_logged") or 0) for v in results.values() if isinstance(v, dict)),
+                default=0,
+            ),
+            "failures": failures,
+            "run_root": str(out_root),
+        },
+    )
+    return summary
+
+
+def _assert_micro_gate(
+    summary: Mapping[str, Any],
+    results: Mapping[str, Any],
+    models: Mapping[str, Any],
+    cache: Mapping[str, Any],
+) -> None:
+    ppo = results.get("PPO_0") or {}
+    dqn = results.get("DQN_0") or {}
+    if int(ppo.get("n_episodes_logged") or 0) < 8:
+        raise ResearchLongError("micro-gate: PPO needs >=8 valid transitions")
+    if int(dqn.get("n_episodes_logged") or 0) < 8:
+        raise ResearchLongError("micro-gate: DQN needs >=8 valid transitions")
+    if not models:
+        raise ResearchLongError("micro-gate: saved-policy reload failed")
+    if int(summary.get("energyplus_severe") or 0) or int(summary.get("energyplus_fatal") or 0):
+        raise ResearchLongError("micro-gate: EnergyPlus severe/fatal is not zero")
+    if not cache.get("payloads"):
+        raise ResearchLongError("micro-gate: paired baseline missing")
+    for day, payload in (cache.get("payloads") or {}).items():
+        if int(payload.get("n_intervals") or 0) != 96:
+            raise ResearchLongError(f"micro-gate: {day} does not have 96 scored intervals")
+    if ppo.get("policy_pack"):
+        raise ResearchLongError("micro-gate: refused dishonest daily_policy.pkl")
+    jsonl = Path(str(ppo.get("model") or "")).parent.parent / "episodes.jsonl"
+    if jsonl.is_file():
+        occs = []
+        for line in jsonl.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            act = row.get("action")
+            if act is None:
+                continue
+            params = decode_continuous_research_v2(act, day=str(row.get("day") or "2025-12-08"))
+            occs.append(params.occupied_heating_f)
+        if occs and all(abs(x - 68.0) < 0.05 for x in occs):
+            raise ResearchLongError("micro-gate: PPO actions collapsed to occupied=68")

--- a/vibe_code_apps_22/eplus_gym/rl/research_spaces.py
+++ b/vibe_code_apps_22/eplus_gym/rl/research_spaces.py
@@ -10,6 +10,7 @@ from eplus_gym.control_v2 import (
     ACTION_KEYS,
     SixZoneDailyParamsV2,
     ZoneOffsetsV2,
+    build_six_schedules_f,
     continuous_params,
     school_windows,
 )
@@ -131,6 +132,210 @@ def decode_discrete_research(index: int, *, day: str) -> SixZoneDailyParamsV2:
         unoccupied_heating_f=params.unoccupied_heating_f,
         heating_setpoint_start_step=frozen["heating_setpoint_start_step"],
         heating_setpoint_end_step=frozen["heating_setpoint_end_step"],
+        recovery_lead_minutes=params.recovery_lead_minutes,
+        recovery_ramp_minutes=params.recovery_lead_minutes,
+        zone_offsets=params.zone_offsets,
+    )
+
+
+# --- research_action_contract_v2 (normalized PPO). Do not reinterpret v1. ---
+
+RESEARCH_ACTION_CONTRACT_V2 = "research_action_contract_v2"
+DECODER_VERSION_V2 = "research_affine_v2"
+N_CONT_V2 = 3 + len(ACTION_KEYS)
+OCC_F_LO_V2, OCC_F_HI_V2 = 68.0, 72.0
+UNOCC_F_FLOOR_V2 = 60.0
+REC_LO_V2, REC_HI_V2 = 0.0, 180.0
+OFFSET_LO_V2, OFFSET_HI_V2 = -1.0, 1.0
+CLG_OCC_F = 74.0
+CLG_UNOCC_F = 85.0
+HTG_CLG_DEADBAND_F = 2.0
+
+DQN_V2_UNOCC = (60.0, 64.0, 66.0)
+DQN_V2_REC = (0, 60, 120, 180)
+DQN_V2_OFFSET = (-1.0, 0.0, 1.0)
+
+
+class ActionContractMismatch(ValueError):
+    """Saved policy action contract does not match research_action_contract_v2."""
+
+
+def assert_research_v2_contract(meta: dict | object) -> None:
+    body = meta if isinstance(meta, dict) else {}
+    got = str(body.get("action_contract_version") or "")
+    if got != RESEARCH_ACTION_CONTRACT_V2:
+        raise ActionContractMismatch(
+            f"refusing to load action contract {got!r}; expected {RESEARCH_ACTION_CONTRACT_V2}"
+        )
+
+
+def _affine(x: float, lo: float, hi: float) -> float:
+    x = _clip(float(x), -1.0, 1.0)
+    return float(lo + (x + 1.0) * 0.5 * (float(hi) - float(lo)))
+
+
+def _inv_affine(y: float, lo: float, hi: float) -> float:
+    span = float(hi) - float(lo)
+    if span <= 1e-9:
+        return 1.0
+    return _clip(2.0 * (float(y) - float(lo)) / span - 1.0, -1.0, 1.0)
+
+
+def continuous_action_space_research_v2() -> gym.spaces.Box:
+    return gym.spaces.Box(low=-1.0, high=1.0, shape=(N_CONT_V2,), dtype=np.float32)
+
+
+def frozen_school_occupancy_v2(day: str) -> dict[str, int] | None:
+    win = school_windows(day)
+    start = win.get("school_occupied_start_step")
+    end = win.get("school_occupied_end_step")
+    if start is None or end is None:
+        return None
+    return {
+        "heating_setpoint_start_step": int(start),
+        "heating_setpoint_end_step": int(end),
+    }
+
+
+def decode_continuous_research_v2(
+    action: Sequence[float] | np.ndarray,
+    *,
+    day: str,
+) -> SixZoneDailyParamsV2:
+    a = np.asarray(action, dtype=np.float64).reshape(-1)
+    if a.size != N_CONT_V2:
+        raise ValueError(f"expected research v2 action len {N_CONT_V2}, got {a.size}")
+    occ = _affine(float(a[0]), OCC_F_LO_V2, OCC_F_HI_V2)
+    unocc = _affine(float(a[1]), UNOCC_F_FLOOR_V2, occ)
+    rec = int(round(_affine(float(a[2]), REC_LO_V2, REC_HI_V2) / 15.0) * 15)
+    rec = int(min(REC_HI_V2, max(REC_LO_V2, rec)))
+    zo: dict[str, ZoneOffsetsV2] = {}
+    for i, key in enumerate(ACTION_KEYS):
+        raw = _affine(float(a[3 + i]), OFFSET_LO_V2, OFFSET_HI_V2)
+        eff = _clip(unocc + raw, UNOCC_F_FLOOR_V2, occ)
+        zo[key] = ZoneOffsetsV2(setback_offset_f=float(eff - unocc))
+    frozen = frozen_school_occupancy_v2(day)
+    if abs(occ - unocc) < 1e-6:
+        return continuous_params(occ)
+    # Do not invent school start=30/end=59 on weekends/holidays.
+    if frozen is None:
+        start, end = 0, 0
+    else:
+        start = frozen["heating_setpoint_start_step"]
+        end = frozen["heating_setpoint_end_step"]
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=occ,
+        unoccupied_heating_f=unocc,
+        heating_setpoint_start_step=int(start),
+        heating_setpoint_end_step=int(end),
+        recovery_lead_minutes=rec,
+        recovery_ramp_minutes=rec,
+        zone_offsets=zo,
+    )
+
+
+def encode_continuous_research_v2(params: SixZoneDailyParamsV2) -> np.ndarray:
+    occ = float(params.occupied_heating_f)
+    unocc = float(params.unoccupied_heating_f)
+    rec = float(params.recovery_lead_minutes)
+    x0 = _inv_affine(occ, OCC_F_LO_V2, OCC_F_HI_V2)
+    x1 = _inv_affine(unocc, UNOCC_F_FLOOR_V2, occ)
+    x2 = _inv_affine(rec, REC_LO_V2, REC_HI_V2)
+    offs = []
+    for key in ACTION_KEYS:
+        raw = float(params.zone_offsets[key].setback_offset_f)
+        offs.append(_inv_affine(raw, OFFSET_LO_V2, OFFSET_HI_V2))
+    return np.asarray([x0, x1, x2, *offs], dtype=np.float32)
+
+
+def _effective_unocc(params: SixZoneDailyParamsV2, key: str) -> float:
+    off = float(params.zone_offsets[key].setback_offset_f)
+    return _clip(float(params.unoccupied_heating_f) + off, UNOCC_F_FLOOR_V2, float(params.occupied_heating_f))
+
+
+def _clamp_htg_clg(series: list[float], *, day: str) -> list[float]:
+    win = school_windows(day)
+    start = win.get("school_occupied_start_step")
+    end = win.get("school_occupied_end_step")
+    out = []
+    for t, val in enumerate(series):
+        occupied = start is not None and end is not None and int(start) <= t < int(end)
+        clg = CLG_OCC_F if occupied else CLG_UNOCC_F
+        out.append(min(float(val), clg - HTG_CLG_DEADBAND_F))
+    return out
+
+
+def research_build_six_schedules_f(params: SixZoneDailyParamsV2, day: str) -> dict[str, list[float]]:
+    win = school_windows(day)
+    if params.continuous_conditioning or win.get("school_occupied"):
+        raw = build_six_schedules_f(params)
+    else:
+        raw = {k: [_effective_unocc(params, k)] * 96 for k in ACTION_KEYS}
+    return {k: _clamp_htg_clg(list(raw[k]), day=day) for k in ACTION_KEYS}
+
+
+def _raw_discrete_v2() -> list[SixZoneDailyParamsV2]:
+    out = [research_continuous_68(), research_continuous_70()]
+    frozen = frozen_school_occupancy_v2("2025-12-08") or {
+        "heating_setpoint_start_step": 30,
+        "heating_setpoint_end_step": 59,
+    }
+    for unocc in DQN_V2_UNOCC:
+        for rec in DQN_V2_REC:
+            for off in DQN_V2_OFFSET:
+                zo = {k: ZoneOffsetsV2(setback_offset_f=float(off)) for k in ACTION_KEYS}
+                out.append(
+                    SixZoneDailyParamsV2(
+                        occupied_heating_f=70.0,
+                        unoccupied_heating_f=float(unocc),
+                        heating_setpoint_start_step=frozen["heating_setpoint_start_step"],
+                        heating_setpoint_end_step=frozen["heating_setpoint_end_step"],
+                        recovery_lead_minutes=int(rec),
+                        recovery_ramp_minutes=int(rec),
+                        zone_offsets=zo,
+                    )
+                )
+    return out
+
+
+def sample_random_params_v2(
+    rng: np.random.Generator | None = None,
+    *,
+    day: str,
+) -> SixZoneDailyParamsV2:
+    r = rng or np.random.default_rng()
+    x = r.uniform(-1.0, 1.0, size=N_CONT_V2).astype(np.float32)
+    return decode_continuous_research_v2(x, day=day)
+
+
+def discrete_n_research_v2() -> int:
+    return len(_raw_discrete_v2())
+
+
+def discrete_action_space_research_v2() -> gym.spaces.Discrete:
+    return gym.spaces.Discrete(discrete_n_research_v2())
+
+
+def decode_discrete_research_v2(index: int, *, day: str) -> SixZoneDailyParamsV2:
+    table = _raw_discrete_v2()
+    n = len(table)
+    idx = int(index)
+    if idx < 0 or idx >= n:
+        raise ValueError(f"DQN research v2 index {idx} wrap is forbidden; valid range [0, {n})")
+    params = table[idx]
+    if params.continuous_conditioning:
+        return params
+    frozen = frozen_school_occupancy_v2(day)
+    if frozen is None:
+        start, end = 0, 0
+    else:
+        start = frozen["heating_setpoint_start_step"]
+        end = frozen["heating_setpoint_end_step"]
+    return SixZoneDailyParamsV2(
+        occupied_heating_f=params.occupied_heating_f,
+        unoccupied_heating_f=params.unoccupied_heating_f,
+        heating_setpoint_start_step=int(start),
+        heating_setpoint_end_step=int(end),
         recovery_lead_minutes=params.recovery_lead_minutes,
         recovery_ramp_minutes=params.recovery_lead_minutes,
         zone_offsets=params.zone_offsets,

--- a/vibe_code_apps_22/eplus_gym/rl/sb3_configs.py
+++ b/vibe_code_apps_22/eplus_gym/rl/sb3_configs.py
@@ -57,9 +57,34 @@ RESEARCH_POC: dict[str, Any] = {
 }
 
 
+RESEARCH_LONG: dict[str, Any] = {
+    "name": "research_long",
+    "label": "SIMULATION_ONLY_RL_RESEARCH",
+    "ppo": {"n_steps": 7, "batch_size": 7},
+    "dqn": {
+        "learning_starts": 14,
+        "buffer_size": 20_000,
+        "exploration_fraction": 0.2,
+        "target_update_interval": 50,
+    },
+    "timesteps": None,
+    "max_wall_hours": 30,
+    "block_size": 7,
+    "valid_transitions_target": 8192,
+}
+
+
 def named_config(name: str) -> dict[str, Any]:
     key = str(name).strip().lower()
-    table = {"smoke": SMOKE, "pilot": PILOT, "long_poc": LONG_POC, "research_poc": RESEARCH_POC}
+    table = {
+        "smoke": SMOKE,
+        "pilot": PILOT,
+        "long_poc": LONG_POC,
+        "research_poc": RESEARCH_POC,
+        "research_long": RESEARCH_LONG,
+    }
     if key not in table:
-        raise ValueError(f"unknown sb3 config {name!r}; expected smoke|pilot|long_poc|research_poc")
+        raise ValueError(
+            f"unknown sb3 config {name!r}; expected smoke|pilot|long_poc|research_poc|research_long"
+        )
     return dict(table[key])

--- a/vibe_code_apps_22/eplus_gym/rl/train_sb3.py
+++ b/vibe_code_apps_22/eplus_gym/rl/train_sb3.py
@@ -19,6 +19,15 @@ from eplus_gym.rl.split_manifest import assert_train_fold_only
 campaign_env_class = MultiDayDailyEnv
 
 
+def should_write_policy_pack(cfg: Dict[str, Any] | None) -> bool:
+    """Research contracts must not emit a dishonest obs-v2 / dim-19 daily_policy.pkl."""
+    body = dict(cfg or {})
+    contract = str(body.get("action_contract_version") or "")
+    if contract.startswith("research_action_contract"):
+        return False
+    return bool(body.get("write_policy_pack", True))
+
+
 def _new_run_id(prefix: str = "rl") -> str:
     return f"{prefix}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
 
@@ -67,6 +76,7 @@ def train_sb3(
     reward_name: str = "reward_v2",
     sb3_config: str = "smoke",
     extra_env_cfg: Dict[str, Any] | None = None,
+    extra_callback: Any | None = None,
 ) -> Dict[str, Any]:
     try:
         from stable_baselines3 import DQN, PPO
@@ -188,9 +198,19 @@ def train_sb3(
                 )
             return True
 
-    model.learn(total_timesteps=max(2, int(cfg_named.get("timesteps") or timesteps)), callback=LogCallback())
+    cb: Any = LogCallback()
+    if extra_callback is not None:
+        from stable_baselines3.common.callbacks import CallbackList
+
+        cb = CallbackList([LogCallback(), extra_callback])
+    model.learn(total_timesteps=max(2, int(cfg_named.get("timesteps") or timesteps)), callback=cb)
     model_path = models_dir / f"{algo_u.lower()}_final.zip"
     model.save(str(model_path))
+    if algo_u == "DQN" and (
+        str(cfg.get("action_contract_version") or "").startswith("research_action_contract")
+        or bool(cfg.get("save_replay_buffer"))
+    ):
+        model.save_replay_buffer(str(models_dir / "replay_buffer.pkl"))
 
     with (run_root / "episodes.jsonl").open("w", encoding="utf-8") as f:
         for row in episode_log:
@@ -199,7 +219,7 @@ def train_sb3(
     plot_learning_curve(
         rewards or [float("nan")],
         plots_dir,
-        title=f"{algo_u} LIVE learning curve",
+        title=f"{algo_u} LIVE learning curve TRAINING ONLY",
         filename=f"{algo_u.lower()}_learning_curve.png",
     )
     peaks = [r["peak_kw"] for r in episode_log if isinstance(r.get("peak_kw"), (int, float))]
@@ -217,16 +237,25 @@ def train_sb3(
         "sb3_config": cfg_named.get("name"),
         "label": "PRELIMINARY_SINGLE_SEED",
         "not_pure_algorithm_comparison": True,
+        "winner_rule": "not_mean_training_reward",
     }
-    (run_root / "train_summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
-    pack = pack_from_sb3_zip(
-        model_path,
-        algo=algo_u,
-        meta={"run_root": str(run_root), "days": list(days), "timesteps": int(timesteps)},
-    )
-    pack_path = models_dir / "daily_policy.pkl"
-    pack.save(pack_path)
-    summary["policy_pack"] = str(pack_path)
+    contract = str(cfg.get("action_contract_version") or "")
+    write_pack = should_write_policy_pack(cfg)
+    if write_pack:
+        pack = pack_from_sb3_zip(
+            model_path,
+            algo=algo_u,
+            meta={"run_root": str(run_root), "days": list(days), "timesteps": int(timesteps)},
+        )
+        pack_path = models_dir / "daily_policy.pkl"
+        pack.save(pack_path)
+        summary["policy_pack"] = str(pack_path)
+    else:
+        summary["policy_pack"] = None
+        summary["policy_pack_skipped"] = "research_sb3_zip_canonical"
+        summary["observation_contract"] = "vibe22.obs.v3"
+        summary["observation_dim"] = 80
+        summary["action_contract_version"] = contract or None
     (run_root / "train_summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
     env.close()
     return summary

--- a/vibe_code_apps_22/scripts/README.md
+++ b/vibe_code_apps_22/scripts/README.md
@@ -2,7 +2,7 @@
 
 | Script | Role |
 | --- | --- |
-| `vibe22_rl.py` | LIVE SB3 campaign / train / bakeoff / report |
+| `vibe22_rl.py` | LIVE SB3 campaign / train / bakeoff / report; `research-poc` and `research-long` are labeled research CLIs, not `campaign` |
 | `gate_six_zone_actuation.py` | Six DualSP gate on A04 copy |
 
 Non-RL CLIs: `archive/2026-08-14_pre_rl_only/scripts/`.

--- a/vibe_code_apps_22/scripts/vibe22_rl.py
+++ b/vibe_code_apps_22/scripts/vibe22_rl.py
@@ -284,6 +284,51 @@ def cmd_operator_pay_experiment(args) -> int:
     return int(out.get("exit_code") or EXIT_OK)
 
 
+def cmd_research_long(args) -> int:
+    """Labeled research-long. Cannot enable campaign or long_campaign_allowed."""
+    from eplus_gym.rl.research_long import ResearchLongError, run_research_long
+    from eplus_gym.rl.research_model import ResearchModelError
+
+    if str(getattr(args, "simulator", SIMULATOR_REQUIRED)) != SIMULATOR_REQUIRED:
+        print(json.dumps({"command": "research-long", "allowed": False, "reason": "only LIVE_ENERGYPLUS"}))
+        return EXIT_INTEGRITY
+    if not bool(getattr(args, "confirm_simulation_only_physics_limits", False)) or not bool(
+        getattr(args, "confirm_a04_not_transient_validated", False)
+    ):
+        print(
+            json.dumps(
+                {
+                    "command": "research-long",
+                    "allowed": False,
+                    "reason": "missing --confirm-simulation-only-physics-limits and/or --confirm-a04-not-transient-validated",
+                    "long_campaign_allowed": False,
+                    "SIMULATION_TRAINING_READY": False,
+                    "OPERATIONAL_DSM_READY": False,
+                }
+            )
+        )
+        return EXIT_INTEGRITY
+    try:
+        live = bool(getattr(args, "micro_gate", False)) or bool(getattr(args, "execute_live", False))
+        site = _site(args) if live else Path(args.site_root or os.environ.get("SITE_ROOT") or ".")
+        out = run_research_long(
+            app_root=_APP,
+            site_root=site,
+            confirm_simulation_only_physics_limits=True,
+            confirm_a04_not_transient_validated=True,
+            max_wall_hours=float(getattr(args, "max_wall_hours", 30.0) or 30.0),
+            micro_gate=bool(getattr(args, "micro_gate", False)),
+            execute_live=bool(getattr(args, "execute_live", False)),
+            heartbeat_path=Path(args.heartbeat) if getattr(args, "heartbeat", None) else None,
+            seed=int(getattr(args, "seed", 0) or 0),
+        )
+    except (ResearchLongError, ResearchModelError, SystemExit) as exc:
+        print(json.dumps({"command": "research-long", "allowed": False, "reason": str(exc), "long_campaign_allowed": False}))
+        return EXIT_INTEGRITY
+    print(json.dumps(out, indent=2, default=str))
+    return EXIT_OK
+
+
 def cmd_research_poc(args) -> int:
     """Bounded real-EnergyPlus research PoC. Cannot enable --mode full or long_campaign_allowed."""
     from eplus_gym.rl.research_model import ResearchModelError
@@ -738,6 +783,17 @@ def main(argv: list[str] | None = None) -> int:
     rp.add_argument("--simulator", default=SIMULATOR_REQUIRED)
     rp.add_argument("--execute-live", action="store_true")
     rp.set_defaults(func=cmd_research_poc)
+
+    rl = sub.add_parser("research-long", parents=[site_parent])
+    rl.add_argument("--confirm-simulation-only-physics-limits", action="store_true")
+    rl.add_argument("--confirm-a04-not-transient-validated", action="store_true")
+    rl.add_argument("--max-wall-hours", type=float, default=30.0)
+    rl.add_argument("--seed", type=int, default=0)
+    rl.add_argument("--simulator", default=SIMULATOR_REQUIRED)
+    rl.add_argument("--micro-gate", action="store_true")
+    rl.add_argument("--execute-live", action="store_true")
+    rl.add_argument("--heartbeat", default=None)
+    rl.set_defaults(func=cmd_research_long)
 
     args = p.parse_args(argv)
     try:

--- a/vibe_code_apps_22/skills/rl-daily-dsm/SKILL.md
+++ b/vibe_code_apps_22/skills/rl-daily-dsm/SKILL.md
@@ -41,6 +41,11 @@ Do not promote a topology merely because warnings drop.
 
 `research-poc` is a separate CLI. Default twin is A04 labeled
 `A04_RESEARCH_POC_NOT_TRANSIENT_VALIDATED`. Missing confirm flag exits 4.
+`research-long` is a **different** subcommand (not an alias of `campaign`).
+It requires both `--confirm-simulation-only-physics-limits` and
+`--confirm-a04-not-transient-validated`. PPO uses `research_action_contract_v2`
+(`Box[-1,1]^9` affine-decoded). The SB3 `.zip` is canonical; do not write a
+v2/dim-19 `daily_policy.pkl`. `long_campaign_allowed` stays false.
 Future agents: inspect IDF/RDD with EnergyPlus MCP first; MCP cannot rewrite
 W2A banks. Frozen ramp stays **2.651 °F / 15 min**.
 
@@ -52,7 +57,8 @@ Future `vibe22_rl.py campaign` constructs `MultiDayDailyEnv`, not
 `DailySixZoneGymEnv` (legacy diagnostic subcommand only). DQN v2 advertises
 unique post-clamp schedules (74), not Discrete(110).
 
-See `docs/audits/2026-08-18-vibe22-final-physics-and-rl-poc.md`.
+See `docs/audits/2026-08-18-vibe22-final-physics-and-rl-poc.md` and
+`docs/audits/2026-08-18-vibe22-research-long-launch.md`.
 A04 remains immutable. Do not raise `ENGINEERING_MARGIN`.
 
 ```powershell
@@ -60,6 +66,8 @@ python scripts/a04_live_multiday_continuity.py --site-root $env:SITE_ROOT
 python scripts/a04v2_trackb_two_pass.py --site-root $env:SITE_ROOT
 python scripts/vibe22_rl.py operator-pay-experiment --mode smoke --reward-name operator_pay_2x_v1 --run-id oppay2x_smoke_20260816 --site-root $env:SITE_ROOT
 python scripts/vibe22_rl.py research-poc --confirm-simulation-only-physics-limits --max-wall-hours 6 --site-root $env:SITE_ROOT
+python scripts/vibe22_rl.py research-long --confirm-simulation-only-physics-limits --confirm-a04-not-transient-validated --micro-gate --site-root $env:SITE_ROOT
+python scripts/vibe22_rl.py research-long --confirm-simulation-only-physics-limits --confirm-a04-not-transient-validated --execute-live --max-wall-hours 30 --site-root $env:SITE_ROOT
 ```
 
 Long `campaign --n-days 100` is prohibited.

--- a/vibe_code_apps_22/tests/test_research_action_contract_v2.py
+++ b/vibe_code_apps_22/tests/test_research_action_contract_v2.py
@@ -1,0 +1,175 @@
+"""research_action_contract_v2: normalized PPO Box(9), frozen v1, no dishonest packs."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from eplus_gym.control_v2 import ACTION_KEYS, build_six_schedules_f
+from eplus_gym.rl.obs_v3 import N_OBS_V3
+from eplus_gym.rl.research_spaces import (
+    RESEARCH_ACTION_CONTRACT,
+    RESEARCH_ACTION_CONTRACT_V2,
+    RESEARCH_UNOCC_F_LO,
+    ActionContractMismatch,
+    assert_research_v2_contract,
+    continuous_action_space_research,
+    continuous_action_space_research_v2,
+    decode_continuous_research,
+    decode_continuous_research_v2,
+    decode_discrete_research_v2,
+    discrete_n_research_v2,
+    encode_continuous_research_v2,
+    research_build_six_schedules_f,
+    research_continuous_68,
+    research_continuous_70,
+)
+
+APP = Path(__file__).resolve().parents[1]
+SCHOOL_DAY = "2025-12-08"  # Monday
+WEEKEND = "2025-12-13"  # Saturday
+
+
+def test_v1_physical_box_is_frozen():
+    space = continuous_action_space_research()
+    assert space.shape == (9,)
+    assert float(space.low[0]) == 68.0
+    p = decode_continuous_research([68.0, 66.0, 0.0] + [0.0] * 6, day=SCHOOL_DAY)
+    assert p.occupied_heating_f == pytest.approx(68.0)
+    assert RESEARCH_UNOCC_F_LO >= 66.0
+    assert RESEARCH_ACTION_CONTRACT == "research_action_contract_v1"
+
+
+def test_v2_box_is_normalized_unit_interval():
+    space = continuous_action_space_research_v2()
+    assert space.shape == (9,)
+    assert space.dtype == np.float32
+    assert np.allclose(space.low, -1.0)
+    assert np.allclose(space.high, 1.0)
+
+
+def test_affine_round_trip_and_bounds():
+    rng = np.random.default_rng(0)
+    for _ in range(40):
+        x = rng.uniform(-1.0, 1.0, size=9).astype(np.float32)
+        params = decode_continuous_research_v2(x, day=SCHOOL_DAY)
+        assert 68.0 - 1e-6 <= params.occupied_heating_f <= 72.0 + 1e-6
+        assert 60.0 - 1e-6 <= params.unoccupied_heating_f <= params.occupied_heating_f + 1e-6
+        assert params.recovery_lead_minutes % 15 == 0
+        assert 0 <= params.recovery_lead_minutes <= 180
+        for key in ACTION_KEYS:
+            eff = params.unoccupied_heating_f + params.zone_offsets[key].setback_offset_f
+            assert 60.0 - 1e-6 <= eff <= params.occupied_heating_f + 1e-6
+        x2 = encode_continuous_research_v2(params)
+        again = decode_continuous_research_v2(x2, day=SCHOOL_DAY)
+        assert again.occupied_heating_f == pytest.approx(params.occupied_heating_f, abs=0.02)
+        assert again.unoccupied_heating_f == pytest.approx(params.unoccupied_heating_f, abs=0.02)
+        assert again.recovery_lead_minutes == params.recovery_lead_minutes
+
+
+def test_continuous_68_and_70_reachable():
+    c68 = decode_continuous_research_v2([-1.0, 1.0, -1.0] + [0.0] * 6, day=SCHOOL_DAY)
+    c70 = decode_continuous_research_v2([0.0, 1.0, -1.0] + [0.0] * 6, day=SCHOOL_DAY)
+    assert c68.continuous_conditioning
+    assert c70.continuous_conditioning
+    assert c68.occupied_heating_f == pytest.approx(68.0, abs=0.02)
+    assert c70.occupied_heating_f == pytest.approx(70.0, abs=0.02)
+    s68 = research_build_six_schedules_f(c68, SCHOOL_DAY)["1F_A"]
+    s70 = research_build_six_schedules_f(c70, SCHOOL_DAY)["1F_A"]
+    assert s68 == pytest.approx([68.0] * 96, abs=0.05)
+    assert s70 == pytest.approx([70.0] * 96, abs=0.05)
+    assert research_continuous_68().occupied_heating_f == 68.0
+    assert research_continuous_70().occupied_heating_f == 70.0
+
+
+def test_deep_setback_60_and_recovery_180():
+    params = decode_continuous_research_v2([0.0, -1.0, 1.0] + [0.0] * 6, day=SCHOOL_DAY)
+    assert params.occupied_heating_f == pytest.approx(70.0, abs=0.05)
+    assert params.unoccupied_heating_f == pytest.approx(60.0, abs=0.05)
+    assert params.recovery_lead_minutes == 180
+    assert not params.continuous_conditioning
+
+
+def test_weekend_is_all_unoccupied_unless_continuous():
+    setback = decode_continuous_research_v2([0.0, -1.0, 0.0] + [0.0] * 6, day=WEEKEND)
+    series = research_build_six_schedules_f(setback, WEEKEND)["1F_A"]
+    assert len(series) == 96
+    assert max(series) == pytest.approx(min(series), abs=0.05)
+    assert min(series) == pytest.approx(60.0, abs=0.15)
+    assert setback.heating_setpoint_start_step == 0
+    assert setback.heating_setpoint_end_step == 0
+    cont = decode_continuous_research_v2([0.0, 1.0, -1.0] + [0.0] * 6, day=WEEKEND)
+    cseries = research_build_six_schedules_f(cont, WEEKEND)["1F_A"]
+    assert cseries == pytest.approx([70.0] * 96, abs=0.05)
+
+
+def test_heating_never_breaches_cooling_deadband():
+    params = decode_continuous_research_v2([1.0, 1.0, -1.0] + [0.0] * 6, day=SCHOOL_DAY)
+    series = research_build_six_schedules_f(params, SCHOOL_DAY)["1F_A"]
+    assert max(series) <= 74.0 - 2.0 + 1e-6
+
+
+def test_dqn_v2_no_wrap_and_cardinality():
+    assert discrete_n_research_v2() == 38
+    decode_discrete_research_v2(0, day=SCHOOL_DAY)
+    decode_discrete_research_v2(37, day=SCHOOL_DAY)
+    with pytest.raises(ValueError, match="wrap"):
+        decode_discrete_research_v2(38, day=SCHOOL_DAY)
+    with pytest.raises(ValueError, match="wrap"):
+        decode_discrete_research_v2(-1, day=SCHOOL_DAY)
+    deep = [decode_discrete_research_v2(i, day=SCHOOL_DAY) for i in range(38)]
+    assert any(abs(p.unoccupied_heating_f - 60.0) < 1e-6 and not p.continuous_conditioning for p in deep)
+
+
+def test_untrained_ppo_samples_interior_not_physical_floor():
+    pytest.importorskip("stable_baselines3")
+    import gymnasium as gym
+    from stable_baselines3 import PPO
+
+    space = continuous_action_space_research_v2()
+
+    class _Stub(gym.Env):
+        metadata = {"render_modes": []}
+
+        def __init__(self):
+            super().__init__()
+            self.action_space = space
+            self.observation_space = gym.spaces.Box(
+                low=-np.inf, high=np.inf, shape=(N_OBS_V3,), dtype=np.float32
+            )
+
+        def reset(self, *, seed=None, options=None):
+            super().reset(seed=seed)
+            return np.zeros(N_OBS_V3, dtype=np.float32), {}
+
+        def step(self, action):
+            return np.zeros(N_OBS_V3, dtype=np.float32), 0.0, True, False, {}
+
+    model = PPO("MlpPolicy", _Stub(), seed=0, n_steps=8, batch_size=8)
+    occs, unoccs, recs = [], [], []
+    obs = np.zeros(N_OBS_V3, dtype=np.float32)
+    for i in range(64):
+        obs[0] = float(i) / 64.0
+        action, _ = model.predict(obs, deterministic=False)
+        params = decode_continuous_research_v2(action, day=SCHOOL_DAY)
+        occs.append(params.occupied_heating_f)
+        unoccs.append(params.unoccupied_heating_f)
+        recs.append(params.recovery_lead_minutes)
+    assert not all(abs(x - 68.0) < 0.05 for x in occs)
+    assert not all(abs(x - 60.0) < 0.05 for x in unoccs)
+    assert not all(x == 0 for x in recs)
+    assert len({round(x, 1) for x in occs}) >= 2
+
+
+def test_refuse_v1_contract_load():
+    with pytest.raises(ActionContractMismatch, match="research_action_contract_v2"):
+        assert_research_v2_contract({"action_contract_version": RESEARCH_ACTION_CONTRACT})
+    assert_research_v2_contract({"action_contract_version": RESEARCH_ACTION_CONTRACT_V2})
+
+
+def test_v1_decode_rejects_v2_normalized_vector_as_physical():
+    """v1 must not silently reinterpret a [-1,1] vector."""
+    p = decode_continuous_research([-1.0, -1.0, -1.0] + [-1.0] * 6, day=SCHOOL_DAY)
+    assert p.occupied_heating_f == pytest.approx(68.0)
+    assert p.unoccupied_heating_f == pytest.approx(66.0)

--- a/vibe_code_apps_22/tests/test_research_long_cli.py
+++ b/vibe_code_apps_22/tests/test_research_long_cli.py
@@ -1,0 +1,237 @@
+"""Research-long CLI, checkpoints, pack honesty, winner rule. No EnergyPlus."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from eplus_gym.control_v2 import build_six_schedules_f, continuous_params
+from eplus_gym.rl.multiday_env import FakeContinuityPlant, MultiDayDailyEnv
+from eplus_gym.rl.obs_v3 import N_OBS_V3
+from eplus_gym.rl.research_checkpoint import (
+    SCHEMA,
+    checkpoint_resumable,
+    refuse_metadata_only,
+    write_block_checkpoint,
+    CheckpointError,
+)
+from eplus_gym.rl.research_eval import select_winner
+from eplus_gym.rl.research_long import freeze_research_long_days, run_research_long, write_heartbeat
+from eplus_gym.rl.research_spaces import RESEARCH_ACTION_CONTRACT_V2, encode_continuous_research_v2
+
+APP = Path(__file__).resolve().parents[1]
+
+
+def _tiny_epw(path: Path) -> Path:
+    lines = ["LOCATION,Fake"]
+    for d in range(1, 32):
+        for h in range(24):
+            lines.append(f"2025,11,{d},{h+1},0,0,-5.0")
+    for d in range(1, 32):
+        for h in range(24):
+            lines.append(f"2025,12,{d},{h+1},0,0,-10.0")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_research_long_cli_missing_confirms_exit_4():
+    import sys
+
+    sys.path.insert(0, str(APP / "scripts"))
+    import vibe22_rl
+
+    rc = vibe22_rl.main(["research-long", "--max-wall-hours", "30"])
+    assert rc == vibe22_rl.EXIT_INTEGRITY
+    rc2 = vibe22_rl.main(
+        [
+            "research-long",
+            "--confirm-simulation-only-physics-limits",
+            "--max-wall-hours",
+            "30",
+        ]
+    )
+    assert rc2 == vibe22_rl.EXIT_INTEGRITY
+
+
+def test_research_long_dry_run_keeps_gates_false():
+    out = run_research_long(
+        app_root=APP,
+        site_root=APP,
+        confirm_simulation_only_physics_limits=True,
+        confirm_a04_not_transient_validated=True,
+        execute_live=False,
+        micro_gate=False,
+    )
+    assert out["allowed"] is True
+    assert out["long_campaign_allowed"] is False
+    assert out["SIMULATION_TRAINING_READY"] is False
+    assert out["OPERATIONAL_DSM_READY"] is False
+    assert out["bacnet_commands"] == 0
+    assert "RESEARCH_LONG_ALLOWED" in out["claim_labels"]
+    assert out["action_contract_version"] == RESEARCH_ACTION_CONTRACT_V2
+    assert out["observation_dim"] == N_OBS_V3
+
+
+def test_research_long_does_not_alias_campaign():
+    import sys
+
+    sys.path.insert(0, str(APP / "scripts"))
+    import vibe22_rl
+
+    rc = vibe22_rl.main(["campaign", "--simulator", "LIVE_ENERGYPLUS", "--n-days", "3"])
+    assert rc == vibe22_rl.EXIT_INTEGRITY
+
+
+def test_freeze_days_excludes_january(tmp_path: Path):
+    epw = _tiny_epw(tmp_path / "fake.epw")
+    pool = freeze_research_long_days(epw)
+    assert pool["train"][0] == "2025-11-01"
+    assert pool["train"][-1] == "2025-12-14"
+    assert pool["validation"][0] == "2025-12-15"
+    assert pool["validation"][-1] == "2025-12-31"
+    assert all(not x.startswith("2026-01") for x in pool["train"] + pool["validation"])
+    assert "NO LOCKED UNSEEN" in pool["locked_unseen"]
+
+
+def test_metadata_only_checkpoint_is_not_resumable(tmp_path: Path):
+    body = {"schema": SCHEMA, "valid_transition_count": 3, "metadata_only": True}
+    assert checkpoint_resumable(body, root=tmp_path) is False
+    with pytest.raises(CheckpointError):
+        refuse_metadata_only(body)
+
+
+class _FakeModel:
+    def save(self, path: str) -> None:
+        Path(path).write_bytes(b"PK\x03\x04fakezip")
+
+    def save_replay_buffer(self, path: str) -> None:
+        Path(path).write_bytes(b"replay")
+
+
+def test_real_checkpoint_requires_zip_and_v2_contract(tmp_path: Path):
+    body = write_block_checkpoint(
+        root=tmp_path,
+        model=_FakeModel(),
+        algo="PPO",
+        seed=0,
+        valid_transition_count=7,
+        block_id="2025-11-01:2025-11-07",
+        day="2025-11-07",
+        idf_sha256="aa",
+        epw_sha256="bb",
+        rng_hex="cc",
+    )
+    assert body["action_contract_version"] == RESEARCH_ACTION_CONTRACT_V2
+    assert body["observation_dim"] == 80
+    assert body["metadata_only"] is False
+    assert checkpoint_resumable(body, root=tmp_path) is True
+    (tmp_path / "ppo_block.zip").unlink()
+    assert checkpoint_resumable(body, root=tmp_path) is False
+
+
+def test_select_winner_none_unless_trained_beats_baselines():
+    rows = []
+    for arm in ("incumbent", "continuous_68", "continuous_70", "shallow_setback", "random"):
+        rows.append({"arm": arm, "training_reward": 1.0, "readiness_ok": True})
+    rows.append({"arm": "trained_ppo_seed0", "training_reward": 0.5, "readiness_ok": True})
+    assert select_winner(rows) is None
+    rows.append({"arm": "trained_ppo_seed0", "training_reward": 2.0, "readiness_ok": True})
+    # one seed only — cannot claim
+    assert select_winner(rows) is None
+    rows.append({"arm": "trained_ppo_seed1", "training_reward": 2.0, "readiness_ok": True})
+    assert select_winner(rows) == "trained_ppo_seed1"
+
+
+def test_research_contract_skips_dishonest_pack():
+    from eplus_gym.rl.train_sb3 import should_write_policy_pack
+
+    assert should_write_policy_pack({"action_contract_version": RESEARCH_ACTION_CONTRACT_V2}) is False
+    assert should_write_policy_pack({"action_contract_version": "research_action_contract_v1"}) is False
+    assert should_write_policy_pack({"write_policy_pack": False}) is False
+    assert should_write_policy_pack({}) is True
+
+
+def test_dqn_checkpoint_requires_replay(tmp_path: Path):
+    body = write_block_checkpoint(
+        root=tmp_path,
+        model=_FakeModel(),
+        algo="DQN",
+        seed=0,
+        valid_transition_count=3,
+        block_id="2025-11-01:2025-11-07",
+        day="2025-11-07",
+        idf_sha256="aa",
+        epw_sha256="bb",
+        rng_hex="cc",
+    )
+    assert checkpoint_resumable(body, root=tmp_path) is True
+    (tmp_path / "replay_buffer.pkl").unlink()
+    assert checkpoint_resumable(body, root=tmp_path) is False
+
+
+def test_restore_refuses_hash_mismatch(tmp_path: Path):
+    write_block_checkpoint(
+        root=tmp_path,
+        model=_FakeModel(),
+        algo="PPO",
+        seed=0,
+        valid_transition_count=3,
+        block_id="b",
+        day="2025-11-07",
+        idf_sha256="aa",
+        epw_sha256="bb",
+        rng_hex="cc",
+    )
+    from eplus_gym.rl.research_checkpoint import restore_checkpoint
+
+    with pytest.raises(CheckpointError, match="idf sha256"):
+        restore_checkpoint(tmp_path, idf_sha256="other", epw_sha256="bb")
+
+
+def test_persist_billing_across_blocks():
+    days = ["2025-12-08", "2025-12-09", "2025-12-10", "2025-12-11"]
+    oat = {d: [-10.0] * 24 for d in days}
+    plant = FakeContinuityPlant()
+    plant.start_episode()
+    sched = build_six_schedules_f(continuous_params(70.0))
+    payloads = {}
+    for day in days:
+        payloads[day] = plant.simulate_day(sched, oat_c=oat[day])
+    env = MultiDayDailyEnv(
+        {
+            "days": days,
+            "plant": FakeContinuityPlant(),
+            "hourly_oat": oat,
+            "baseline_payloads": payloads,
+            "block_size": 2,
+            "persist_billing": True,
+            "action_contract_version": RESEARCH_ACTION_CONTRACT_V2,
+            "require_live_energyplus": False,
+        }
+    )
+    obs, _ = env.reset()
+    assert obs.shape[0] == N_OBS_V3
+    action = encode_continuous_research_v2(continuous_params(70.0))
+    floors = []
+    done = False
+    while not done:
+        obs, _, term, trunc, info = env.step(action)
+        floors.append(info["closing_mtd_kw"])
+        done = term or trunc
+    first_close = floors[-1]
+    obs, _ = env.reset()
+    _, _, _, _, info2 = env.step(action)
+    assert info2["opening_mtd_kw"] >= first_close - 1e-6
+
+
+def test_heartbeat_never_unlocks_gates(tmp_path: Path):
+    path = tmp_path / "hb.json"
+    write_heartbeat(path, {"valid_transitions": 3, "pid": 1})
+    body = json.loads(path.read_text(encoding="utf-8"))
+    assert body["long_campaign_allowed"] is False
+    assert body["SIMULATION_TRAINING_READY"] is False
+    assert body["bacnet_commands"] == 0
+    assert body["pid"]
+    assert body["contaminated"] is False

--- a/vibe_code_apps_22/vibe22_agent_spec/CONTRIBUTING_RL.md
+++ b/vibe_code_apps_22/vibe22_agent_spec/CONTRIBUTING_RL.md
@@ -23,7 +23,7 @@ deterministic DualSP defaults (**never** `action_space.sample()`) and six-actuat
 | Ramp gate | `eplus_gym/rl/physics_ramp_gate.py` — BAS p99.9 × 3; **do not raise** to pass A04 |
 | DQN v2 | Unique post-clamp table (`Discrete(74)`); declared grid 110 is not advertised as the action space |
 | Track B | Later LIVE matrix: **2,106 scored / 5,332 warmup** (37 reports); superseded two-pass **3,780** kept; **no champion**. Track C sequential C1/C2 also failed scored-runtime W2A=0. |
-| Trainer | SB3 PPO/DQN — `--mode full` refused until a physics champion is written to `active_rl_model_v1.json`. Fallback is `research-poc` (cannot set `long_campaign_allowed`). |
+| Trainer | SB3 PPO/DQN — `--mode full` refused until a physics champion is written to `active_rl_model_v1.json`. Fallback is `research-poc` / `research-long` (cannot set `long_campaign_allowed`). Research-long: `research_action_contract_v2`, SB3 `.zip` canonical, no `daily_policy.pkl`. |
 | MCP | Inspect A04/RDD with EnergyPlus MCP before IDF edits; Track C topology changes stay in Python. |
 
 DSM DualSP recovery must not add a separate fixed 60-min ramp on top of lead (that made 60/120/180 identical). Evening setback remains a step; A04 zone air can follow ~5 °F in 15 min. That is a **model/physics** NO-GO for long RL, not a license to inflate the threshold.
@@ -34,4 +34,4 @@ Campaign paths refuse `FakeContinuityPlant`. Integrity failures are truncated/in
 
 1. Screening claim: ENERGYPLUS DSM OPTIMIZATION SCREENING / RETROSPECTIVE REPLAY
 2. Subprocess isolation: `live_day_worker` (Windows torch + `delete_state`)
-3. Long campaign: **NO-GO** until a physics champion exists. Terminal B = labeled A04 research PoC only. Do not start 5–10 sequence pilots without explicit human authorization.
+3. Long campaign: **NO-GO** until a physics champion exists. Terminal B = labeled A04 research PoC / research-long only. Do not start 5–10 sequence pilots without explicit human authorization. `research-long` does not alias `campaign`.

--- a/vibe_code_apps_22/vibe22_agent_spec/README.md
+++ b/vibe_code_apps_22/vibe22_agent_spec/README.md
@@ -6,7 +6,7 @@
 | [CONTRIBUTING_RL.md](CONTRIBUTING_RL.md) | rleplus backend, A04, no Ray |
 | [EPLUS_GYM.md](EPLUS_GYM.md) | Gym adapter + W2A parser |
 | [AGENT_LOOP.md](AGENT_LOOP.md) | Campaign loop (ramp gate first; long RL NO-GO) |
-| [../docs/audits/2026-08-17-vibe22-correctness-repair.md](../docs/audits/2026-08-17-vibe22-correctness-repair.md) | P0/P1 scientific-correctness repair |
+| [../docs/audits/2026-08-18-vibe22-research-long-launch.md](../docs/audits/2026-08-18-vibe22-research-long-launch.md) | Research-long launch (v2 Box, checkpoints, no champion) |
 | [../docs/audits/2026-08-16-vibe22-physics-ramp-nogo.md](../docs/audits/2026-08-16-vibe22-physics-ramp-nogo.md) | Long-train NO-GO |
 | ../plots/rl_report/README.md | Report pack |
 | ../skills/rl-daily-dsm/SKILL.md | Skill |

--- a/vibe_code_apps_22/vibe22_agent_spec/RL_DAILY_DSM.md
+++ b/vibe_code_apps_22/vibe22_agent_spec/RL_DAILY_DSM.md
@@ -16,8 +16,8 @@ Not operational MPC. Not verified savings. Not BACnet.
 | Simulator | `LIVE_ENERGYPLUS` only; campaign refuses `FakeContinuityPlant` |
 | Action | Daily DualSP plan → six 96-step heating schedules (`control_v2`) |
 | Recovery | `recovery_lead_minutes` is the linear ramp duration ending at start_step |
-| PPO | `occupied`, `setback_depth` (deadband 0.25°F → continuous), start, end, lead, 6 offsets |
-| DQN | Unique post-clamp schedules (`Discrete(74)` on 2026-01-12); declared grid is 110; indices outside `[0, n)` rejected (no wrap); actions 0/1 = continuous 68/70 |
+| PPO research v2 | `research_action_contract_v2`: normalized `Box[-1,1]^9` affine-decoded to 68–72 / 60–occ / 0–180 / offsets. v1 physical Box is frozen. |
+| DQN research v2 | Unique table `Discrete(38)`; no wrap; actions 0/1 = continuous 68/70 |
 | Readiness | Steps **30 and 31**, band **68–74°F**, **all six zones**, school days only |
 | Reward | `reward_contract_v2`: utility accounting + display paycheck + unbounded-by-paycheck train reward; occupied low/high DH split; within-day movement is the training term |
 | Integrity | crash / NaN / missing baseline / wrong timestep → invalid/truncated, not `-1e6` |
@@ -26,7 +26,7 @@ Not operational MPC. Not verified savings. Not BACnet.
 | Trainer | Stable-Baselines3 PPO + DQN (not Ray) — **do not start** a full campaign |
 | Track B | Later LIVE matrix **executed** (first child **2,106 scored / 5,332 warmup** W2A; **37** reports). Superseded two-pass tree **3,780** scored kept. CLI instrumented day **738 / 4,657** plus active invalid-domain **759**. Not a champion. |
 
-**Terminal paths:** **A** = every champion gate passes → update `active_rl_model_v1.json` and long RL. **B** (this campaign) = no champion; bounded A04 `research-poc` labeled `RESEARCH_POC_ALLOWED`. **C** = EnergyPlus/RL computation itself failed. Do not call implementation complete.
+**Terminal paths:** **A** = every champion gate passes → update `active_rl_model_v1.json` and long RL. **B** (this campaign) = no champion; bounded A04 `research-poc` / `research-long` labeled `RESEARCH_POC_ALLOWED` / `RESEARCH_LONG_ALLOWED`. **C** = EnergyPlus/RL computation itself failed. Do not call implementation complete.
 
 EnergyPlus MCP (`user-energyplus`) inspects IDF/RDD before edits. MCP cannot rewrite W2A banks. Track C (`scripts/a04v2_trackc_one_w2a.py`) stays in Python. Output names come from the generated RDD, never guessed.
 
@@ -39,11 +39,16 @@ python scripts/a04_live_multiday_continuity.py --site-root $env:SITE_ROOT
 python scripts/a04v2_trackb_two_pass.py --site-root $env:SITE_ROOT
 python scripts/vibe22_rl.py operator-pay-experiment --mode smoke --reward-name operator_pay_2x_v1 --site-root $env:SITE_ROOT
 python scripts/vibe22_rl.py research-poc --confirm-simulation-only-physics-limits --max-wall-hours 6 --site-root $env:SITE_ROOT
+python scripts/vibe22_rl.py research-long --confirm-simulation-only-physics-limits --confirm-a04-not-transient-validated --micro-gate --site-root $env:SITE_ROOT
+python scripts/vibe22_rl.py research-long --confirm-simulation-only-physics-limits --confirm-a04-not-transient-validated --execute-live --max-wall-hours 30 --site-root $env:SITE_ROOT
 ```
 
 `campaign --n-days 100` remains prohibited. Default campaign `reward_name` is `reward_v2`.
-`research-poc` is not an operator-pay `--mode`. Missing confirm → exit 4. The research
-contract cannot enable `long_campaign_allowed`.
+`research-poc` is not an operator-pay `--mode`. `research-long` is not an alias of `campaign`.
+Missing either research-long confirm → exit 4. PPO research-long uses
+`research_action_contract_v2` (`Box[-1,1]^9`). The SB3 `.zip` is canonical; do not
+write a v2/dim-19 `daily_policy.pkl`. The research contract cannot enable
+`long_campaign_allowed`.
 `scripts/vibe22_rl.py campaign` constructs `MultiDayDailyEnv` via `train_sb3.make_env`.
 `legacy-daily-env --confirm-legacy-diagnostic` is the only path to `DailySixZoneGymEnv`.
 A04 3-day continuity gallery (`scripts/a04_live_multiday_continuity.py`) is screening only:


### PR DESCRIPTION
## Summary
- Normalize research PPO to Box[-1,1]^9 (`research_action_contract_v2`) so untrained policies are not clipped to physical floors; freeze v1.
- Fail closed on `daily_policy.pkl`; SB3 `.zip` plus DQN replay are the canonical checkpoints. Eval uses `predict` on obs v3 dim 80; winner stays none unless chronological validation and readiness agree across seeds.
- Add `research-long` (not an alias of `campaign`) with two confirm flags, Nov 1–Dec 14 train / Dec 15–31 val, 7-day EnergyPlus blocks, 8192 valid transitions, 30 h cap. LIVE micro-gate passed. `long_campaign_allowed` remains false. Do not merge.

## Test plan
- [x] `python -m pytest tests -q -k "not trackb_research_child"` (249 passed)
- [x] LIVE `research-long --micro-gate` (8 PPO + 8 DQN transitions, 0 severe/fatal, no policy pack)
- [ ] Overnight `--execute-live` heartbeat >=3 valid transitions (started after this PR; do not wait 30 h)
- [ ] Do not treat training mean reward as a winner
