### PR TITLE
feat(vibe13): pin af4e886 upstream dev; post-pin Gate 4 smoke + Haystack 4b

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ vibe_code_apps_13/captures/*
 !vibe_code_apps_13/captures/wire-test-*.json
 !vibe_code_apps_13/captures/mstp-passive-*.json
 !vibe_code_apps_13/captures/mstp-fec-*.json
+!vibe_code_apps_13/captures/mstp-gate3-*.json
 !vibe_code_apps_13/captures/phase2-no-ip-gate-status.txt
 vibe_code_apps_13/reports/*
 !vibe_code_apps_13/reports/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ vibe_code_apps_13/target/
 vibe_code_apps_13/captures/*
 !vibe_code_apps_13/captures/.gitkeep
 !vibe_code_apps_13/captures/wire-test-*.json
+!vibe_code_apps_13/captures/mstp-passive-*.json
+!vibe_code_apps_13/captures/mstp-fec-*.json
+!vibe_code_apps_13/captures/phase2-no-ip-gate-status.txt
 vibe_code_apps_13/reports/*
 !vibe_code_apps_13/reports/.gitkeep
 vibe_code_apps_13/.bootstrap-backup/

--- a/vibe_code_apps_13/Cargo.lock
+++ b/vibe_code_apps_13/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 [[package]]
 name = "bacnet-client"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
+source = "git+https://github.com/jscott3201/rusty-bacnet?rev=af4e88680c51eb4da64dac47f0540a35bf184732#af4e88680c51eb4da64dac47f0540a35bf184732"
 dependencies = [
  "bacnet-encoding",
  "bacnet-endpoint-core",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "bacnet-encoding"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
+source = "git+https://github.com/jscott3201/rusty-bacnet?rev=af4e88680c51eb4da64dac47f0540a35bf184732#af4e88680c51eb4da64dac47f0540a35bf184732"
 dependencies = [
  "bacnet-types",
  "bytes",
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "bacnet-endpoint-core"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
+source = "git+https://github.com/jscott3201/rusty-bacnet?rev=af4e88680c51eb4da64dac47f0540a35bf184732#af4e88680c51eb4da64dac47f0540a35bf184732"
 dependencies = [
  "bacnet-encoding",
  "bacnet-network",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "bacnet-network"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
+source = "git+https://github.com/jscott3201/rusty-bacnet?rev=af4e88680c51eb4da64dac47f0540a35bf184732#af4e88680c51eb4da64dac47f0540a35bf184732"
 dependencies = [
  "bacnet-encoding",
  "bacnet-transport",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "bacnet-objects"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
+source = "git+https://github.com/jscott3201/rusty-bacnet?rev=af4e88680c51eb4da64dac47f0540a35bf184732#af4e88680c51eb4da64dac47f0540a35bf184732"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "bacnet-server"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
+source = "git+https://github.com/jscott3201/rusty-bacnet?rev=af4e88680c51eb4da64dac47f0540a35bf184732#af4e88680c51eb4da64dac47f0540a35bf184732"
 dependencies = [
  "bacnet-encoding",
  "bacnet-endpoint-core",
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "bacnet-services"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
+source = "git+https://github.com/jscott3201/rusty-bacnet?rev=af4e88680c51eb4da64dac47f0540a35bf184732#af4e88680c51eb4da64dac47f0540a35bf184732"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "bacnet-transport"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
+source = "git+https://github.com/jscott3201/rusty-bacnet?rev=af4e88680c51eb4da64dac47f0540a35bf184732#af4e88680c51eb4da64dac47f0540a35bf184732"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "bacnet-types"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
+source = "git+https://github.com/jscott3201/rusty-bacnet?rev=af4e88680c51eb4da64dac47f0540a35bf184732#af4e88680c51eb4da64dac47f0540a35bf184732"
 dependencies = [
  "bitflags 2.13.1",
  "smallvec",
@@ -601,6 +601,7 @@ dependencies = [
  "bytes",
  "clap",
  "lab-common",
+ "mstp-lab",
  "serde",
  "serde_json",
  "tokio",

--- a/vibe_code_apps_13/Cargo.lock
+++ b/vibe_code_apps_13/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 [[package]]
 name = "bacnet-client"
 version = "0.10.1"
-source = "git+https://github.com/jscott3201/rusty-bacnet?rev=c77f78445fbf40da15867fec28a36ea120ad1739#c77f78445fbf40da15867fec28a36ea120ad1739"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
 dependencies = [
  "bacnet-encoding",
  "bacnet-endpoint-core",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "bacnet-encoding"
 version = "0.10.1"
-source = "git+https://github.com/jscott3201/rusty-bacnet?rev=c77f78445fbf40da15867fec28a36ea120ad1739#c77f78445fbf40da15867fec28a36ea120ad1739"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
 dependencies = [
  "bacnet-types",
  "bytes",
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "bacnet-endpoint-core"
 version = "0.10.1"
-source = "git+https://github.com/jscott3201/rusty-bacnet?rev=c77f78445fbf40da15867fec28a36ea120ad1739#c77f78445fbf40da15867fec28a36ea120ad1739"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
 dependencies = [
  "bacnet-encoding",
  "bacnet-network",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "bacnet-network"
 version = "0.10.1"
-source = "git+https://github.com/jscott3201/rusty-bacnet?rev=c77f78445fbf40da15867fec28a36ea120ad1739#c77f78445fbf40da15867fec28a36ea120ad1739"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
 dependencies = [
  "bacnet-encoding",
  "bacnet-transport",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "bacnet-objects"
 version = "0.10.1"
-source = "git+https://github.com/jscott3201/rusty-bacnet?rev=c77f78445fbf40da15867fec28a36ea120ad1739#c77f78445fbf40da15867fec28a36ea120ad1739"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "bacnet-server"
 version = "0.10.1"
-source = "git+https://github.com/jscott3201/rusty-bacnet?rev=c77f78445fbf40da15867fec28a36ea120ad1739#c77f78445fbf40da15867fec28a36ea120ad1739"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
 dependencies = [
  "bacnet-encoding",
  "bacnet-endpoint-core",
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "bacnet-services"
 version = "0.10.1"
-source = "git+https://github.com/jscott3201/rusty-bacnet?rev=c77f78445fbf40da15867fec28a36ea120ad1739#c77f78445fbf40da15867fec28a36ea120ad1739"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "bacnet-transport"
 version = "0.10.1"
-source = "git+https://github.com/jscott3201/rusty-bacnet?rev=c77f78445fbf40da15867fec28a36ea120ad1739#c77f78445fbf40da15867fec28a36ea120ad1739"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "bacnet-types"
 version = "0.10.1"
-source = "git+https://github.com/jscott3201/rusty-bacnet?rev=c77f78445fbf40da15867fec28a36ea120ad1739#c77f78445fbf40da15867fec28a36ea120ad1739"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
 dependencies = [
  "bitflags 2.13.1",
  "smallvec",
@@ -588,6 +588,23 @@ dependencies = [
  "lab-common",
  "mstp-lab",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "mstp-passive-sniff"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bacnet-transport",
+ "bytes",
+ "clap",
+ "lab-common",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-serial",
  "tracing",
  "tracing-subscriber",
 ]

--- a/vibe_code_apps_13/Cargo.lock
+++ b/vibe_code_apps_13/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 [[package]]
 name = "bacnet-client"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
 dependencies = [
  "bacnet-encoding",
  "bacnet-endpoint-core",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "bacnet-encoding"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
 dependencies = [
  "bacnet-types",
  "bytes",
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "bacnet-endpoint-core"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
 dependencies = [
  "bacnet-encoding",
  "bacnet-network",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "bacnet-network"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
 dependencies = [
  "bacnet-encoding",
  "bacnet-transport",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "bacnet-objects"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "bacnet-server"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
 dependencies = [
  "bacnet-encoding",
  "bacnet-endpoint-core",
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "bacnet-services"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "bacnet-transport"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "bacnet-types"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=19d205d78c947aea3fe98110d8a6c392359aa627#19d205d78c947aea3fe98110d8a6c392359aa627"
 dependencies = [
  "bitflags 2.13.1",
  "smallvec",

--- a/vibe_code_apps_13/Cargo.lock
+++ b/vibe_code_apps_13/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 [[package]]
 name = "bacnet-client"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
 dependencies = [
  "bacnet-encoding",
  "bacnet-endpoint-core",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "bacnet-encoding"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
 dependencies = [
  "bacnet-types",
  "bytes",
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "bacnet-endpoint-core"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
 dependencies = [
  "bacnet-encoding",
  "bacnet-network",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "bacnet-network"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
 dependencies = [
  "bacnet-encoding",
  "bacnet-transport",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "bacnet-objects"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "bacnet-server"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
 dependencies = [
  "bacnet-encoding",
  "bacnet-endpoint-core",
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "bacnet-services"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "bacnet-transport"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "bacnet-types"
 version = "0.10.1"
-source = "git+https://github.com/bbartling/rusty-bacnet?rev=73a1fd41df7df2dfb3fa005cf339f347751f0286#73a1fd41df7df2dfb3fa005cf339f347751f0286"
+source = "git+https://github.com/bbartling/rusty-bacnet?rev=e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef#e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
 dependencies = [
  "bitflags 2.13.1",
  "smallvec",

--- a/vibe_code_apps_13/Cargo.toml
+++ b/vibe_code_apps_13/Cargo.toml
@@ -25,16 +25,16 @@ all = "warn"
 pedantic = "warn"
 
 [workspace.dependencies]
-# rusty-bacnet pin: Clause 9 CRC + USB stream reassembly (bbartling fork until upstream #464 merges)
+# rusty-bacnet pin: bbartling fork branch vibe13-mstp (Clause 9 CRC + USB + 9.5.6 token/PFM) — fork-only, not upstream
 # Commits: a9912b8 USB gaps ≠ T_frame_abort; 6a70b85 Clause 9 CRC 0x81/0x8408
-bacnet-types = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
-bacnet-encoding = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
-bacnet-services = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
-bacnet-transport = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286", features = ["serial"] }
-bacnet-network = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
-bacnet-client = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
-bacnet-objects = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
-bacnet-server = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
+bacnet-types = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
+bacnet-encoding = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
+bacnet-services = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
+bacnet-transport = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef", features = ["serial"] }
+bacnet-network = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
+bacnet-client = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
+bacnet-objects = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
+bacnet-server = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
 anyhow = "1.0"
 bytes = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/vibe_code_apps_13/Cargo.toml
+++ b/vibe_code_apps_13/Cargo.toml
@@ -25,16 +25,16 @@ all = "warn"
 pedantic = "warn"
 
 [workspace.dependencies]
-# rusty-bacnet pin: bbartling fork branch vibe13-mstp (Clause 9 CRC + USB + 9.5.6 token/PFM) — upstream PR https://github.com/jscott3201/rusty-bacnet/pull/467
-# Commits: a9912b8 USB gaps ≠ T_frame_abort; 6a70b85 Clause 9 CRC 0x81/0x8408
-bacnet-types = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
-bacnet-encoding = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
-bacnet-services = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
-bacnet-transport = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627", features = ["serial"] }
-bacnet-network = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
-bacnet-client = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
-bacnet-objects = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
-bacnet-server = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
+# rusty-bacnet pin: jscott3201/dev @ af4e886 — PR #467 (CRC/token) and #468 (Python MS/TP) merged
+# Upstream candidate PRs (local branches): fix/mstp-validate-rust-config, fix/mstp-tx-completion-after-drain
+bacnet-types = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "af4e88680c51eb4da64dac47f0540a35bf184732" }
+bacnet-encoding = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "af4e88680c51eb4da64dac47f0540a35bf184732" }
+bacnet-services = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "af4e88680c51eb4da64dac47f0540a35bf184732" }
+bacnet-transport = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "af4e88680c51eb4da64dac47f0540a35bf184732", features = ["serial"] }
+bacnet-network = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "af4e88680c51eb4da64dac47f0540a35bf184732" }
+bacnet-client = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "af4e88680c51eb4da64dac47f0540a35bf184732" }
+bacnet-objects = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "af4e88680c51eb4da64dac47f0540a35bf184732" }
+bacnet-server = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "af4e88680c51eb4da64dac47f0540a35bf184732" }
 anyhow = "1.0"
 bytes = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/vibe_code_apps_13/Cargo.toml
+++ b/vibe_code_apps_13/Cargo.toml
@@ -7,8 +7,7 @@ members = [
     "apps/mstp-mini-device",
     "apps/mstp-probe",
     "apps/mstp-fec-diag",
-    # mstp-passive-sniff requires decode_frame_stream (USB fix) — enable via
-    # .cargo/config.toml path-patch to ~/src/rusty-bacnet-vibe13 until pin bumps.
+    "apps/mstp-passive-sniff",
 ]
 
 [workspace.package]
@@ -26,15 +25,16 @@ all = "warn"
 pedantic = "warn"
 
 [workspace.dependencies]
-# Pinned rusty-bacnet (jscott3201/rusty-bacnet main @ 2026-08-28)
-bacnet-types = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "c77f78445fbf40da15867fec28a36ea120ad1739" }
-bacnet-encoding = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "c77f78445fbf40da15867fec28a36ea120ad1739" }
-bacnet-services = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "c77f78445fbf40da15867fec28a36ea120ad1739" }
-bacnet-transport = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "c77f78445fbf40da15867fec28a36ea120ad1739", features = ["serial"] }
-bacnet-network = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "c77f78445fbf40da15867fec28a36ea120ad1739" }
-bacnet-client = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "c77f78445fbf40da15867fec28a36ea120ad1739" }
-bacnet-objects = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "c77f78445fbf40da15867fec28a36ea120ad1739" }
-bacnet-server = { git = "https://github.com/jscott3201/rusty-bacnet", rev = "c77f78445fbf40da15867fec28a36ea120ad1739" }
+# rusty-bacnet pin: Clause 9 CRC + USB stream reassembly (bbartling fork until upstream #464 merges)
+# Commits: a9912b8 USB gaps ≠ T_frame_abort; 6a70b85 Clause 9 CRC 0x81/0x8408
+bacnet-types = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
+bacnet-encoding = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
+bacnet-services = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
+bacnet-transport = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286", features = ["serial"] }
+bacnet-network = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
+bacnet-client = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
+bacnet-objects = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
+bacnet-server = { git = "https://github.com/bbartling/rusty-bacnet", rev = "73a1fd41df7df2dfb3fa005cf339f347751f0286" }
 anyhow = "1.0"
 bytes = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/vibe_code_apps_13/Cargo.toml
+++ b/vibe_code_apps_13/Cargo.toml
@@ -25,16 +25,16 @@ all = "warn"
 pedantic = "warn"
 
 [workspace.dependencies]
-# rusty-bacnet pin: bbartling fork branch vibe13-mstp (Clause 9 CRC + USB + 9.5.6 token/PFM) — fork-only, not upstream
+# rusty-bacnet pin: bbartling fork branch vibe13-mstp (Clause 9 CRC + USB + 9.5.6 token/PFM) — upstream PR https://github.com/jscott3201/rusty-bacnet/pull/467
 # Commits: a9912b8 USB gaps ≠ T_frame_abort; 6a70b85 Clause 9 CRC 0x81/0x8408
-bacnet-types = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
-bacnet-encoding = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
-bacnet-services = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
-bacnet-transport = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef", features = ["serial"] }
-bacnet-network = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
-bacnet-client = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
-bacnet-objects = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
-bacnet-server = { git = "https://github.com/bbartling/rusty-bacnet", rev = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef" }
+bacnet-types = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
+bacnet-encoding = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
+bacnet-services = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
+bacnet-transport = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627", features = ["serial"] }
+bacnet-network = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
+bacnet-client = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
+bacnet-objects = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
+bacnet-server = { git = "https://github.com/bbartling/rusty-bacnet", rev = "19d205d78c947aea3fe98110d8a6c392359aa627" }
 anyhow = "1.0"
 bytes = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/vibe_code_apps_13/README.md
+++ b/vibe_code_apps_13/README.md
@@ -1,6 +1,6 @@
 # Checkpoint 13 - Rust BACnet MS/TP Router Appliance
 
-**Status: Active** — Phase 2 Rescue **Gate 1–4 hardware PASS** on pin `19d205d` (fork `vibe13-mstp`, rebased on upstream `dev`). Upstream candidate: [rusty-bacnet#467](https://github.com/jscott3201/rusty-bacnet/pull/467). JENEsys discovers **Rust MS/TP Mini Device** `device:123001` with points Polled `{ok}`. Gates 5–6 OPEN. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
+**Status: Active** — Phase 2 on pin `af4e886` (`jscott3201/rusty-bacnet` dev; #467/#468 **merged**). Historical Gate 1–4 PASS on `19d205d` — **post-pin live smoke required**. Vibe13 retains Rust hardware mini-device; upstream Python example is binding-only. Gates 5–6 OPEN. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
 
 ## Limitations (current)
 
@@ -84,13 +84,13 @@ The B/CH343G adapters are retained for B+B and B+C compatibility runs after the 
 
 ## Dependency snapshot
 
-Workspace pins `bbartling/rusty-bacnet` @ tip matching upstream PR [#467](https://github.com/jscott3201/rusty-bacnet/pull/467) (`pr/mstp-clause9-interop` / `vibe13-mstp`):
+Workspace pins `jscott3201/rusty-bacnet` @ dev SHA (exact rev in `Cargo.toml` / `Cargo.lock`):
 
 ```text
-19d205d78c947aea3fe98110d8a6c392359aa627
+af4e88680c51eb4da64dac47f0540a35bf184732
 ```
 
-Includes Clause 9.6 CRC (`0x81` / `0x8408`), USB stream reassembly, and Clause 9.5.6 token/PFM coexistence fix. Commit `Cargo.lock`.
+Includes merged #467 (CRC, USB reassembly, token/PFM) and #468 (Python MS/TP binding example). Vibe13 keeps its Rust hardware mini-device. Commit `Cargo.lock`.
 
 ## Initial workspace
 

--- a/vibe_code_apps_13/README.md
+++ b/vibe_code_apps_13/README.md
@@ -1,6 +1,6 @@
 # Checkpoint 13 - Rust BACnet MS/TP Router Appliance
 
-**Status: Active** — Phase 2 on pin `af4e886` (`jscott3201/rusty-bacnet` dev; #467/#468 **merged**). Historical Gate 1–4 PASS on `19d205d` — **post-pin live smoke required**. Vibe13 retains Rust hardware mini-device; upstream Python example is binding-only. Gates 5–6 OPEN. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
+**Status: Active** — Phase 2 on pin `af4e886` (`jscott3201/rusty-bacnet` dev; #467/#468 **merged**). Gates 1–4 **PASS** on `af4e886` (2026-08-31 hardware + Haystack 4b). Vibe13 retains Rust hardware mini-device; upstream Python example is binding-only. Gates 5–6 OPEN. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
 
 ## Limitations (current)
 
@@ -13,7 +13,7 @@
 
 ## Linux resources (mstp-mini-device on live MS/TP)
 
-Measured on **bensbench** (2026-08-30) while Gate 4 Workbench discovery was live — release binary, MAC 3, 38 400 baud, pin `e3b9edb` (behavior unchanged on `19d205d`):
+Measured on **bensbench** (2026-08-31) while Gate 4 Workbench discovery was live — release binary, MAC 3, 38 400 baud, pin `af4e886`:
 
 | Metric | Value |
 |--------|------:|

--- a/vibe_code_apps_13/README.md
+++ b/vibe_code_apps_13/README.md
@@ -1,6 +1,6 @@
 # Checkpoint 13 - Rust BACnet MS/TP Router Appliance
 
-**Status: Active** — Phase 1 wire-test + Phase 2 MS/TP software/loopback acceptance are in-repo. **Phase 2 hardware NOT RUN** (adapters not installed/wired). See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
+**Status: Active** — Phase 1 wire-test + Phase 2 MS/TP software/loopback in-repo. **Phase 2 Rescue (2026-08-30):** Clause 9 CRC + USB stream pin `73a1fd4`; live BASRT/FEC bench exists. Hardware Gates 2–6 OPEN until `captures/` evidence. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
 
 This checkpoint develops a Linux x86 BACnet appliance in three strictly gated phases using two Waveshare USB TO RS485 (C) adapters and `rusty-bacnet`:
 
@@ -59,13 +59,13 @@ The B/CH343G adapters are retained for B+B and B+C compatibility runs after the 
 
 ## Dependency snapshot
 
-Research was performed against `jscott3201/rusty-bacnet` branch `dev` at commit:
+Workspace pins `bbartling/rusty-bacnet` (fork) until upstream merges [#464](https://github.com/jscott3201/rusty-bacnet/pull/464):
 
 ```text
-c77f78445fbf40da15867fec28a36ea120ad1739
+73a1fd41df7df2dfb3fa005cf339f347751f0286
 ```
 
-Do not depend on the moving branch in a reproducible build. Pin an exact reviewed commit and commit `Cargo.lock`. Revalidate the source before changing the pin.
+Includes Clause 9.6 CRC polys (`0x81` / `0x8408`) and USB stream reassembly (`a9912b8`). Do not depend on a moving branch. Commit `Cargo.lock`. Re-pin to `jscott3201/rusty-bacnet` at the merge SHA when #464 lands.
 
 ## Initial workspace
 

--- a/vibe_code_apps_13/README.md
+++ b/vibe_code_apps_13/README.md
@@ -1,11 +1,19 @@
 # Checkpoint 13 - Rust BACnet MS/TP Router Appliance
 
-**Status: Active** — Phase 2 Rescue **Gate 1–4 hardware PASS** on pin `e3b9edb` (fork `vibe13-mstp` only). JENEsys discovers **Rust MS/TP Mini Device** `device:123001` with points Polled `{ok}`. Gates 5–6 OPEN. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
+**Status: Active** — Phase 2 Rescue **Gate 1–4 hardware PASS** on pin `19d205d` (fork `vibe13-mstp`, rebased on upstream `dev`). Upstream candidate: [rusty-bacnet#467](https://github.com/jscott3201/rusty-bacnet/pull/467). JENEsys discovers **Rust MS/TP Mini Device** `device:123001` with points Polled `{ok}`. Gates 5–6 OPEN. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
 
+## Limitations (current)
+
+- **Not a Clause 9 conformance claim** — CRC / USB stream / 9.5.6 token+PFM only.
+- **No extended MS/TP frames** (types 32/33, COBS, CRC-32K) — do not claim router or oversized-frame conformance.
+- **Gates 5–6 OPEN** — shared endpoint + soak not closed.
+- **Host USB timing** — stale-partial timeout is scheduling-aware; not wire `T_frame_abort`.
+- **Workbench nits** — Niagara Write=`readonly` facets, °C display vs BACnet degF (62), name slash → `MS.TP` are cosmetic / UI, not stack blockers.
+- **Do not run open-fdd MQTT soaks** on the same Waveshare tty while mini-device owns the trunk.
 
 ## Linux resources (mstp-mini-device on live MS/TP)
 
-Measured on **bensbench** (2026-08-30) while Gate 4 Workbench discovery was live — release binary, MAC 3, 38 400 baud, pin `e3b9edb`:
+Measured on **bensbench** (2026-08-30) while Gate 4 Workbench discovery was live — release binary, MAC 3, 38 400 baud, pin `e3b9edb` (behavior unchanged on `19d205d`):
 
 | Metric | Value |
 |--------|------:|
@@ -76,13 +84,13 @@ The B/CH343G adapters are retained for B+B and B+C compatibility runs after the 
 
 ## Dependency snapshot
 
-Workspace pins **fork-only** `bbartling/rusty-bacnet` branch `vibe13-mstp`:
+Workspace pins `bbartling/rusty-bacnet` @ tip matching upstream PR [#467](https://github.com/jscott3201/rusty-bacnet/pull/467) (`pr/mstp-clause9-interop` / `vibe13-mstp`):
 
 ```text
-e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef
+19d205d78c947aea3fe98110d8a6c392359aa627
 ```
 
-Includes Clause 9.6 CRC (`0x81` / `0x8408`), USB stream reassembly, and Clause 9.5.6 token/PFM coexistence fix. Commit `Cargo.lock`. Do not open PRs against upstream for this train.
+Includes Clause 9.6 CRC (`0x81` / `0x8408`), USB stream reassembly, and Clause 9.5.6 token/PFM coexistence fix. Commit `Cargo.lock`.
 
 ## Initial workspace
 

--- a/vibe_code_apps_13/README.md
+++ b/vibe_code_apps_13/README.md
@@ -1,6 +1,6 @@
 # Checkpoint 13 - Rust BACnet MS/TP Router Appliance
 
-**Status: Active** — Phase 1 wire-test + Phase 2 MS/TP software/loopback in-repo. **Phase 2 Rescue (2026-08-30):** Clause 9 CRC pin `73a1fd4` (Gate 1–2 PASS). Gate 3 application PASS / **coexistence FAIL** — active TX blocked pending [rusty-bacnet#465](https://github.com/jscott3201/rusty-bacnet/pull/465). Gates 4–6 BLOCKED. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
+**Status: Active** — Phase 2 Rescue **Gate 1–4 hardware PASS** on pin `e3b9edb` (fork `vibe13-mstp` only). JENEsys discovers **Rust MS/TP Mini Device** `device:123001` with points Polled `{ok}`. Gates 5–6 OPEN. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
 
 This checkpoint develops a Linux x86 BACnet appliance in three strictly gated phases using two Waveshare USB TO RS485 (C) adapters and `rusty-bacnet`:
 
@@ -59,13 +59,13 @@ The B/CH343G adapters are retained for B+B and B+C compatibility runs after the 
 
 ## Dependency snapshot
 
-Workspace pins `bbartling/rusty-bacnet` (fork) until upstream merges [#464](https://github.com/jscott3201/rusty-bacnet/pull/464):
+Workspace pins **fork-only** `bbartling/rusty-bacnet` branch `vibe13-mstp`:
 
 ```text
-73a1fd41df7df2dfb3fa005cf339f347751f0286
+e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef
 ```
 
-Includes Clause 9.6 CRC polys (`0x81` / `0x8408`) and USB stream reassembly (`a9912b8`). Do not depend on a moving branch. Commit `Cargo.lock`. Re-pin to `jscott3201/rusty-bacnet` at the merge SHA when #464 lands.
+Includes Clause 9.6 CRC (`0x81` / `0x8408`), USB stream reassembly, and Clause 9.5.6 token/PFM coexistence fix. Commit `Cargo.lock`. Do not open PRs against upstream for this train.
 
 ## Initial workspace
 

--- a/vibe_code_apps_13/README.md
+++ b/vibe_code_apps_13/README.md
@@ -1,6 +1,6 @@
 # Checkpoint 13 - Rust BACnet MS/TP Router Appliance
 
-**Status: Active** — Phase 1 wire-test + Phase 2 MS/TP software/loopback in-repo. **Phase 2 Rescue (2026-08-30):** Clause 9 CRC + USB stream pin `73a1fd4`; live BASRT/FEC bench exists. Hardware Gates 2–6 OPEN until `captures/` evidence. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
+**Status: Active** — Phase 1 wire-test + Phase 2 MS/TP software/loopback in-repo. **Phase 2 Rescue (2026-08-30):** Clause 9 CRC pin `73a1fd4` (Gate 1–2 PASS). Gate 3 application PASS / **coexistence FAIL** — active TX blocked pending [rusty-bacnet#465](https://github.com/jscott3201/rusty-bacnet/pull/465). Gates 4–6 BLOCKED. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
 
 This checkpoint develops a Linux x86 BACnet appliance in three strictly gated phases using two Waveshare USB TO RS485 (C) adapters and `rusty-bacnet`:
 

--- a/vibe_code_apps_13/README.md
+++ b/vibe_code_apps_13/README.md
@@ -2,6 +2,23 @@
 
 **Status: Active** — Phase 2 Rescue **Gate 1–4 hardware PASS** on pin `e3b9edb` (fork `vibe13-mstp` only). JENEsys discovers **Rust MS/TP Mini Device** `device:123001` with points Polled `{ok}`. Gates 5–6 OPEN. See [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
 
+
+## Linux resources (mstp-mini-device on live MS/TP)
+
+Measured on **bensbench** (2026-08-30) while Gate 4 Workbench discovery was live — release binary, MAC 3, 38 400 baud, pin `e3b9edb`:
+
+| Metric | Value |
+|--------|------:|
+| Release binary size | ~4.9 MiB |
+| Resident memory (VmRSS / HWM) | **~5.6 MiB** |
+| Virtual size (VmSize) | ~404 MiB (mapped; not all resident) |
+| Threads | 7 |
+| CPU (steady, pidstat ~3 s) | **~1%** of one core (~0.3% usr / 0.7% sys) |
+| Host | Linux 6.8 x86_64, 6 CPUs |
+
+This is a **mega milestone**: a native Rust MS/TP master mini-device stays discoverable in JENEsys with **single-digit MiB RSS** and ~1% CPU while coexisting on the BASRT+FEC trunk.
+
+
 This checkpoint develops a Linux x86 BACnet appliance in three strictly gated phases using two Waveshare USB TO RS485 (C) adapters and `rusty-bacnet`:
 
 1. **Phase 1 - USB/RS-485 wire test:** prove both USB ports, adapters, wiring, serial settings, bidirectional bytes, timing, unplug behavior, and repeatable hardware tests. This phase contains no BACnet protocol.

--- a/vibe_code_apps_13/apps/mstp-fec-diag/src/main.rs
+++ b/vibe_code_apps_13/apps/mstp-fec-diag/src/main.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 use tokio::time::{sleep, timeout};
 use tracing::{error, info, warn};
 
-const RUSTY_BACNET_REV: &str = "c77f78445fbf40da15867fec28a36ea120ad1739";
+const RUSTY_BACNET_REV: &str = "73a1fd41df7df2dfb3fa005cf339f347751f0286";
 
 #[derive(Parser, Debug)]
 #[command(
@@ -231,7 +231,10 @@ async fn main() -> Result<()> {
         report.error = Some(format!("Who-Is: {e:#}"));
         return finish(report_path.as_deref(), report);
     }
-    sleep(Duration::from_millis(2_000)).await;
+    // Token-ring join with Max_Master=127 can be slow; give I-Am time to arrive.
+    let iam_wait_ms = args.apdu_timeout_ms.max(8_000);
+    info!(iam_wait_ms, "Waiting for I-Am");
+    sleep(Duration::from_millis(iam_wait_ms)).await;
 
     let Some(dev) = client.get_device(args.device_instance).await else {
         report.error = Some(format!(

--- a/vibe_code_apps_13/apps/mstp-fec-diag/src/main.rs
+++ b/vibe_code_apps_13/apps/mstp-fec-diag/src/main.rs
@@ -14,12 +14,10 @@ use bacnet_types::enums::{ObjectType, PropertyIdentifier};
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 use clap::Parser;
 use lab_common::BaudRate;
-use mstp_lab::{master_config, open_mstp_transport};
+use mstp_lab::{master_config, open_mstp_transport, RUSTY_BACNET_REV};
 use serde::Serialize;
 use tokio::time::{sleep, timeout};
 use tracing::{error, info, warn};
-
-const RUSTY_BACNET_REV: &str = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef";
 
 #[derive(Parser, Debug)]
 #[command(

--- a/vibe_code_apps_13/apps/mstp-fec-diag/src/main.rs
+++ b/vibe_code_apps_13/apps/mstp-fec-diag/src/main.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 use tokio::time::{sleep, timeout};
 use tracing::{error, info, warn};
 
-const RUSTY_BACNET_REV: &str = "73a1fd41df7df2dfb3fa005cf339f347751f0286";
+const RUSTY_BACNET_REV: &str = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef";
 
 #[derive(Parser, Debug)]
 #[command(

--- a/vibe_code_apps_13/apps/mstp-mini-device/src/main.rs
+++ b/vibe_code_apps_13/apps/mstp-mini-device/src/main.rs
@@ -1,5 +1,7 @@
 //! MS/TP-only `BACnet` mini-device (Phase 2). No `BACnet`/IP.
 
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -10,7 +12,7 @@ use clap::Parser;
 use lab_common::{BaudRate, MstpMasterConfig};
 use mstp_lab::{
     apply_simulated_inputs, build_mini_device_database, open_mstp_transport, MiniDeviceConfig,
-    LAB_VENDOR_ID, UNITS_DEGF,
+    LAB_VENDOR_ID, RUSTY_BACNET_REV, UNITS_DEGF,
 };
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
@@ -52,7 +54,7 @@ fn master_config(args: &Args) -> Result<MstpMasterConfig> {
     Ok(cfg)
 }
 
-async fn wait_shutdown_signal() {
+async fn wait_shutdown_signal(shutdown: Arc<AtomicBool>) {
     #[cfg(unix)]
     {
         use tokio::signal::unix::{signal, SignalKind};
@@ -61,12 +63,29 @@ async fn wait_shutdown_signal() {
         tokio::select! {
             _ = sigterm.recv() => warn!("SIGTERM — shutting down"),
             _ = sigint.recv() => warn!("SIGINT — shutting down"),
+            () = async {
+                while !shutdown.load(Ordering::Relaxed) {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                warn!("transport watchdog — shutting down");
+            } => {}
         }
     }
     #[cfg(not(unix))]
     {
         let _ = tokio::signal::ctrl_c().await;
         warn!("Ctrl-C — shutting down");
+    }
+}
+
+async fn serial_watchdog(serial_path: String, shutdown: Arc<AtomicBool>) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        if !Path::new(&serial_path).exists() {
+            error!(path = %serial_path, "serial device path disappeared (USB unplug?)");
+            shutdown.store(true, Ordering::Relaxed);
+            return;
+        }
     }
 }
 
@@ -110,8 +129,15 @@ async fn main() -> Result<()> {
     })?;
 
     info!(
-        "Starting MS/TP mini-device: serial={} mac={} instance={} baud={} vendor_id={} (lab placeholder)",
-        args.serial, args.mac, args.device_instance, args.baud, args.vendor_id
+        serial = %args.serial,
+        baud = args.baud,
+        mac = args.mac,
+        max_master = args.max_master,
+        max_info_frames = args.max_info_frames,
+        device_instance = args.device_instance,
+        rusty_bacnet_rev = RUSTY_BACNET_REV,
+        vendor_id = args.vendor_id,
+        "Starting MS/TP mini-device (lab placeholder vendor ID)"
     );
 
     let mut server = BACnetServer::generic_builder()
@@ -127,12 +153,15 @@ async fn main() -> Result<()> {
         args.mac, args.device_instance
     );
 
+    let shutdown = Arc::new(AtomicBool::new(false));
+    tokio::spawn(serial_watchdog(args.serial.clone(), Arc::clone(&shutdown)));
+
     let db_arc = Arc::clone(server.database());
     tokio::spawn(simulation_task(db_arc));
 
-    // Upstream BACnetServer does not expose a public "transport died" notification
-    // on this pin; we wait for SIGINT/SIGTERM only. Documented in PHASE2_SOFTWARE_RESULTS.
-    wait_shutdown_signal().await;
+    // Upstream BACnetServer does not expose transport disconnect on this pin;
+    // serial path watchdog provides bounded application supervision until upstream health exists.
+    wait_shutdown_signal(shutdown).await;
     info!("Shutting down…");
     server.stop().await.context("stop server")?;
     Ok(())

--- a/vibe_code_apps_13/apps/mstp-passive-sniff/Cargo.toml
+++ b/vibe_code_apps_13/apps/mstp-passive-sniff/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 bacnet-transport = { workspace = true }
+bytes.workspace = true
 clap.workspace = true
 lab-common.workspace = true
 serde = { workspace = true }

--- a/vibe_code_apps_13/apps/mstp-passive-sniff/Cargo.toml
+++ b/vibe_code_apps_13/apps/mstp-passive-sniff/Cargo.toml
@@ -16,6 +16,7 @@ bacnet-transport = { workspace = true }
 bytes.workspace = true
 clap.workspace = true
 lab-common.workspace = true
+mstp-lab.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/vibe_code_apps_13/apps/mstp-passive-sniff/src/main.rs
+++ b/vibe_code_apps_13/apps/mstp-passive-sniff/src/main.rs
@@ -1,5 +1,5 @@
 //! Receive-only MS/TP frame sniffer (no token participation / no TX).
-//! Uses streaming decode from bacnet-transport (path-patch to USB fix for local proof).
+//! Streaming decode from bacnet-transport @ Clause 9 CRC + USB reassembly pin.
 
 use std::fs;
 use std::io::ErrorKind;
@@ -15,6 +15,9 @@ use tokio::io::AsyncReadExt;
 use tokio::time::timeout;
 use tokio_serial::{DataBits, FlowControl, Parity, SerialPortBuilderExt, StopBits};
 use tracing::{info, warn};
+
+/// rusty-bacnet pin recorded into hardware reports (must match workspace Cargo.toml).
+const RUSTY_BACNET_REV: &str = "73a1fd41df7df2dfb3fa005cf339f347751f0286";
 
 #[derive(Parser, Debug)]
 #[command(
@@ -38,18 +41,22 @@ struct SniffReport {
     serial: String,
     baud: u32,
     seconds: u64,
+    rusty_bacnet_rev: String,
     rx_bytes: u64,
     complete_frames: u64,
     tokens: u64,
+    token_0_from_7: u64,
     poll_for_master: u64,
     data_frames: u64,
     invalid: u64,
     need_more_stalls: u64,
+    valid_ratio: f64,
     sources_seen: Vec<u8>,
     error: Option<String>,
 }
 
 #[tokio::main]
+#[allow(clippy::too_many_lines)]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -68,6 +75,7 @@ async fn main() -> Result<()> {
         serial: args.serial.clone(),
         baud: baud.as_u32(),
         seconds: args.seconds,
+        rusty_bacnet_rev: RUSTY_BACNET_REV.to_string(),
         ..Default::default()
     };
 
@@ -75,6 +83,7 @@ async fn main() -> Result<()> {
         serial = %args.serial,
         baud = baud.as_u32(),
         seconds = args.seconds,
+        rusty = RUSTY_BACNET_REV,
         "Passive sniff starting (no TX; 8N1, no flow control)"
     );
 
@@ -99,7 +108,7 @@ async fn main() -> Result<()> {
         }
         match timeout(remaining, port.read(&mut recv)).await {
             Err(_) => break,
-            Ok(Ok(0)) => continue,
+            Ok(Ok(0)) => {}
             Ok(Ok(n)) => {
                 report.rx_bytes += n as u64;
                 frame_buf.extend_from_slice(&recv[..n]);
@@ -112,6 +121,12 @@ async fn main() -> Result<()> {
                         StreamDecode::Complete { frame, consumed } => {
                             report.complete_frames += 1;
                             sources.insert(frame.source);
+                            if frame.frame_type == FrameType::Token
+                                && frame.destination == 0
+                                && frame.source == 7
+                            {
+                                report.token_0_from_7 += 1;
+                            }
                             match frame.frame_type {
                                 FrameType::Token => report.tokens += 1,
                                 FrameType::PollForMaster => report.poll_for_master += 1,
@@ -137,7 +152,7 @@ async fn main() -> Result<()> {
                     frame_buf.clear();
                 }
             }
-            Ok(Err(e)) if e.kind() == ErrorKind::TimedOut => continue,
+            Ok(Err(e)) if e.kind() == ErrorKind::TimedOut => {}
             Ok(Err(e)) => {
                 report.error = Some(e.to_string());
                 break;
@@ -146,18 +161,32 @@ async fn main() -> Result<()> {
     }
 
     report.sources_seen = sources.into_iter().collect();
+    let denom = report.complete_frames + report.invalid;
+    report.valid_ratio = if denom == 0 {
+        0.0
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        {
+            report.complete_frames as f64 / denom as f64
+        }
+    };
     report.ok = report.rx_bytes > 0
         && report.complete_frames > 0
         && report.tokens > 0
+        && report.sources_seen.contains(&0)
+        && report.sources_seen.contains(&7)
+        && report.token_0_from_7 > 0
         && report.error.is_none();
 
     info!(
         rx_bytes = report.rx_bytes,
         complete = report.complete_frames,
         tokens = report.tokens,
+        token_0_from_7 = report.token_0_from_7,
         pfm = report.poll_for_master,
         data = report.data_frames,
         invalid = report.invalid,
+        valid_ratio = report.valid_ratio,
         sources = ?report.sources_seen,
         ok = report.ok,
         "Passive sniff done"
@@ -177,10 +206,67 @@ async fn main() -> Result<()> {
         Ok(())
     } else {
         bail!(
-            "passive gate FAIL (rx={} frames={} tokens={})",
+            "passive gate FAIL (rx={} frames={} tokens={} token_0_from_7={} sources={:?})",
             report.rx_bytes,
             report.complete_frames,
-            report.tokens
+            report.tokens,
+            report.token_0_from_7,
+            report.sources_seen
         );
+    }
+}
+
+#[cfg(test)]
+mod offline_fixture_tests {
+    use bacnet_transport::mstp_frame::{
+        decode_frame, decode_frame_stream, encode_frame, FrameType, StreamDecode,
+    };
+    use bytes::BytesMut;
+
+    /// Live trunk Token: dest BASRT(0) ← FEC(7), header CRC 0x37.
+    const TOKEN_0_FROM_7: &[u8] = &[0x55, 0xFF, 0x00, 0x00, 0x07, 0x00, 0x00, 0x37];
+
+    #[test]
+    fn offline_literal_token_0_from_7_decodes() {
+        let (frame, consumed) = decode_frame(TOKEN_0_FROM_7).expect("Token 0<-7");
+        assert_eq!(consumed, 8);
+        assert_eq!(frame.frame_type, FrameType::Token);
+        assert_eq!(frame.destination, 0);
+        assert_eq!(frame.source, 7);
+
+        let mut enc = BytesMut::new();
+        encode_frame(&mut enc, &frame).unwrap();
+        assert_eq!(&enc[..], TOKEN_0_FROM_7);
+    }
+
+    #[test]
+    fn offline_stream_split_across_usb_chunks() {
+        let wire = TOKEN_0_FROM_7;
+        let mut buf = Vec::new();
+        for chunk in [2usize, 3, 1, 2] {
+            let start = buf.len();
+            let end = (start + chunk).min(wire.len());
+            if start >= wire.len() {
+                break;
+            }
+            buf.extend_from_slice(&wire[start..end]);
+            match decode_frame_stream(&buf) {
+                StreamDecode::NeedMore => {}
+                StreamDecode::Complete { frame, consumed } => {
+                    assert_eq!(frame.source, 7);
+                    assert_eq!(consumed, 8);
+                    return;
+                }
+                StreamDecode::Invalid { .. } => panic!("unexpected invalid"),
+            }
+        }
+        match decode_frame_stream(&buf) {
+            StreamDecode::Complete { frame, .. } => {
+                assert_eq!(frame.frame_type, FrameType::Token);
+                assert_eq!(frame.destination, 0);
+                assert_eq!(frame.source, 7);
+            }
+            other => panic!("expected complete, got {other:?}"),
+        }
     }
 }

--- a/vibe_code_apps_13/apps/mstp-passive-sniff/src/main.rs
+++ b/vibe_code_apps_13/apps/mstp-passive-sniff/src/main.rs
@@ -17,7 +17,7 @@ use tokio_serial::{DataBits, FlowControl, Parity, SerialPortBuilderExt, StopBits
 use tracing::{info, warn};
 
 /// rusty-bacnet pin recorded into hardware reports (must match workspace Cargo.toml).
-const RUSTY_BACNET_REV: &str = "73a1fd41df7df2dfb3fa005cf339f347751f0286";
+const RUSTY_BACNET_REV: &str = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef";
 
 #[derive(Parser, Debug)]
 #[command(

--- a/vibe_code_apps_13/apps/mstp-passive-sniff/src/main.rs
+++ b/vibe_code_apps_13/apps/mstp-passive-sniff/src/main.rs
@@ -16,8 +16,7 @@ use tokio::time::timeout;
 use tokio_serial::{DataBits, FlowControl, Parity, SerialPortBuilderExt, StopBits};
 use tracing::{info, warn};
 
-/// rusty-bacnet pin recorded into hardware reports (must match workspace Cargo.toml).
-const RUSTY_BACNET_REV: &str = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef";
+use mstp_lab::RUSTY_BACNET_REV;
 
 #[derive(Parser, Debug)]
 #[command(

--- a/vibe_code_apps_13/captures/mstp-fec-ai1173-30s.json
+++ b/vibe_code_apps_13/captures/mstp-fec-ai1173-30s.json
@@ -1,0 +1,18 @@
+{
+  "ok": false,
+  "serial": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0",
+  "resolved_hint": "/dev/ttyUSB0",
+  "baud": 38400,
+  "mac": 3,
+  "max_master": 7,
+  "max_info_frames": 1,
+  "device_instance": 5007,
+  "expect_mac": 7,
+  "ai_instance": 1173,
+  "rusty_bacnet_rev": "73a1fd41df7df2dfb3fa005cf339f347751f0286",
+  "object_name": "BENS BENCHTEST BOX",
+  "ai_present_value": 75.35767,
+  "loop_ok": 9,
+  "loop_fail": 11,
+  "error": "peer loop finished with 11 failures (9 ok)"
+}

--- a/vibe_code_apps_13/captures/mstp-fec-ai1173-af4e886-oneshot.json
+++ b/vibe_code_apps_13/captures/mstp-fec-ai1173-af4e886-oneshot.json
@@ -1,0 +1,18 @@
+{
+  "ok": true,
+  "serial": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0",
+  "resolved_hint": "/dev/ttyUSB0",
+  "baud": 38400,
+  "mac": 3,
+  "max_master": 7,
+  "max_info_frames": 1,
+  "device_instance": 5007,
+  "expect_mac": 7,
+  "ai_instance": 1173,
+  "rusty_bacnet_rev": "af4e88680c51eb4da64dac47f0540a35bf184732",
+  "object_name": "BENS BENCHTEST BOX",
+  "ai_present_value": 75.74877,
+  "loop_ok": 1,
+  "loop_fail": 0,
+  "error": null
+}

--- a/vibe_code_apps_13/captures/mstp-fec-ai1173-join-try.json
+++ b/vibe_code_apps_13/captures/mstp-fec-ai1173-join-try.json
@@ -1,0 +1,18 @@
+{
+  "ok": false,
+  "serial": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0",
+  "resolved_hint": "/dev/ttyUSB0",
+  "baud": 38400,
+  "mac": 3,
+  "max_master": 7,
+  "max_info_frames": 1,
+  "device_instance": 5007,
+  "expect_mac": 7,
+  "ai_instance": 1173,
+  "rusty_bacnet_rev": "c77f78445fbf40da15867fec28a36ea120ad1739",
+  "object_name": null,
+  "ai_present_value": null,
+  "loop_ok": 0,
+  "loop_fail": 0,
+  "error": "no I-Am for instance 5007 after Who-Is (token/join or wiring?)"
+}

--- a/vibe_code_apps_13/captures/mstp-fec-ai1173-oneshot.json
+++ b/vibe_code_apps_13/captures/mstp-fec-ai1173-oneshot.json
@@ -1,0 +1,18 @@
+{
+  "ok": true,
+  "serial": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0",
+  "resolved_hint": "/dev/ttyUSB0",
+  "baud": 38400,
+  "mac": 3,
+  "max_master": 7,
+  "max_info_frames": 1,
+  "device_instance": 5007,
+  "expect_mac": 7,
+  "ai_instance": 1173,
+  "rusty_bacnet_rev": "73a1fd41df7df2dfb3fa005cf339f347751f0286",
+  "object_name": "BENS BENCHTEST BOX",
+  "ai_present_value": 75.56651,
+  "loop_ok": 0,
+  "loop_fail": 0,
+  "error": null
+}

--- a/vibe_code_apps_13/captures/mstp-fec-ai1173-smoke.json
+++ b/vibe_code_apps_13/captures/mstp-fec-ai1173-smoke.json
@@ -1,0 +1,18 @@
+{
+  "ok": false,
+  "serial": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0",
+  "resolved_hint": "/dev/ttyUSB0",
+  "baud": 38400,
+  "mac": 3,
+  "max_master": 127,
+  "max_info_frames": 1,
+  "device_instance": 5007,
+  "expect_mac": 7,
+  "ai_instance": 1173,
+  "rusty_bacnet_rev": "c77f78445fbf40da15867fec28a36ea120ad1739",
+  "object_name": null,
+  "ai_present_value": null,
+  "loop_ok": 0,
+  "loop_fail": 0,
+  "error": "no I-Am for instance 5007 after Who-Is (token/join or wiring?)"
+}

--- a/vibe_code_apps_13/captures/mstp-gate3-coexistence-abort.json
+++ b/vibe_code_apps_13/captures/mstp-gate3-coexistence-abort.json
@@ -1,0 +1,24 @@
+{
+  "gate": 3,
+  "overall_ok": false,
+  "hardware_ok": false,
+  "application_exchange_ok": true,
+  "coexistence_ok": false,
+  "exit_reason": "aborted: existing MS/TP trunk went offline",
+  "gate1_crc": "PASS",
+  "gate2_passive": "PASS",
+  "gate3_application_exchange": "PASS",
+  "gate3_network_coexistence": "FAIL",
+  "gate3_overall": "FAIL",
+  "gates_4_6": "BLOCKED",
+  "active_tx": "blocked",
+  "notes": [
+    "Workbench/FEC offline while mstp-fec-diag MAC 3 participated",
+    "Root cause: Clause 9.5.6 DoneWithToken/PFM maintenance (PS=NS+1 reversed scan) and NextStationUnknown Token 3->3",
+    "Not CRC, wiring, latency_timer, APDU timeout, or Max_Master",
+    "20x30s soak not PASS; do not resume live TX until deterministic multi-master tests pass"
+  ],
+  "evidence_oneshot": "captures/mstp-fec-ai1173-oneshot.json",
+  "evidence_partial_30s": "captures/mstp-fec-ai1173-30s.json",
+  "rusty_bacnet_rev_at_fail": "73a1fd41df7df2dfb3fa005cf339f347751f0286"
+}

--- a/vibe_code_apps_13/captures/mstp-passive-af4e886-60s.json
+++ b/vibe_code_apps_13/captures/mstp-passive-af4e886-60s.json
@@ -1,0 +1,21 @@
+{
+  "ok": true,
+  "serial": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0",
+  "baud": 38400,
+  "seconds": 60,
+  "rusty_bacnet_rev": "af4e88680c51eb4da64dac47f0540a35bf184732",
+  "rx_bytes": 34309,
+  "complete_frames": 3975,
+  "tokens": 2835,
+  "token_0_from_7": 1418,
+  "poll_for_master": 1116,
+  "data_frames": 24,
+  "invalid": 1,
+  "need_more_stalls": 2380,
+  "valid_ratio": 0.9997484909456741,
+  "sources_seen": [
+    0,
+    7
+  ],
+  "error": null
+}

--- a/vibe_code_apps_13/captures/mstp-passive-crc-fixed.json
+++ b/vibe_code_apps_13/captures/mstp-passive-crc-fixed.json
@@ -4,6 +4,7 @@
   "baud": 38400,
   "seconds": 45,
   "rusty_bacnet_rev": "6a70b85ef23c18ac06900709552113b96c1ea64e",
+  "historical_note": "Archived pre-af4e886 capture — not evidence for current pin; see mstp-passive-af4e886-60s.json",
   "rx_bytes": 25651,
   "complete_frames": 2971,
   "tokens": 2117,

--- a/vibe_code_apps_13/captures/mstp-passive-crc-fixed.json
+++ b/vibe_code_apps_13/captures/mstp-passive-crc-fixed.json
@@ -1,0 +1,21 @@
+{
+  "ok": true,
+  "serial": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0",
+  "baud": 38400,
+  "seconds": 45,
+  "rusty_bacnet_rev": "6a70b85ef23c18ac06900709552113b96c1ea64e",
+  "rx_bytes": 25651,
+  "complete_frames": 2971,
+  "tokens": 2117,
+  "token_0_from_7": 1058,
+  "poll_for_master": 836,
+  "data_frames": 18,
+  "invalid": 2,
+  "need_more_stalls": 1849,
+  "valid_ratio": 0.9993272788429196,
+  "sources_seen": [
+    0,
+    7
+  ],
+  "error": null
+}

--- a/vibe_code_apps_13/captures/mstp-passive-eol-30s.json
+++ b/vibe_code_apps_13/captures/mstp-passive-eol-30s.json
@@ -1,0 +1,17 @@
+{
+  "ok": false,
+  "serial": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0",
+  "baud": 38400,
+  "seconds": 30,
+  "rx_bytes": 16542,
+  "complete_frames": 4,
+  "tokens": 0,
+  "poll_for_master": 4,
+  "data_frames": 0,
+  "invalid": 16510,
+  "need_more_stalls": 1158,
+  "sources_seen": [
+    7
+  ],
+  "error": null
+}

--- a/vibe_code_apps_13/captures/mstp-passive-pre-minidevice.json
+++ b/vibe_code_apps_13/captures/mstp-passive-pre-minidevice.json
@@ -1,0 +1,21 @@
+{
+  "ok": true,
+  "serial": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0",
+  "baud": 38400,
+  "seconds": 20,
+  "rusty_bacnet_rev": "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef",
+  "rx_bytes": 12390,
+  "complete_frames": 1336,
+  "tokens": 935,
+  "token_0_from_7": 468,
+  "poll_for_master": 363,
+  "data_frames": 38,
+  "invalid": 9,
+  "need_more_stalls": 825,
+  "valid_ratio": 0.9933085501858736,
+  "sources_seen": [
+    0,
+    7
+  ],
+  "error": null
+}

--- a/vibe_code_apps_13/captures/phase2-no-ip-gate-status.txt
+++ b/vibe_code_apps_13/captures/phase2-no-ip-gate-status.txt
@@ -1,5 +1,5 @@
 phase2_no_ip_gate: blocked_dependency_isolation
-rusty_bacnet: e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef
+rusty_bacnet: af4e88680c51eb4da64dac47f0540a35bf184732
 socket2: present_via_bacnet_transport
 local_bip_markers: absent
 runtime_ip_sockets: forbidden

--- a/vibe_code_apps_13/captures/phase2-no-ip-gate-status.txt
+++ b/vibe_code_apps_13/captures/phase2-no-ip-gate-status.txt
@@ -1,5 +1,5 @@
 phase2_no_ip_gate: blocked_dependency_isolation
-rusty_bacnet: 73a1fd41df7df2dfb3fa005cf339f347751f0286
+rusty_bacnet: e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef
 socket2: present_via_bacnet_transport
 local_bip_markers: absent
 runtime_ip_sockets: forbidden

--- a/vibe_code_apps_13/captures/phase2-no-ip-gate-status.txt
+++ b/vibe_code_apps_13/captures/phase2-no-ip-gate-status.txt
@@ -1,0 +1,5 @@
+phase2_no_ip_gate: blocked_dependency_isolation
+rusty_bacnet: 73a1fd41df7df2dfb3fa005cf339f347751f0286
+socket2: present_via_bacnet_transport
+local_bip_markers: absent
+runtime_ip_sockets: forbidden

--- a/vibe_code_apps_13/crates/mstp-lab/Cargo.toml
+++ b/vibe_code_apps_13/crates/mstp-lab/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
+build = "build.rs"
 
 [dependencies]
 anyhow.workspace = true

--- a/vibe_code_apps_13/crates/mstp-lab/build.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-env=RUSTY_BACNET_REV=af4e88680c51eb4da64dac47f0540a35bf184732");
+}

--- a/vibe_code_apps_13/crates/mstp-lab/src/acceptance.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/acceptance.rs
@@ -632,7 +632,19 @@ async fn run_acceptance_core<S: SerialPort + 'static>(
             .await
         {
             Ok(_) => bail!("expected invalid array index for Object_List[9999]"),
-            Err(e) => Ok(format!("invalid array index as expected: {e}")),
+            Err(e) => {
+                let err = anyhow::Error::from(e);
+                if is_protocol_error(&err, ErrorClass::PROPERTY, ErrorCode::INVALID_ARRAY_INDEX)
+                    || err
+                        .to_string()
+                        .to_ascii_lowercase()
+                        .contains("invalid array")
+                {
+                    Ok(format!("invalid array index as expected: {err}"))
+                } else {
+                    bail!("unexpected error for Object_List[9999]: {err}");
+                }
+            }
         }
     })
     .await;
@@ -643,7 +655,29 @@ async fn run_acceptance_core<S: SerialPort + 'static>(
             .await
         {
             Ok(_) => bail!("expected unknown property/index error"),
-            Err(e) => Ok(format!("unknown property/index as expected: {e}")),
+            Err(e) => {
+                let err = anyhow::Error::from(e);
+                if is_protocol_error(&err, ErrorClass::PROPERTY, ErrorCode::UNKNOWN_PROPERTY)
+                    || is_protocol_error(&err, ErrorClass::PROPERTY, ErrorCode::INVALID_ARRAY_INDEX)
+                    || is_protocol_error(
+                        &err,
+                        ErrorClass::PROPERTY,
+                        ErrorCode::PROPERTY_IS_NOT_AN_ARRAY,
+                    )
+                    || err
+                        .to_string()
+                        .to_ascii_lowercase()
+                        .contains("unknown property")
+                    || err
+                        .to_string()
+                        .to_ascii_lowercase()
+                        .contains("not-an-array")
+                {
+                    Ok(format!("unknown property/index as expected: {err}"))
+                } else {
+                    bail!("unexpected error for Device DESCRIPTION[1]: {err}");
+                }
+            }
         }
     })
     .await;
@@ -693,7 +727,17 @@ async fn run_acceptance_core<S: SerialPort + 'static>(
             .await
         {
             Ok(()) => bail!("expected write-access denial for BI:1"),
-            Err(e) => Ok(format!("BI:1 write denied as expected: {e}")),
+            Err(e) => {
+                let err = anyhow::Error::from(e);
+                if is_protocol_error(&err, ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED)
+                    || err.to_string().to_ascii_lowercase().contains("denied")
+                    || err.to_string().to_ascii_lowercase().contains("write")
+                {
+                    Ok(format!("BI:1 write denied as expected: {err}"))
+                } else {
+                    bail!("unexpected BI write error: {err}");
+                }
+            }
         }
     })
     .await;

--- a/vibe_code_apps_13/crates/mstp-lab/src/acceptance.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/acceptance.rs
@@ -365,6 +365,70 @@ async fn run_acceptance_core<S: SerialPort + 'static>(
     })
     .await;
 
+    timed_step(&mut report, "read_device_pics_properties", || async {
+        let props = [
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::SYSTEM_STATUS,
+            PropertyIdentifier::VENDOR_NAME,
+            PropertyIdentifier::VENDOR_IDENTIFIER,
+            PropertyIdentifier::MODEL_NAME,
+            PropertyIdentifier::APPLICATION_SOFTWARE_VERSION,
+            PropertyIdentifier::PROTOCOL_VERSION,
+            PropertyIdentifier::PROTOCOL_REVISION,
+            PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED,
+            PropertyIdentifier::PROTOCOL_OBJECT_TYPES_SUPPORTED,
+            PropertyIdentifier::MAX_APDU_LENGTH_ACCEPTED,
+            PropertyIdentifier::SEGMENTATION_SUPPORTED,
+            PropertyIdentifier::APDU_TIMEOUT,
+            PropertyIdentifier::NUMBER_OF_APDU_RETRIES,
+        ];
+        let mut details = Vec::new();
+        for prop in props {
+            let ack = client.read_property(&mac, device_oid, prop, None).await?;
+            let (val, _) =
+                decode_application_value(&ack.property_value, 0).context("decode device PICS")?;
+            if prop == PropertyIdentifier::MAX_APDU_LENGTH_ACCEPTED {
+                let pv = match val {
+                    PropertyValue::Unsigned(n) => n,
+                    other => bail!("expected Unsigned Max_APDU, got {other:?}"),
+                };
+                if pv != 480 {
+                    bail!("Max_APDU_Length_Accepted={pv}, expected 480");
+                }
+            }
+            details.push(format!("{prop:?}={val:?}"));
+        }
+        Ok(details.join("; "))
+    })
+    .await;
+
+    timed_step(&mut report, "read_object_list_index_zero", || async {
+        let ack = client
+            .read_property(&mac, device_oid, PropertyIdentifier::OBJECT_LIST, Some(0))
+            .await?;
+        let (val, _) = decode_application_value(&ack.property_value, 0).context("decode OL[0]")?;
+        match val {
+            PropertyValue::Unsigned(n) if n == 5 => Ok(format!("Object_List[0]=count {n}")),
+            other => bail!("Object_List[0] expected count 5, got {other:?}"),
+        }
+    })
+    .await;
+
+    timed_step(&mut report, "read_object_list_index_one", || async {
+        let ack = client
+            .read_property(&mac, device_oid, PropertyIdentifier::OBJECT_LIST, Some(1))
+            .await?;
+        let (val, _) = decode_application_value(&ack.property_value, 0).context("decode OL[1]")?;
+        match val {
+            PropertyValue::ObjectIdentifier(oid) if oid == device_oid => {
+                Ok(format!("Object_List[1]={oid:?}"))
+            }
+            other => bail!("Object_List[1] expected device oid, got {other:?}"),
+        }
+    })
+    .await;
+
     timed_step(&mut report, "read_ai_present_value", || async {
         let ack = client
             .read_property(&mac, ai_oid, PropertyIdentifier::PRESENT_VALUE, None)
@@ -557,6 +621,33 @@ async fn run_acceptance_core<S: SerialPort + 'static>(
     })
     .await;
 
+    timed_step(&mut report, "invalid_array_index_error", || async {
+        match client
+            .read_property(
+                &mac,
+                device_oid,
+                PropertyIdentifier::OBJECT_LIST,
+                Some(9999),
+            )
+            .await
+        {
+            Ok(_) => bail!("expected invalid array index for Object_List[9999]"),
+            Err(e) => Ok(format!("invalid array index as expected: {e}")),
+        }
+    })
+    .await;
+
+    timed_step(&mut report, "unknown_property_error", || async {
+        match client
+            .read_property(&mac, device_oid, PropertyIdentifier::DESCRIPTION, Some(1))
+            .await
+        {
+            Ok(_) => bail!("expected unknown property/index error"),
+            Err(e) => Ok(format!("unknown property/index as expected: {e}")),
+        }
+    })
+    .await;
+
     timed_step(&mut report, "write_ai_denied", || async {
         let mut buf = BytesMut::new();
         encode_property_value(&mut buf, &PropertyValue::Real(99.0))?;
@@ -583,6 +674,26 @@ async fn run_acceptance_core<S: SerialPort + 'static>(
                     bail!("unexpected AI write error: {err}");
                 }
             }
+        }
+    })
+    .await;
+
+    timed_step(&mut report, "write_bi_denied", || async {
+        let mut buf = BytesMut::new();
+        encode_property_value(&mut buf, &PropertyValue::Enumerated(0))?;
+        match client
+            .write_property(
+                &mac,
+                bi_oid,
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                buf.to_vec(),
+                None,
+            )
+            .await
+        {
+            Ok(()) => bail!("expected write-access denial for BI:1"),
+            Err(e) => Ok(format!("BI:1 write denied as expected: {e}")),
         }
     })
     .await;

--- a/vibe_code_apps_13/crates/mstp-lab/src/database.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/database.rs
@@ -212,4 +212,30 @@ mod tests {
             .unwrap();
         assert_ne!(after, PropertyValue::Real(75.0));
     }
+
+    #[test]
+    fn object_list_has_device_and_four_points() {
+        let db = build_mini_device_database(&MiniDeviceConfig::default()).unwrap();
+        assert_eq!(db.list_objects().len(), 5, "device + AI + BI + AV + BV");
+        let oid = ObjectIdentifier::new(ObjectType::DEVICE, 123_001).unwrap();
+        let list = db
+            .get(&oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::OBJECT_LIST, None)
+            .unwrap();
+        // PropertyValue shape varies by pin; ensure we got a non-null list payload
+        assert!(!matches!(list, PropertyValue::Null));
+    }
+
+    #[test]
+    fn max_apdu_is_standard_frame_480() {
+        let db = build_mini_device_database(&MiniDeviceConfig::default()).unwrap();
+        let oid = ObjectIdentifier::new(ObjectType::DEVICE, 123_001).unwrap();
+        let v = db
+            .get(&oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::MAX_APDU_LENGTH_ACCEPTED, None)
+            .unwrap();
+        assert_eq!(v, PropertyValue::Unsigned(u64::from(MSTP_MAX_APDU)));
+    }
 }

--- a/vibe_code_apps_13/crates/mstp-lab/src/database.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/database.rs
@@ -94,7 +94,9 @@ pub fn build_mini_device_database(cfg: &MiniDeviceConfig) -> Result<ObjectDataba
 /// Trusted local simulation update for AI:1 / BI:1 using `set_present_value`.
 ///
 /// Network WriteProperty to these inputs remains denied while in-service.
-/// Replaces the objects in-place because `dyn BACnetObject` has no downcast.
+/// Re-adds AI/BI after local `set_present_value` because `dyn BACnetObject` has no
+/// safe downcast for in-service input mutation. OIDs remain stable; object-local
+/// state (e.g. future COV) may reset — upstream `ObjectDatabase` mutation API TBD.
 pub fn apply_simulated_inputs(
     db: &mut ObjectDatabase,
     active: bool,

--- a/vibe_code_apps_13/crates/mstp-lab/src/lib.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/lib.rs
@@ -18,6 +18,7 @@
 mod acceptance;
 mod database;
 mod report;
+mod token_edges;
 mod transport;
 
 pub use acceptance::{run_hardware_acceptance, run_loopback_acceptance, AcceptanceOptions};
@@ -28,4 +29,5 @@ pub use database::{
 pub use report::{
     AcceptanceProfile, AcceptanceReport, LatencySummary, StepResult, GATE_REQUIRED_STEPS,
 };
+pub use token_edges::{TokenEdge, TokenEdgeCounters};
 pub use transport::{master_config, mstp_config_from_lab, open_mstp_transport, MstpEndpoint};

--- a/vibe_code_apps_13/crates/mstp-lab/src/lib.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/lib.rs
@@ -31,3 +31,6 @@ pub use report::{
 };
 pub use token_edges::{TokenEdge, TokenEdgeCounters};
 pub use transport::{master_config, mstp_config_from_lab, open_mstp_transport, MstpEndpoint};
+
+/// Pinned `jscott3201/rusty-bacnet` git revision (must match workspace `Cargo.toml`).
+pub const RUSTY_BACNET_REV: &str = env!("RUSTY_BACNET_REV");

--- a/vibe_code_apps_13/crates/mstp-lab/src/report.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/report.rs
@@ -151,7 +151,7 @@ pub struct AcceptanceReport {
 
 impl AcceptanceReport {
     pub const SCHEMA_VERSION: &'static str = "phase2_acceptance_v2";
-    pub const RUSTY_BACNET_COMMIT: &'static str = "c77f78445fbf40da15867fec28a36ea120ad1739";
+    pub const RUSTY_BACNET_COMMIT: &'static str = "73a1fd41df7df2dfb3fa005cf339f347751f0286";
 
     #[must_use]
     pub fn new(

--- a/vibe_code_apps_13/crates/mstp-lab/src/report.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/report.rs
@@ -151,7 +151,7 @@ pub struct AcceptanceReport {
 
 impl AcceptanceReport {
     pub const SCHEMA_VERSION: &'static str = "phase2_acceptance_v2";
-    pub const RUSTY_BACNET_COMMIT: &'static str = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef";
+    pub const RUSTY_BACNET_COMMIT: &'static str = env!("RUSTY_BACNET_REV");
 
     #[must_use]
     pub fn new(

--- a/vibe_code_apps_13/crates/mstp-lab/src/report.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/report.rs
@@ -151,7 +151,7 @@ pub struct AcceptanceReport {
 
 impl AcceptanceReport {
     pub const SCHEMA_VERSION: &'static str = "phase2_acceptance_v2";
-    pub const RUSTY_BACNET_COMMIT: &'static str = "73a1fd41df7df2dfb3fa005cf339f347751f0286";
+    pub const RUSTY_BACNET_COMMIT: &'static str = "e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef";
 
     #[must_use]
     pub fn new(

--- a/vibe_code_apps_13/crates/mstp-lab/src/token_edges.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/token_edges.rs
@@ -111,9 +111,7 @@ mod tests {
         assert!(c.has_ring_0_3_7());
         assert_eq!(c.self_tokens, 1);
         assert_eq!(c.edge_count(0, 3), 1);
-        assert!(c
-            .coexistence_red_flags()
-            .contains(&"self_token_ts_to_ts"));
+        assert!(c.coexistence_red_flags().contains(&"self_token_ts_to_ts"));
     }
 
     #[test]

--- a/vibe_code_apps_13/crates/mstp-lab/src/token_edges.rs
+++ b/vibe_code_apps_13/crates/mstp-lab/src/token_edges.rs
@@ -1,0 +1,127 @@
+//! Token-edge counters for coexistence evidence (Gate 3+).
+//!
+//! A successful FEC ReadProperty alone must never set `hardware_ok=true`.
+//! Reports must include directed Token edges (e.g. `0→3`, `3→7`, `7→0`).
+
+use std::collections::BTreeMap;
+
+use bacnet_transport::mstp_frame::{FrameType, MstpFrame};
+use serde::Serialize;
+
+/// Directed Token edge `source → destination`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct TokenEdge {
+    pub from: u8,
+    pub to: u8,
+}
+
+impl TokenEdge {
+    #[must_use]
+    pub fn new(from: u8, to: u8) -> Self {
+        Self { from, to }
+    }
+
+    #[must_use]
+    pub fn label(&self) -> String {
+        format!("{}->{}", self.from, self.to)
+    }
+}
+
+/// Accumulates MS/TP control-plane telemetry from decoded frames.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct TokenEdgeCounters {
+    pub tokens: u64,
+    pub self_tokens: u64,
+    pub poll_for_master: u64,
+    pub reply_to_pfm: u64,
+    pub edges: BTreeMap<String, u64>,
+}
+
+impl TokenEdgeCounters {
+    pub fn observe(&mut self, frame: &MstpFrame) {
+        match frame.frame_type {
+            FrameType::Token => {
+                self.tokens += 1;
+                if frame.source == frame.destination {
+                    self.self_tokens += 1;
+                }
+                let edge = TokenEdge::new(frame.source, frame.destination);
+                *self.edges.entry(edge.label()).or_insert(0) += 1;
+            }
+            FrameType::PollForMaster => {
+                self.poll_for_master += 1;
+            }
+            FrameType::ReplyToPollForMaster => {
+                self.reply_to_pfm += 1;
+            }
+            _ => {}
+        }
+    }
+
+    /// Count for a specific directed Token edge.
+    #[must_use]
+    pub fn edge_count(&self, from: u8, to: u8) -> u64 {
+        self.edges
+            .get(&TokenEdge::new(from, to).label())
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// True when the classic three-master ring edges are all present at least once.
+    #[must_use]
+    pub fn has_ring_0_3_7(&self) -> bool {
+        self.edge_count(0, 3) > 0 && self.edge_count(3, 7) > 0 && self.edge_count(7, 0) > 0
+    }
+
+    /// Coexistence soft-fail signals (software heuristics).
+    #[must_use]
+    pub fn coexistence_red_flags(&self) -> Vec<&'static str> {
+        let mut flags = Vec::new();
+        if self.self_tokens > 0 {
+            flags.push("self_token_ts_to_ts");
+        }
+        if self.edge_count(3, 0) > 0 && self.edge_count(3, 7) == 0 {
+            flags.push("token_3_to_0_without_3_to_7");
+        }
+        flags
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    fn token(from: u8, to: u8) -> MstpFrame {
+        MstpFrame {
+            frame_type: FrameType::Token,
+            destination: to,
+            source: from,
+            data: Bytes::new(),
+        }
+    }
+
+    #[test]
+    fn counts_ring_edges_and_self_token() {
+        let mut c = TokenEdgeCounters::default();
+        c.observe(&token(0, 3));
+        c.observe(&token(3, 7));
+        c.observe(&token(7, 0));
+        c.observe(&token(3, 3));
+        assert!(c.has_ring_0_3_7());
+        assert_eq!(c.self_tokens, 1);
+        assert_eq!(c.edge_count(0, 3), 1);
+        assert!(c
+            .coexistence_red_flags()
+            .contains(&"self_token_ts_to_ts"));
+    }
+
+    #[test]
+    fn flags_token_3_to_0_without_successor_7() {
+        let mut c = TokenEdgeCounters::default();
+        c.observe(&token(3, 0));
+        assert!(c
+            .coexistence_red_flags()
+            .contains(&"token_3_to_0_without_3_to_7"));
+    }
+}

--- a/vibe_code_apps_13/docs/DECISIONS.md
+++ b/vibe_code_apps_13/docs/DECISIONS.md
@@ -64,8 +64,20 @@ Waveshare midspan was previously the probe point; current bench places the USB R
 
 ## D-010 - USB host gaps are not Clause 9 T_frame_abort
 
-Status: accepted pending upstream merge.
+Status: accepted (implemented upstream-capable; awaiting merge).
 
-Async USB/serial read chunk gaps must not clear MS/TP reassembly buffers using wire `T_frame_abort` (~1.56 ms @ 38400). Host reassembly uses a named stale-partial policy; token state-machine timers stay separate. Tracked in sibling `~/src/rusty-bacnet-vibe13` branch `fix/mstp-usb-stream-decoder` (local commit; push only with human OK).
+Async USB/serial read chunk gaps must not clear MS/TP reassembly buffers using wire `T_frame_abort` (~1.56 ms @ 38400). Host reassembly uses a named stale-partial policy; token state-machine timers stay separate. Commit `a9912b8` on `fix/mstp-clause9-crc` / PR [#464](https://github.com/jscott3201/rusty-bacnet/pull/464).
+
+## D-011 - Clause 9 CRC was the primary MS/TP interoperability blocker
+
+Status: accepted (2026-08-30).
+
+Prior diagnosis that header CRC `0x37` on Token `55 FF 00 00 07 00 00 37` was “invalid” was **wrong**. `CRC8([00,00,07,00,00]) == 0x37` under Clause 9.6. rusty-bacnet previously used reflected polys `0xE0` / `0xA001` (self-round-trip green, live trunk reject). Correct polys: header `0x81`, data `0x8408`. Commit `6a70b85`. `latency_timer` affects host latency but does not make `0x37` invalid.
+
+## D-012 - PR #126 merged; old USB-only Cursor plan is historical
+
+Status: accepted (2026-08-30).
+
+`develop` includes merge `eb178f70` (PR #126). The attached Cursor plan `vibe13_ms_tp_usb_fix_*` is historical. Active work follows the **Phase 2 Rescue** prompt (CRC → passive → FEC client → mini-device → shared endpoint → FEC mirror).
 
 

--- a/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
+++ b/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
@@ -1,96 +1,85 @@
-# Phase 2 — Hardware runbook (NOT EXECUTED)
+# Phase 2 — Hardware runbook (BASRT + JCI FEC + Waveshare C)
 
-**Status:** Prepared only. **Phase 2 hardware was not run because the adapters are not installed/wired.**
+**Status (2026-08-30):** Live midspan/end-of-line bench exists. Loopback ≠ hardware PASS.  
+**Active rescue prompt:** Phase 2 Rescue (CRC Clause 9 + gates 1–6). Historical Cursor plan `vibe13_ms_tp_usb_fix_*` is obsolete.
 
-Do not mark any command below as executed until real captures exist under `captures/`.
-
-## Topology
+## Topology (current)
 
 ```text
-mstp-probe, MAC 0                 mstp-mini-device, MAC 1
-Waveshare C adapter A             Waveshare C adapter B
-          A+ ============================== A+
-          B- ============================== B-
-         REF ============================== REF
+BASRT-B, MAC 0                  JCI FEC, MAC 7               Linux/Waveshare C
+physical endpoint              middle device                physical endpoint
+termination enabled            termination disabled          fixed ~130 ohms
+         |                            |                            |
+         +----------------------------+----------------------------+
+               + to +, - to -, REF/common to REF/common
 ```
 
-- Two Waveshare **C** adapters (FT232RNL, hardware auto direction, isolated)
-- Device on adapter **B**, probe on adapter **A**
-- **No USB 5 V field connection** between adapters
-- Exactly **two** endpoint **120 Ω** terminations (no intermediate termination)
-- Independent bias verification (do not assume onboard 120 Ω is bias)
-- Powered-off A/B resistance expectation ≈ **60 Ω** (two 120 Ω in parallel)
-- Prefer stable `/dev/serial/by-id/...` paths
-- Operator in `dialout` (do not change groups/udev from the agent)
+| Setting | Value |
+|---------|--------|
+| Baud | 38,400 |
+| BASRT MS/TP MAC / net | 0 / 2000 |
+| BASRT Max_Master | 127 |
+| FEC MAC / device instance | 7 / 5007 |
+| Rust station MAC | **3** (never 0 with BASRT; never 7) |
+| Mini-device instance | 123001 |
+| Max_Info_Frames (initial) | 1 |
 
-Placeholders:
+Powered-off trunk A/B should read ≈ **60–65 Ω**. ≈40–45 Ω ⇒ three terminations — fix before TX.
 
-- `/dev/serial/by-id/<PROBE_ADAPTER>`
-- `/dev/serial/by-id/<DEVICE_ADAPTER>`
+Do **not** add a second Waveshare C as midspan tap (extra fixed termination).
 
-Initial baud: **38400** (8N1, no flow control). Shared Max_Master=10, Max_Info_Frames=1.
+## Serial path
+
+```bash
+PORT=/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0
+TTY="$(readlink -f "$PORT")"
+ls -l "$PORT"; fuser -v "$TTY" || true
+cat "/sys/bus/usb-serial/devices/${TTY##*/}/latency_timer"
+# If not 1, human runs: echo 1 | sudo tee "/sys/bus/usb-serial/devices/${TTY##*/}/latency_timer"
+```
 
 ## Build
 
 ```bash
 cd ~/py-bacnet-stacks-playground/vibe_code_apps_13
-cargo build --release --locked -p mstp-mini-device -p mstp-probe
+cargo build --release --locked -p mstp-passive-sniff -p mstp-fec-diag -p mstp-mini-device
 ```
 
-## Start mini-device (adapter B)
+## Gate 2 — Passive (no TX)
+
+Only one process may own the tty. Stop mini-device / fec-diag first.
 
 ```bash
-./target/release/mstp-mini-device \
-  --serial /dev/serial/by-id/<DEVICE_ADAPTER> \
-  --baud 38400 \
-  --mac 1 \
-  --max-master 10 \
-  --max-info-frames 1 \
-  --device-instance 123001 \
-  --vendor-id 999
+cargo run --release -p mstp-passive-sniff -- \
+  --serial "$PORT" --baud 38400 --seconds 60 \
+  --report captures/mstp-passive-crc-fixed.json
 ```
 
-## Probe smoke (adapter A)
+PASS: `rx_bytes>0`, `tokens>0`, sources include **0 and 7**, `token_0_from_7>0`, Workbench stays online, **no Rust TX**.
+
+## Gate 3 — Client-only FEC (after passive)
 
 ```bash
-./target/release/mstp-probe \
-  --profile smoke \
-  --baud 38400 \
-  --repeated-reads 10 \
-  --report captures/mstp-hardware-smoke.json \
-  hardware \
-  --probe-serial /dev/serial/by-id/<PROBE_ADAPTER> \
-  --device-serial /dev/serial/by-id/<DEVICE_ADAPTER>
+cargo run --release -p mstp-fec-diag -- \
+  --serial "$PORT" --baud 38400 --mac 3 --max-master 7 --max-info-frames 1 \
+  --device-instance 5007 --expect-mac 7 --ai-instance 1173 \
+  --settle-ms 30000 --apdu-timeout-ms 15000 \
+  --loop-secs 30 --loop-count 20 \
+  --report captures/mstp-fec-ai1173-30s.json
 ```
 
-`--device-serial` is **report metadata only** — the probe never opens the device tty.
+Read-only. Never WriteProperty to the FEC. Start with AI:1173 (OA-T).
 
-## Probe gate (≥500 reads)
+**Join tip:** Rust station `--max-master 7` (highest known master on this bench) so PollForMaster admits MAC 3 in tens of seconds. BASRT/FEC may keep Max_Master=127. Settle ≥30s; I-Am wait uses `--apdu-timeout-ms`.
 
-```bash
-./target/release/mstp-probe \
-  --profile gate \
-  --baud 38400 \
-  --repeated-reads 500 \
-  --report captures/mstp-hardware-gate.json \
-  hardware \
-  --probe-serial /dev/serial/by-id/<PROBE_ADAPTER> \
-  --device-serial /dev/serial/by-id/<DEVICE_ADAPTER>
-```
+## Gate 4 — Mini-device server-only
 
-## Matrix to run on the bench
+Stop fec-diag first. Then `mstp-mini-device` on MAC 3 / instance 123001; validate from Workbench/BASRT.
 
-1. Startup order: device-first / probe-first
-2. Sole-master then returning-master admission
-3. Duplicate-MAC negative (expect clear failure)
-4. Baud-mismatch negative (never false PASS)
-5. Unplug / fail-fast
-6. 500-read gate
-7. One-hour soak
-8. Later: per-baud matrix (9600…115200)
+## Gates 5–6
 
-## Report expectations
+Combined server+requester + FEC mirror + soak — see Phase 2 Rescue prompt / `PHASE_2_MSTP_MINI_DEVICE.md`. Not claimed PASS until evidence exists.
 
-Hardware reports must eventually include Git commit, rusty-bacnet SHA, kernel/arch, by-id paths, USB IDs, driver, actual baud, Max_Master, Max_Info_Frames, termination/bias notes, start/end, exit reason, and `hardware_evidence=true`.
+## rusty-bacnet pin
 
-Loopback must never set `hardware_evidence=true`.
+Workspace pins `bbartling/rusty-bacnet` @ `73a1fd4…` (Clause 9 CRC + USB stream + LOC split). Upstream PR: https://github.com/jscott3201/rusty-bacnet/pull/464 — re-pin to `jscott3201` when merged.

--- a/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
+++ b/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Phase 2 — Hardware runbook (BASRT + JCI FEC + Waveshare C)
 
-**Status (2026-08-31):** Live midspan/end-of-line bench. Software pin **`af4e886`** (`jscott3201/rusty-bacnet` dev — #467/#468 merged). Gate 2–4 hardware **PASS** on historical pin `19d205d`; **revalidation required** on `af4e886`. Gates 5–6 open.
+**Status (2026-08-31):** Live midspan/end-of-line bench. Software pin **`af4e886`** (`jscott3201/rusty-bacnet` dev — #467/#468 merged). Gates 2–4 hardware **PASS** on `af4e886` (2026-08-31 smoke). Gates 5–6 open.
 
 **Upstream:** [#467](https://github.com/jscott3201/rusty-bacnet/pull/467) and [#468](https://github.com/jscott3201/rusty-bacnet/pull/468) **merged**. Limitations: not conformance; no extended frames; Gates 5–6 open.
 
@@ -50,18 +50,18 @@ cargo build --release --locked -p mstp-passive-sniff -p mstp-fec-diag -p mstp-mi
 ```bash
 cargo run --release --locked -p mstp-passive-sniff -- \
   --serial "$PORT" --baud 38400 --seconds 60 \
-  --report captures/mstp-passive-crc-fixed.json
+  --report captures/mstp-passive-af4e886-60s.json
 ```
 
-PASS: `rx_bytes>0`, `tokens>0`, sources include **0 and 7**, `token_0_from_7>0`, Workbench stays online, **no Rust TX**.
+PASS: report **`ok=true`** (command exit 0), `rx_bytes>0`, `tokens>0`, sources include **0 and 7**, `token_0_from_7>0`, Workbench stays online, **no Rust TX**. Historical `captures/mstp-passive-crc-fixed.json` (`rusty_bacnet_rev` `6a70b85`) is archived — not evidence for `af4e886`.
 
 ## Gate 3 — Client-only FEC
 
-**Status:** PASS on pin `e3b9edb` after 9.5.6 fix (prior `73a1fd4` coexistence FAIL archived in `captures/mstp-gate3-coexistence-abort.json`).
+**Status:** PASS on pin `af4e886` (2026-08-31 one-shot; historical `e3b9edb` on `19d205d` archived).
 
 `mstp-fec-diag` always does setup reads (I-Am / object-name / AI) then optional loops.
 
-**One-shot (setup reads only — default loop-count 1):**
+**One-shot (setup + one periodic read — `--loop-count 1`):**
 
 ```bash
 cargo run --release --locked -p mstp-fec-diag -- \
@@ -98,7 +98,7 @@ Read-only vs FEC. Never WriteProperty to the FEC.
 
 ## Gate 4 — Mini-device server-only
 
-**Status: PASS (2026-08-30)** — JENEsys discovered `device:123001` / points Polled `{ok}` while FEC stayed online.
+**Status: PASS (2026-08-31, pin `af4e886`)** — JENEsys discovered `device:123001` / points Polled `{ok}` while FEC stayed online.
 
 Stop any other holder of `$PORT`, then:
 

--- a/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
+++ b/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
@@ -1,8 +1,8 @@
 # Phase 2 — Hardware runbook (BASRT + JCI FEC + Waveshare C)
 
-**Status (2026-08-30):** Live midspan/end-of-line bench. Pin **`e3b9edb`** (fork `vibe13-mstp`). Gate 2–4 hardware **PASS** with Workbench. Gates 5–6 open. Loopback ≠ soak PASS.
+**Status (2026-08-30):** Live midspan/end-of-line bench. Software pin **`19d205d`** (MS/TP-equivalent to lab `e3b9edb`; fork `vibe13-mstp` rebased on upstream `dev`). Gate 2–4 hardware **PASS** with Workbench. Gates 5–6 open. Loopback ≠ soak PASS.
 
-**Active rescue:** Phase 2 on bbartling fork only (no upstream contribution).
+**Upstream:** [rusty-bacnet#467](https://github.com/jscott3201/rusty-bacnet/pull/467) (CRC + USB stream + 9.5.6). Limitations: not conformance; no extended frames; Gates 5–6 open.
 
 ## Topology (current)
 
@@ -23,7 +23,7 @@ termination enabled            termination disabled          fixed ~130 ohms
 | Rust station MAC | **3** (never 0 with BASRT; never 7) |
 | Mini-device instance | 123001 |
 | Max_Info_Frames (initial) | 1 |
-| rusty-bacnet | `bbartling/rusty-bacnet` @ `e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef` |
+| rusty-bacnet | `bbartling/rusty-bacnet` @ `19d205d78c947aea3fe98110d8a6c392359aa627` |
 
 Powered-off trunk A/B should read ≈ **60–65 Ω**. ≈40–45 Ω ⇒ three terminations — fix before TX.
 
@@ -116,4 +116,5 @@ In Workbench: Who-Is / discover on the MS/TP network → **Rust MS/TP Mini Devic
 
 ## rusty-bacnet pin
 
-Fork-only: `bbartling/rusty-bacnet` default branch `vibe13-mstp` @ `e3b9edb…`. Do not open PRs against upstream for this train.
+`bbartling/rusty-bacnet` @ `19d205d…` (`vibe13-mstp` / `pr/mstp-clause9-interop`). Upstream: https://github.com/jscott3201/rusty-bacnet/pull/467
+

--- a/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
+++ b/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
@@ -1,8 +1,8 @@
 # Phase 2 — Hardware runbook (BASRT + JCI FEC + Waveshare C)
 
-**Status (2026-08-30):** Live midspan/end-of-line bench. Software pin **`19d205d`** (MS/TP-equivalent to lab `e3b9edb`; fork `vibe13-mstp` rebased on upstream `dev`). Gate 2–4 hardware **PASS** with Workbench. Gates 5–6 open. Loopback ≠ soak PASS.
+**Status (2026-08-31):** Live midspan/end-of-line bench. Software pin **`af4e886`** (`jscott3201/rusty-bacnet` dev — #467/#468 merged). Gate 2–4 hardware **PASS** on historical pin `19d205d`; **revalidation required** on `af4e886`. Gates 5–6 open.
 
-**Upstream:** [rusty-bacnet#467](https://github.com/jscott3201/rusty-bacnet/pull/467) (CRC + USB stream + 9.5.6). Limitations: not conformance; no extended frames; Gates 5–6 open.
+**Upstream:** [#467](https://github.com/jscott3201/rusty-bacnet/pull/467) and [#468](https://github.com/jscott3201/rusty-bacnet/pull/468) **merged**. Limitations: not conformance; no extended frames; Gates 5–6 open.
 
 ## Topology (current)
 
@@ -23,7 +23,7 @@ termination enabled            termination disabled          fixed ~130 ohms
 | Rust station MAC | **3** (never 0 with BASRT; never 7) |
 | Mini-device instance | 123001 |
 | Max_Info_Frames (initial) | 1 |
-| rusty-bacnet | `bbartling/rusty-bacnet` @ `19d205d78c947aea3fe98110d8a6c392359aa627` |
+| rusty-bacnet | `jscott3201/rusty-bacnet` @ `af4e88680c51eb4da64dac47f0540a35bf184732` |
 
 Powered-off trunk A/B should read ≈ **60–65 Ω**. ≈40–45 Ω ⇒ three terminations — fix before TX.
 
@@ -110,11 +110,21 @@ cargo run --release --locked -p mstp-mini-device -- \
 
 In Workbench: Who-Is / discover on the MS/TP network → **Rust MS/TP Mini Device**.
 
+## Gate 4b — Haystack trunk (supervisory, parallel evidence)
+
+Requires `HAYSTACK_USER` / `HAYSTACK_PASS` (e.g. from `~/open-fdd/.env`):
+
+```bash
+./scripts/check_mstp_haystack_trunk.sh check          # before/after functional matrix
+./scripts/check_mstp_haystack_trunk.sh perturb-stop-mini   # mini-device stopped; FEC still ok
+./scripts/check_mstp_haystack_trunk.sh restore      # after mini-device restarted
+```
+
 ## Gates 5–6
 
 **OPEN.** Combined endpoint + mirror + long soak — not claimed.
 
 ## rusty-bacnet pin
 
-`bbartling/rusty-bacnet` @ `19d205d…` (`vibe13-mstp` / `pr/mstp-clause9-interop`). Upstream: https://github.com/jscott3201/rusty-bacnet/pull/467
+`jscott3201/rusty-bacnet` @ `af4e886…` (dev after #467/#468). Historical: `bbartling` @ `19d205d…`.
 

--- a/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
+++ b/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
@@ -1,7 +1,8 @@
 # Phase 2 — Hardware runbook (BASRT + JCI FEC + Waveshare C)
 
-**Status (2026-08-30):** Live midspan/end-of-line bench exists. Loopback ≠ hardware PASS.  
-**Active rescue prompt:** Phase 2 Rescue (CRC Clause 9 + gates 1–6). Historical Cursor plan `vibe13_ms_tp_usb_fix_*` is obsolete.
+**Status (2026-08-30):** Live midspan/end-of-line bench. Pin **`e3b9edb`** (fork `vibe13-mstp`). Gate 2–4 hardware **PASS** with Workbench. Gates 5–6 open. Loopback ≠ soak PASS.
+
+**Active rescue:** Phase 2 on bbartling fork only (no upstream contribution).
 
 ## Topology (current)
 
@@ -18,11 +19,11 @@ termination enabled            termination disabled          fixed ~130 ohms
 |---------|--------|
 | Baud | 38,400 |
 | BASRT MS/TP MAC / net | 0 / 2000 |
-| BASRT Max_Master | 127 |
 | FEC MAC / device instance | 7 / 5007 |
 | Rust station MAC | **3** (never 0 with BASRT; never 7) |
 | Mini-device instance | 123001 |
 | Max_Info_Frames (initial) | 1 |
+| rusty-bacnet | `bbartling/rusty-bacnet` @ `e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef` |
 
 Powered-off trunk A/B should read ≈ **60–65 Ω**. ≈40–45 Ω ⇒ three terminations — fix before TX.
 
@@ -35,7 +36,6 @@ PORT=/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0
 TTY="$(readlink -f "$PORT")"
 ls -l "$PORT"; fuser -v "$TTY" || true
 cat "/sys/bus/usb-serial/devices/${TTY##*/}/latency_timer"
-# If not 1, human runs: echo 1 | sudo tee "/sys/bus/usb-serial/devices/${TTY##*/}/latency_timer"
 ```
 
 ## Build
@@ -47,24 +47,46 @@ cargo build --release --locked -p mstp-passive-sniff -p mstp-fec-diag -p mstp-mi
 
 ## Gate 2 — Passive (no TX)
 
-Only one process may own the tty. Stop mini-device / fec-diag first.
-
 ```bash
-cargo run --release -p mstp-passive-sniff -- \
+cargo run --release --locked -p mstp-passive-sniff -- \
   --serial "$PORT" --baud 38400 --seconds 60 \
   --report captures/mstp-passive-crc-fixed.json
 ```
 
 PASS: `rx_bytes>0`, `tokens>0`, sources include **0 and 7**, `token_0_from_7>0`, Workbench stays online, **no Rust TX**.
 
-## Gate 3 — Client-only FEC (after passive)
+## Gate 3 — Client-only FEC
 
-**Status:** application exchange can succeed while **network coexistence FAIL**. Do **not** run live TX on pin `73a1fd4` — requires Clause 9.5.6 PR https://github.com/jscott3201/rusty-bacnet/pull/465 and token-edge telemetry. Abort evidence: `captures/mstp-gate3-coexistence-abort.json`.
+**Status:** PASS on pin `e3b9edb` after 9.5.6 fix (prior `73a1fd4` coexistence FAIL archived in `captures/mstp-gate3-coexistence-abort.json`).
 
-When unblocked (post-pin), sequence: join with **no** app traffic → confirm edges `0→3`, `3→7`, `7→0` → one Who-Is → one RP → five 30s reads with Workbench watched → only then 20× soak.
+`mstp-fec-diag` always does setup reads (I-Am / object-name / AI) then optional loops.
+
+**One-shot (setup reads only — default loop-count 1):**
 
 ```bash
-cargo run --release -p mstp-fec-diag -- \
+cargo run --release --locked -p mstp-fec-diag -- \
+  --serial "$PORT" --baud 38400 --mac 3 --max-master 7 --max-info-frames 1 \
+  --device-instance 5007 --expect-mac 7 --ai-instance 1173 \
+  --settle-ms 30000 --apdu-timeout-ms 15000 \
+  --loop-secs 30 --loop-count 1 \
+  --report captures/mstp-fec-ai1173-oneshot.json
+```
+
+**Five 30s reads (operator watches Workbench):**
+
+```bash
+cargo run --release --locked -p mstp-fec-diag -- \
+  --serial "$PORT" --baud 38400 --mac 3 --max-master 7 --max-info-frames 1 \
+  --device-instance 5007 --expect-mac 7 --ai-instance 1173 \
+  --settle-ms 30000 --apdu-timeout-ms 15000 \
+  --loop-secs 30 --loop-count 5 \
+  --report captures/mstp-fec-ai1173-5x30s.json
+```
+
+**Twenty 30s soak (only after five-read coexistence holds):**
+
+```bash
+cargo run --release --locked -p mstp-fec-diag -- \
   --serial "$PORT" --baud 38400 --mac 3 --max-master 7 --max-info-frames 1 \
   --device-instance 5007 --expect-mac 7 --ai-instance 1173 \
   --settle-ms 30000 --apdu-timeout-ms 15000 \
@@ -72,21 +94,26 @@ cargo run --release -p mstp-fec-diag -- \
   --report captures/mstp-fec-ai1173-30s.json
 ```
 
-Read-only. Never WriteProperty to the FEC. Start with AI:1173 (OA-T).
-
-**Join tip:** Rust station `--max-master 7` (highest known master on this bench). Longer waits / Max_Master tweaks are **not** substitutes for the 9.5.6 state-machine fix.
+Read-only vs FEC. Never WriteProperty to the FEC.
 
 ## Gate 4 — Mini-device server-only
 
-**BLOCKED** until Gate 3 coexistence PASS.
+**Status: PASS (2026-08-30)** — JENEsys discovered `device:123001` / points Polled `{ok}` while FEC stayed online.
 
-Stop fec-diag first. Then `mstp-mini-device` on MAC 3 / instance 123001; validate from Workbench/BASRT.
+Stop any other holder of `$PORT`, then:
+
+```bash
+cargo run --release --locked -p mstp-mini-device -- \
+  --serial "$PORT" --baud 38400 --mac 3 --max-master 7 --max-info-frames 1 \
+  --device-instance 123001 --name "Rust MS/TP Mini Device" --vendor-id 999
+```
+
+In Workbench: Who-Is / discover on the MS/TP network → **Rust MS/TP Mini Device**.
 
 ## Gates 5–6
 
-**BLOCKED.** Combined server+requester + FEC mirror + soak — see Phase 2 Rescue prompt / `PHASE_2_MSTP_MINI_DEVICE.md`. Not claimed PASS until evidence exists.
+**OPEN.** Combined endpoint + mirror + long soak — not claimed.
 
 ## rusty-bacnet pin
 
-Workspace pins `bbartling/rusty-bacnet` @ `73a1fd4…` (Clause 9 CRC + USB stream + LOC split). Upstream CRC: https://github.com/jscott3201/rusty-bacnet/pull/464.  
-**Required follow-up pin:** Clause 9.5.6 token/PFM https://github.com/jscott3201/rusty-bacnet/pull/465 — do not resume live TX until pinned and regressions A–E are green in-tree.
+Fork-only: `bbartling/rusty-bacnet` default branch `vibe13-mstp` @ `e3b9edb…`. Do not open PRs against upstream for this train.

--- a/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
+++ b/vibe_code_apps_13/docs/PHASE2_HARDWARE_RUNBOOK.md
@@ -59,6 +59,10 @@ PASS: `rx_bytes>0`, `tokens>0`, sources include **0 and 7**, `token_0_from_7>0`,
 
 ## Gate 3 — Client-only FEC (after passive)
 
+**Status:** application exchange can succeed while **network coexistence FAIL**. Do **not** run live TX on pin `73a1fd4` — requires Clause 9.5.6 PR https://github.com/jscott3201/rusty-bacnet/pull/465 and token-edge telemetry. Abort evidence: `captures/mstp-gate3-coexistence-abort.json`.
+
+When unblocked (post-pin), sequence: join with **no** app traffic → confirm edges `0→3`, `3→7`, `7→0` → one Who-Is → one RP → five 30s reads with Workbench watched → only then 20× soak.
+
 ```bash
 cargo run --release -p mstp-fec-diag -- \
   --serial "$PORT" --baud 38400 --mac 3 --max-master 7 --max-info-frames 1 \
@@ -70,16 +74,19 @@ cargo run --release -p mstp-fec-diag -- \
 
 Read-only. Never WriteProperty to the FEC. Start with AI:1173 (OA-T).
 
-**Join tip:** Rust station `--max-master 7` (highest known master on this bench) so PollForMaster admits MAC 3 in tens of seconds. BASRT/FEC may keep Max_Master=127. Settle ≥30s; I-Am wait uses `--apdu-timeout-ms`.
+**Join tip:** Rust station `--max-master 7` (highest known master on this bench). Longer waits / Max_Master tweaks are **not** substitutes for the 9.5.6 state-machine fix.
 
 ## Gate 4 — Mini-device server-only
+
+**BLOCKED** until Gate 3 coexistence PASS.
 
 Stop fec-diag first. Then `mstp-mini-device` on MAC 3 / instance 123001; validate from Workbench/BASRT.
 
 ## Gates 5–6
 
-Combined server+requester + FEC mirror + soak — see Phase 2 Rescue prompt / `PHASE_2_MSTP_MINI_DEVICE.md`. Not claimed PASS until evidence exists.
+**BLOCKED.** Combined server+requester + FEC mirror + soak — see Phase 2 Rescue prompt / `PHASE_2_MSTP_MINI_DEVICE.md`. Not claimed PASS until evidence exists.
 
 ## rusty-bacnet pin
 
-Workspace pins `bbartling/rusty-bacnet` @ `73a1fd4…` (Clause 9 CRC + USB stream + LOC split). Upstream PR: https://github.com/jscott3201/rusty-bacnet/pull/464 — re-pin to `jscott3201` when merged.
+Workspace pins `bbartling/rusty-bacnet` @ `73a1fd4…` (Clause 9 CRC + USB stream + LOC split). Upstream CRC: https://github.com/jscott3201/rusty-bacnet/pull/464.  
+**Required follow-up pin:** Clause 9.5.6 token/PFM https://github.com/jscott3201/rusty-bacnet/pull/465 — do not resume live TX until pinned and regressions A–E are green in-tree.

--- a/vibe_code_apps_13/docs/PHASE2_PICS_EVIDENCE.md
+++ b/vibe_code_apps_13/docs/PHASE2_PICS_EVIDENCE.md
@@ -1,0 +1,55 @@
+# Phase 2 PICS-like evidence (project lab — not BTL certification)
+
+This document records **tested** BACnet Device and point behavior for the Vibe13 Rust MS/TP mini-device. It is derived from automated acceptance (`mstp-probe --profile gate`) and live service reads — not an official PICS submission.
+
+**Pin:** `jscott3201/rusty-bacnet` @ `af4e88680c51eb4da64dac47f0540a35bf184732`  
+**Device:** instance `123001`, MAC `3`, standard frames only, `Max_APDU_Length_Accepted=480`, `Segmentation_Supported=no segmentation`.
+
+## Device object (ReadProperty verified)
+
+| Property | Expected / observed |
+|----------|---------------------|
+| Object_Identifier | `device,123001` |
+| Object_Name | `Rust MS/TP Mini Device` |
+| Object_Type | `device` (8) |
+| System_Status | operational (0) |
+| Vendor_Name | `vibe13-mstp-lab` |
+| Vendor_Identifier | 999 (lab placeholder) |
+| Model_Name | `mstp-mini-device` |
+| Application_Software_Version | crate `0.1.0` |
+| Protocol_Version / Protocol_Revision | 1 / 22 |
+| Protocol_Services_Supported | bitstring (loopback + hardware acceptance) |
+| Protocol_Object_Types_Supported | device + AI/BI/AV/BV |
+| Object_List[0] | array count 5 |
+| Object_List[1..] | device + AI:1 + BI:1 + AV:2 + BV:2 |
+| Max_APDU_Length_Accepted | 480 |
+| Segmentation_Supported | no segmentation (3) |
+| APDU_Timeout | 6000 ms |
+| Number_Of_APDU_Retries | 3 |
+
+## Point services (BACnet services)
+
+| Service | Result |
+|---------|--------|
+| Who-Is / I-Am | PASS |
+| ReadProperty Device/Object_Name | PASS |
+| ReadProperty AI:1 / BI:1 Present_Value | PASS |
+| ReadPropertyMultiple | PASS |
+| WriteProperty AV:2 @ priority 8 + readback | PASS |
+| Relinquish AV:2 @ priority 8 (NULL) | PASS |
+| WriteProperty BV:2 + relinquish | PASS |
+| WriteProperty AI:1 / BI:1 Present_Value | write-access-denied |
+| Unknown object AI:99 | unknown-object |
+| Invalid Object_List index | invalid-array-index |
+| Unknown property array index | property-is-not-an-array |
+
+## Explicit non-claims
+
+- Not Clause 9 conformant
+- Not BTL certified
+- No extended MS/TP (types 32/33)
+- No MS/TP segmentation
+- No simultaneous FEC mirror + local server
+- Not a BACnet router
+
+Historical captures labeled `19d205d` / `e3b9edb` predate this pin and require revalidation before reuse.

--- a/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
+++ b/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-08-30  
 **Branch:** `fix/vibe13-mstp-crc-phase2`  
-**rusty-bacnet pin:** `bbartling/rusty-bacnet` @ `e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef` (`vibe13-mstp` / fork **only** — not contributed upstream)
+**rusty-bacnet pin:** `bbartling/rusty-bacnet` @ `19d205d78c947aea3fe98110d8a6c392359aa627` (rebased on upstream `dev`; MS/TP equivalent to lab pin `e3b9edb`)  
+**Upstream PR:** https://github.com/jscott3201/rusty-bacnet/pull/467
 
 **Hardware evidence:** Gate 2 passive **PASS**. Gate 3 FEC application **PASS**. Gate 3 coexistence **PASS** on `e3b9edb` (mini-device MAC 3 + Workbench/FEC stay up). Gate 4 mini-device **PASS** (JENEsys discover + points `{ok}`). Gates 5–6 still open. Loopback ≠ hardware for soak claims.
 
@@ -52,6 +53,8 @@ Do **not** resume open-fdd bosspi MQTT soaks on this Waveshare while mini-device
 
 ## Known limitations
 
-- Gates 5–6 not claimed.
+- Gates 5–6 not claimed (shared endpoint + soak).
 - Transitive `socket2` still in dep graph; runtime must not open IP sockets.
-- Fork-only rusty-bacnet tip; upstream PRs closed on purpose.
+- Not a Clause 9 conformance claim; no extended frames (32/33 / COBS / CRC-32K).
+- Host USB stale-partial timeout ≠ wire `T_frame_abort`.
+- Upstream contribution is open as PR #467 (MS/TP-only; Windows retry-budget timeout stays on fork `main` only).

--- a/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
+++ b/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
@@ -2,75 +2,56 @@
 
 **Date:** 2026-08-30  
 **Branch:** `fix/vibe13-mstp-crc-phase2`  
-**rusty-bacnet pin:** `bbartling/rusty-bacnet` @ `73a1fd41df7df2dfb3fa005cf339f347751f0286`  
-(Upstream CRC PR: https://github.com/jscott3201/rusty-bacnet/pull/464 — still required.)  
-**Follow-up (required before live TX):** Clause 9.5.6 token/PFM — https://github.com/jscott3201/rusty-bacnet/pull/465 (`e3b9edb` on `fix/mstp-clause956-token-pfm`).
+**rusty-bacnet pin:** `bbartling/rusty-bacnet` @ `e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef` (`vibe13-mstp` / fork **only** — not contributed upstream)
 
-**Hardware evidence:** Gate 2 passive **PASS**. Gate 3 **application exchange PASS / coexistence FAIL**. Active TX **blocked** until #465 + deterministic tests are pinned. Loopback ≠ hardware.
+**Hardware evidence:** Gate 2 passive **PASS**. Gate 3 FEC application **PASS**. Gate 3 coexistence **PASS** on `e3b9edb` (mini-device MAC 3 + Workbench/FEC stay up). Gate 4 mini-device **PASS** (JENEsys discover + points `{ok}`). Gates 5–6 still open. Loopback ≠ hardware for soak claims.
+
+## Status model (explicit)
+
+| Gate | Software / offline | Live hardware |
+|------|-------------------|---------------|
+| 1 CRC + USB stream | **PASS** | **PASS** (via pin) |
+| 2 Passive | n/a | **PASS** `mstp-passive-crc-fixed.json` |
+| 3 FEC client app exchange | loopback N/A | **PASS** oneshot |
+| 3 Network coexistence | regressions A–E **PASS** | **PASS** on `e3b9edb` (Workbench online with MAC 3 TX) |
+| 4 Mini-device discoverable | loopback acceptance **PASS** | **PASS** JENEsys device:123001 + 4 points Polled `{ok}` |
+| 5 Shared endpoint + mirror | **OPEN** | **OPEN** |
+| 6 Long soak | **OPEN** | **OPEN** |
 
 ## Root-cause correction
 
 | Claim | Verdict |
 |-------|---------|
-| Token `55 FF 00 00 07 00 00 37` has “invalid” header CRC | **Wrong** — Clause 9.6 `CRC8([00,00,07,00,00]) == 0x37` |
-| Primary blocker was USB `latency_timer` | Partial — latency matters for delivery; **CRC polys** were the interoperability break |
-| Prior rusty-bacnet CRC `0xE0` / `0xA001` | Incorrect (self-round-trip only) |
-| Correct polys | Header `0x81`, data `0x8408` |
-| USB read gaps as `T_frame_abort` | Incorrect host policy — fixed in `a9912b8` |
-| Gate 3 FEC read success ⇒ trunk coexistence OK | **Wrong** — Workbench/FEC went offline while MAC 3 participated |
-| Root cause of coexistence FAIL | Clause **9.5.6** master SM (reversed maintenance scan `PS=NS+1`, Token `TS→TS`) — **not** CRC/wiring/latency/APDU/Max_Master |
+| Token header CRC “invalid” | **Wrong** — Clause 9.6 polys |
+| Primary blocker = `latency_timer` | Partial; CRC was the decode break |
+| Gate 3 FEC read ⇒ coexistence OK | **Wrong** on `73a1fd4` — FAIL until 9.5.6 |
+| Coexistence root cause | Clause **9.5.6** DONE_WITH_TOKEN / PFM (not Max_Master waits) |
+| Fix location | Fork `vibe13-mstp` @ `e3b9edb` |
 
-## Software checks (CRC pin `73a1fd4`)
+## Software checks (pin `e3b9edb`)
 
 | Check | Result |
 |-------|--------|
-| Upstream `cargo test -p bacnet-transport` (Clause 9 golden + stream) | PASS (2026-08-30) |
-| Vibe13 offline Token 0←7 fixture (`mstp-passive-sniff` unit tests) | expected PASS after lock update |
-| `./scripts/check_mstp_no_ip.sh` | required before handoff |
-| Loopback `mstp-probe` | still valid software smoke; `hardware_evidence=false` |
+| `cargo test -p bacnet-transport --lib` (incl. clause956 A–E) | PASS |
+| Workspace pin + `Cargo.lock` → `e3b9edb` | PASS |
+| `./scripts/check_mstp_no_ip.sh` | OK local sources; socket2 transitive **documented BLOCKED** in `captures/phase2-no-ip-gate-status.txt` |
+| Loopback `mstp-probe` / acceptance | PASS (`hardware_evidence=false`) |
+| `TokenEdgeCounters` unit tests | PASS |
 
-## Software checks (9.5.6 PR #465 — not yet pinned in workspace)
+## Gate 4 Workbench notes (2026-08-30)
 
-| Check | Result |
-|-------|--------|
-| Regressions A–E (`clause956_tests.rs`) | PASS on `e3b9edb` |
-| 2000-rotation ring `0→3→7→0`, no self-token | PASS |
-| Live TX retest | **BLOCKED** until pin + token-edge telemetry |
+- Device **Rust MS/TP Mini Device** / `device:123001` / MAC **3** discovered; `systemStatus=Operational`.
+- Points: AI:1, BI:1, AV:2, BV:2 all **Polled `{ok}`**.
+- Niagara may show Write=`readonly` on AV/BV after discover-add — that is often a **Niagara point facet**, not proof the BACnet objects reject WP. Validate with an explicit WriteProperty / priority command.
+- AI units are BACnet **degrees-Fahrenheit (62)**; Niagara UI may display `°C` depending on facets.
+- Name slash may become `Rust MS.TP…` in Niagara — cosmetic.
 
-## Phase 2 hardware gates (Rescue prompt)
+## Active-TX / open-fdd note
 
-| Gate | Status |
-|------|--------|
-| 1 Transport CRC + USB fragmentation | **PASS** on pin `73a1fd4` |
-| 2 Passive live bus | **PASS** — `captures/mstp-passive-crc-fixed.json` |
-| 3 Client FEC application exchange | **PASS** one-shot — `captures/mstp-fec-ai1173-oneshot.json` |
-| 3 Network coexistence | **FAIL** — `captures/mstp-gate3-coexistence-abort.json` (Workbench/FEC offline under MAC 3 TX) |
-| 3 Overall | **FAIL** / active TX blocked |
-| 4 Mini-device server-only | **BLOCKED** |
-| 5 Combined endpoint + mirror | **BLOCKED** |
-| 6 Soak | **BLOCKED** — 20×30s must not be marked PASS |
-
-### Gate 3 abort notes
-
-- `application_exchange_ok=true`, `coexistence_ok=false`, `overall_ok=false`
-- `exit_reason="aborted: existing MS/TP trunk went offline"`
-- Invalid maintenance path at `TS=3,NS=7,Max_Master=7` previously set `PS=next(NS)=0` and PFM’d BASRT, allowing ring `0→3→0` and excluding FEC 7
-- Waveshare C may also load the trunk electrically (fixed termination) — unplug before resuming open-fdd bosspi MQTT soaks if Workbench is offline
-
-### Re-test order (after #465 pin only)
-
-1. Passive 60s (Workbench online)  
-2. Active join, **no** application traffic — verify token edges `0→3`, `3→7`, `7→0`  
-3. One Who-Is  
-4. One ReadProperty  
-5. Five 30s reads while operator watches Workbench  
-6. Only then twenty-read soak  
-
-A successful FEC read alone must never set `hardware_ok=true`.
+Do **not** resume open-fdd bosspi MQTT soaks on this Waveshare while mini-device owns the tty. Unplug Waveshare (or stop mini-device) before bosspi fieldbus, and keep pin ≥ `e3b9edb` if rejoining this trunk.
 
 ## Known limitations
 
-- Workspace still on CRC tip `73a1fd4` until #465 is reviewed and re-pinned.
-- Shared server+requester endpoint (Workstream E) not implemented yet.
-- Transitive `socket2` still present; runtime must not open IP sockets (Phase 2 apps).
-- PR #126 is merged on `develop` (`eb178f70`); old USB-only Cursor plan is historical.
+- Gates 5–6 not claimed.
+- Transitive `socket2` still in dep graph; runtime must not open IP sockets.
+- Fork-only rusty-bacnet tip; upstream PRs closed on purpose.

--- a/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
+++ b/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
@@ -3,9 +3,10 @@
 **Date:** 2026-08-30  
 **Branch:** `fix/vibe13-mstp-crc-phase2`  
 **rusty-bacnet pin:** `bbartling/rusty-bacnet` @ `73a1fd41df7df2dfb3fa005cf339f347751f0286`  
-(Upstream PR: https://github.com/jscott3201/rusty-bacnet/pull/464 — re-pin to `jscott3201` when merged.)
+(Upstream CRC PR: https://github.com/jscott3201/rusty-bacnet/pull/464 — still required.)  
+**Follow-up (required before live TX):** Clause 9.5.6 token/PFM — https://github.com/jscott3201/rusty-bacnet/pull/465 (`e3b9edb` on `fix/mstp-clause956-token-pfm`).
 
-**Hardware evidence:** Gate 2 passive **PASS** (`captures/mstp-passive-crc-fixed.json`). Gate 3+ OPEN. Loopback ≠ hardware.
+**Hardware evidence:** Gate 2 passive **PASS**. Gate 3 **application exchange PASS / coexistence FAIL**. Active TX **blocked** until #465 + deterministic tests are pinned. Loopback ≠ hardware.
 
 ## Root-cause correction
 
@@ -16,8 +17,10 @@
 | Prior rusty-bacnet CRC `0xE0` / `0xA001` | Incorrect (self-round-trip only) |
 | Correct polys | Header `0x81`, data `0x8408` |
 | USB read gaps as `T_frame_abort` | Incorrect host policy — fixed in `a9912b8` |
+| Gate 3 FEC read success ⇒ trunk coexistence OK | **Wrong** — Workbench/FEC went offline while MAC 3 participated |
+| Root cause of coexistence FAIL | Clause **9.5.6** master SM (reversed maintenance scan `PS=NS+1`, Token `TS→TS`) — **not** CRC/wiring/latency/APDU/Max_Master |
 
-## Software checks (this pin)
+## Software checks (CRC pin `73a1fd4`)
 
 | Check | Result |
 |-------|--------|
@@ -26,26 +29,48 @@
 | `./scripts/check_mstp_no_ip.sh` | required before handoff |
 | Loopback `mstp-probe` | still valid software smoke; `hardware_evidence=false` |
 
+## Software checks (9.5.6 PR #465 — not yet pinned in workspace)
+
+| Check | Result |
+|-------|--------|
+| Regressions A–E (`clause956_tests.rs`) | PASS on `e3b9edb` |
+| 2000-rotation ring `0→3→7→0`, no self-token | PASS |
+| Live TX retest | **BLOCKED** until pin + token-edge telemetry |
+
 ## Phase 2 hardware gates (Rescue prompt)
 
 | Gate | Status |
 |------|--------|
-| 1 Transport CRC + USB fragmentation | **Software PASS** on pin `73a1fd4` |
-| 2 Passive live bus | **PASS** 2026-08-30 — `captures/mstp-passive-crc-fixed.json` (45s: rx=25651, frames=2971, tokens=2117, token_0_from_7=1058, sources=[0,7], invalid=2, valid_ratio≈0.999) |
-| 3 Client-only FEC AI:1173 | **PASS one-shot** — `captures/mstp-fec-ai1173-oneshot.json` (I-Am@7, `BENS BENCHTEST BOX`, PV≈75.57). 20×30s: `captures/mstp-fec-ai1173-30s.*`. Rust `--max-master 7` for PFM join. |
-| 4 Mini-device server-only | **OPEN** |
-| 5 Combined endpoint + mirror | **OPEN** (needs Workstream E upstream) |
-| 6 Soak | **OPEN** |
+| 1 Transport CRC + USB fragmentation | **PASS** on pin `73a1fd4` |
+| 2 Passive live bus | **PASS** — `captures/mstp-passive-crc-fixed.json` |
+| 3 Client FEC application exchange | **PASS** one-shot — `captures/mstp-fec-ai1173-oneshot.json` |
+| 3 Network coexistence | **FAIL** — `captures/mstp-gate3-coexistence-abort.json` (Workbench/FEC offline under MAC 3 TX) |
+| 3 Overall | **FAIL** / active TX blocked |
+| 4 Mini-device server-only | **BLOCKED** |
+| 5 Combined endpoint + mirror | **BLOCKED** |
+| 6 Soak | **BLOCKED** — 20×30s must not be marked PASS |
 
-### Gate 2 notes
+### Gate 3 abort notes
 
-- `latency_timer` was **16** during the PASS (not 1). Optional: `echo 1 | sudo tee /sys/bus/usb-serial/devices/ttyUSB0/latency_timer`
-- Workbench observation: operator should confirm still online (agent did not kill trunk).
-- No Rust TX (passive sniff only).
+- `application_exchange_ok=true`, `coexistence_ok=false`, `overall_ok=false`
+- `exit_reason="aborted: existing MS/TP trunk went offline"`
+- Invalid maintenance path at `TS=3,NS=7,Max_Master=7` previously set `PS=next(NS)=0` and PFM’d BASRT, allowing ring `0→3→0` and excluding FEC 7
+- Waveshare C may also load the trunk electrically (fixed termination) — unplug before resuming open-fdd bosspi MQTT soaks if Workbench is offline
+
+### Re-test order (after #465 pin only)
+
+1. Passive 60s (Workbench online)  
+2. Active join, **no** application traffic — verify token edges `0→3`, `3→7`, `7→0`  
+3. One Who-Is  
+4. One ReadProperty  
+5. Five 30s reads while operator watches Workbench  
+6. Only then twenty-read soak  
+
+A successful FEC read alone must never set `hardware_ok=true`.
 
 ## Known limitations
 
-- Pin is on **bbartling fork** until upstream #464 merges.
+- Workspace still on CRC tip `73a1fd4` until #465 is reviewed and re-pinned.
 - Shared server+requester endpoint (Workstream E) not implemented yet.
 - Transitive `socket2` still present; runtime must not open IP sockets (Phase 2 apps).
 - PR #126 is merged on `develop` (`eb178f70`); old USB-only Cursor plan is historical.

--- a/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
+++ b/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
@@ -1,60 +1,57 @@
-# Phase 2 — Software / pin results
+# Phase 2 — Software results
 
-**Date:** 2026-08-30  
-**Branch:** `fix/vibe13-mstp-crc-phase2`  
-**rusty-bacnet pin:** `bbartling/rusty-bacnet` @ `19d205d78c947aea3fe98110d8a6c392359aa627` (rebased on upstream `dev`; MS/TP equivalent to lab pin `e3b9edb`)  
-**Upstream PR:** https://github.com/jscott3201/rusty-bacnet/pull/467
+**Updated:** 2026-08-31  
+**rusty-bacnet pin:** `jscott3201/rusty-bacnet` @ `af4e88680c51eb4da64dac47f0540a35bf184732`  
+**Upstream merged:** [#467](https://github.com/jscott3201/rusty-bacnet/pull/467) (CRC/token), [#468](https://github.com/jscott3201/rusty-bacnet/pull/468) (Python MS/TP surfaces)  
+**Vibe13 project SHA:** see `git rev-parse HEAD` on branch `fix/vibe13-mstp-crc-phase2`
 
-**Hardware evidence:** Gate 2 passive **PASS**. Gate 3 FEC application **PASS**. Gate 3 coexistence **PASS** on `e3b9edb` (mini-device MAC 3 + Workbench/FEC stay up). Gate 4 mini-device **PASS** (JENEsys discover + points `{ok}`). Gates 5–6 still open. Loopback ≠ hardware for soak claims.
+Historical captures with `19d205d` / `e3b9edb` / `bbartling` fork are **not** evidence for the current pin until revalidated.
 
-## Status model (explicit)
+## Classification (2026-08-31 audit)
 
-| Gate | Software / offline | Live hardware |
-|------|-------------------|---------------|
-| 1 CRC + USB stream | **PASS** | **PASS** (via pin) |
-| 2 Passive | n/a | **PASS** `mstp-passive-crc-fixed.json` |
-| 3 FEC client app exchange | loopback N/A | **PASS** oneshot |
-| 3 Network coexistence | regressions A–E **PASS** | **PASS** on `e3b9edb` (Workbench online with MAC 3 TX) |
-| 4 Mini-device discoverable | loopback acceptance **PASS** | **PASS** JENEsys device:123001 + 4 points Polled `{ok}` |
-| 5 Shared endpoint + mirror | **OPEN** | **OPEN** |
-| 6 Long soak | **OPEN** | **OPEN** |
+| Class | Items |
+|-------|--------|
+| **Implemented/proven** | Clause 9 CRC + USB reassembly + token/PFM (#467); Python binding example (#468); Gate 1–4 on historical pin; loopback + CI acceptance on `af4e886` |
+| **Current mini-device blocker** | Upstream transport health notification (app uses serial-path watchdog); simulation still remove/re-add AI/BI (needs `ObjectDatabase` in-place mutation API) |
+| **Phase 2.1 mirror blocker** | Shared MS/TP endpoint (one tty, client+server) |
+| **Phase 3 router blocker** | Extended frames 32/33, COBS, CRC-32K, B/IP↔MS/TP routing |
+| **Conformance evidence gaps** | Six-baud timing matrix; golden vectors; 24h soak; BFR-derived router tests only in research doc |
 
-## Root-cause correction
+## Upstream candidate PRs (local branches in `~/src/rusty-bacnet`)
 
-| Claim | Verdict |
-|-------|---------|
-| Token header CRC “invalid” | **Wrong** — Clause 9.6 polys |
-| Primary blocker = `latency_timer` | Partial; CRC was the decode break |
-| Gate 3 FEC read ⇒ coexistence OK | **Wrong** on `73a1fd4` — FAIL until 9.5.6 |
-| Coexistence root cause | Clause **9.5.6** DONE_WITH_TOKEN / PFM (not Max_Master waits) |
-| Fix location | Fork `vibe13-mstp` @ `e3b9edb` |
+| Branch | Topic |
+|--------|--------|
+| `fix/mstp-validate-rust-config` | Rust `MstpConfig` validation parity with Python |
+| `fix/mstp-tx-completion-after-drain` | `tcdrain` after serial write + wire-delay regression |
 
-## Software checks (pin `e3b9edb`)
+## Software checks (`af4e886`)
 
 | Check | Result |
 |-------|--------|
-| `cargo test -p bacnet-transport --lib` (incl. clause956 A–E) | PASS |
-| Workspace pin + `Cargo.lock` → `e3b9edb` | PASS |
-| `./scripts/check_mstp_no_ip.sh` | OK local sources; socket2 transitive **documented BLOCKED** in `captures/phase2-no-ip-gate-status.txt` |
-| Loopback `mstp-probe` / acceptance | PASS (`hardware_evidence=false`) |
-| `TokenEdgeCounters` unit tests | PASS |
+| `cargo fmt --all -- --check` | PASS |
+| `cargo clippy --workspace --all-targets -- -D warnings` | PASS |
+| `cargo test --workspace --locked` | PASS |
+| `./scripts/check_mstp_no_ip.sh` | PASS (transitive `socket2` documented) |
+| `./scripts/check_mstp_no_ip_runtime.sh` | PASS (no AF_INET on PTY startup) |
+| `mstp-probe --profile smoke loopback` | PASS |
 
-## Gate 4 Workbench notes (2026-08-30)
+## Transport / timing limitations (honest)
 
-- Device **Rust MS/TP Mini Device** / `device:123001` / MAC **3** discovered; `systemStatus=Operational`.
-- Points: AI:1, BI:1, AV:2, BV:2 all **Polled `{ok}`**.
-- Niagara may show Write=`readonly` on AV/BV after discover-add — that is often a **Niagara point facet**, not proof the BACnet objects reject WP. Validate with an explicit WriteProperty / priority command.
-- AI units are BACnet **degrees-Fahrenheit (62)**; Niagara UI may display `°C` depending on facets.
-- Name slash may become `Rust MS.TP…` in Niagara — cosmetic.
+- `TokioSerialPort::write` on pin `af4e886` completes after `write_all` only — **no `tcdrain`**. Upstream fix proposed on branch `fix/mstp-tx-completion-after-drain`.
+- Mini-device exits when serial by-id path disappears (USB unplug watchdog); does not yet observe MS/TP recv-task exit via public server API.
 
-## Active-TX / open-fdd note
+## Allowed acceptance language (after post-pin hardware + Haystack Gate 4b)
 
-Do **not** resume open-fdd bosspi MQTT soaks on this Waveshare while mini-device owns the tty. Unplug Waveshare (or stop mini-device) before bosspi fieldbus, and keep pin ≥ `e3b9edb` if rejoining this trunk.
+> Vibe13 provides a stable, server-only, standard-frame BACnet MS/TP lab device at 38,400 baud on the tested BASRT/FEC/Waveshare topology.
 
-## Known limitations
+## Hardware revalidation (`af4e886`, 2026-08-31)
 
-- Gates 5–6 not claimed (shared endpoint + soak).
-- Transitive `socket2` still in dep graph; runtime must not open IP sockets.
-- Not a Clause 9 conformance claim; no extended frames (32/33 / COBS / CRC-32K).
-- Host USB stale-partial timeout ≠ wire `T_frame_abort`.
-- Upstream contribution is open as PR #467 (MS/TP-only; Windows retry-budget timeout stays on fork `main` only).
+| Step | Result | Artifact |
+|------|--------|----------|
+| Passive sniff 60s @ 38400 | PASS (tokens 2835, MAC 0+7, no TX) | `captures/mstp-passive-af4e886-60s.json` |
+| Gate 3 FEC AI:1173 one-shot | PASS | `captures/mstp-fec-ai1173-af4e886-oneshot.json` |
+| Haystack Gate 4b (after ~2 min settle) | PASS | `captures/haystack-trunk/` |
+| Mini-device MAC 3 @ 38400 | PASS (read-only-ai ok) | `captures/mstp-mini-device-af4e886.log` |
+| 1h / 24h soak | **Not run** this session | schedule after operator watch window |
+
+**Go/no-go (minimal post-pin smoke):** **GO** for continued Gate 4 lab use at 38 400 on this topology. **No-go** for soak, mirror, router, or conformance claims.

--- a/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
+++ b/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
@@ -1,63 +1,51 @@
-# Phase 2 — Software results (loopback / CI)
+# Phase 2 — Software / pin results
 
-**Date:** 2026-08-28  
-**rusty-bacnet pin:** `c77f78445fbf40da15867fec28a36ea120ad1739`  
-**Hardware evidence:** **NOT RUN** (USB RS-485 adapters are not installed/wired)
+**Date:** 2026-08-30  
+**Branch:** `fix/vibe13-mstp-crc-phase2`  
+**rusty-bacnet pin:** `bbartling/rusty-bacnet` @ `73a1fd41df7df2dfb3fa005cf339f347751f0286`  
+(Upstream PR: https://github.com/jscott3201/rusty-bacnet/pull/464 — re-pin to `jscott3201` when merged.)
 
-## Passed software checks
+**Hardware evidence:** Gate 2 passive **PASS** (`captures/mstp-passive-crc-fixed.json`). Gate 3+ OPEN. Loopback ≠ hardware.
+
+## Root-cause correction
+
+| Claim | Verdict |
+|-------|---------|
+| Token `55 FF 00 00 07 00 00 37` has “invalid” header CRC | **Wrong** — Clause 9.6 `CRC8([00,00,07,00,00]) == 0x37` |
+| Primary blocker was USB `latency_timer` | Partial — latency matters for delivery; **CRC polys** were the interoperability break |
+| Prior rusty-bacnet CRC `0xE0` / `0xA001` | Incorrect (self-round-trip only) |
+| Correct polys | Header `0x81`, data `0x8408` |
+| USB read gaps as `T_frame_abort` | Incorrect host policy — fixed in `a9912b8` |
+
+## Software checks (this pin)
 
 | Check | Result |
 |-------|--------|
-| `cargo fmt --all -- --check` | PASS |
-| `cargo clippy --workspace --all-targets --locked -- -D warnings` | PASS |
-| `cargo test --workspace --locked` | PASS |
-| `./scripts/check_mstp_no_ip.sh` (local source markers) | PASS |
-| `mstp-probe --profile smoke … loopback` | PASS (`hardware_evidence=false`) |
-| Baud propagation unit tests (all 6 rates) | PASS |
-| Gate report completeness unit tests | PASS |
-| Vendor ID consistency in Device object | PASS |
-| Local AI/BI simulation via `set_present_value` + network WP denied | PASS |
-| Streamlit AppTest (Phase 2 buttons present) | PASS (CI) |
+| Upstream `cargo test -p bacnet-transport` (Clause 9 golden + stream) | PASS (2026-08-30) |
+| Vibe13 offline Token 0←7 fixture (`mstp-passive-sniff` unit tests) | expected PASS after lock update |
+| `./scripts/check_mstp_no_ip.sh` | required before handoff |
+| Loopback `mstp-probe` | still valid software smoke; `hardware_evidence=false` |
 
-## Loopback evidence
+## Phase 2 hardware gates (Rescue prompt)
 
-Loopback runs a full application-service sequence on `LoopbackSerial`:
+| Gate | Status |
+|------|--------|
+| 1 Transport CRC + USB fragmentation | **Software PASS** on pin `73a1fd4` |
+| 2 Passive live bus | **PASS** 2026-08-30 — `captures/mstp-passive-crc-fixed.json` (45s: rx=25651, frames=2971, tokens=2117, token_0_from_7=1058, sources=[0,7], invalid=2, valid_ratio≈0.999) |
+| 3 Client-only FEC AI:1173 | **PASS one-shot** — `captures/mstp-fec-ai1173-oneshot.json` (I-Am@7, `BENS BENCHTEST BOX`, PV≈75.57). 20×30s: `captures/mstp-fec-ai1173-30s.*`. Rust `--max-master 7` for PFM join. |
+| 4 Mini-device server-only | **OPEN** |
+| 5 Combined endpoint + mirror | **OPEN** (needs Workstream E upstream) |
+| 6 Soak | **OPEN** |
 
-- Who-Is → require I-Am for instance + MAC + vendor
-- Device Object_Name + Object_List (Device + AI:1 + BI:1 + AV:2 + BV:2)
-- RP AI/BI, RPM, WP/relinquish AV:2 + BV:2
-- Unknown object + write-access denial on AI:1
-- Repeated reads with latency summary
-- Clean client/server stop
+### Gate 2 notes
 
-Reports use schema `phase2_acceptance_v2` with `profile`, `hardware_evidence=false` for loopback.
+- `latency_timer` was **16** during the PASS (not 1). Optional: `echo 1 | sudo tee /sys/bus/usb-serial/devices/ttyUSB0/latency_timer`
+- Workbench observation: operator should confirm still online (agent did not kill trunk).
+- No Rust TX (passive sniff only).
 
-Artifact example: `captures/mstp-loopback-software.json` / CI `captures/mstp-loopback-ci.json`.
+## Known limitations
 
-## Hardware NOT RUN
-
-Phase 2 USB RS-485 adapters are **not installed or wired** on this host.
-
-- Do not treat loopback PASS as hardware gate PASS.
-- See [`PHASE2_HARDWARE_RUNBOOK.md`](PHASE2_HARDWARE_RUNBOOK.md) for the exact human bench commands (placeholders only).
-
-## Known rusty-bacnet / upstream blockers
-
-| Topic | Status |
-|-------|--------|
-| Transitive `socket2` via `bacnet-transport` even with `features=["serial"]` | **BLOCKED** dependency-level isolation on this pin — documented by `check_mstp_no_ip.sh` / `captures/phase2-no-ip-gate-status.txt`. Runtime still opens no IP sockets. Upstream ask: split serial-only builds from B/IP/socket2. |
-| `BACnetServer` transport-death notification | **Gap** — pin exposes `stop()` but no public “transport task died” waiter. Apps wait for SIGINT/SIGTERM only. |
-| Lab vendor ID `999` | Placeholder only — not production-ready. |
-
-## Remaining gate work (requires hardware)
-
-- Smoke + gate profiles on real dual Waveshare C adapters
-- Startup-order / sole-master / duplicate-MAC / baud-mismatch / unplug
-- 500-read gate + one-hour soak + per-baud matrix
-
-## Profiles
-
-| Profile | `repeated_reads` | Required steps |
-|---------|------------------|----------------|
-| `smoke` | small (CI default 5–10) | Full service coverage; zero failures |
-| `gate` | ≥ 500 | Every `GATE_REQUIRED_STEPS` present and ok |
+- Pin is on **bbartling fork** until upstream #464 merges.
+- Shared server+requester endpoint (Workstream E) not implemented yet.
+- Transitive `socket2` still present; runtime must not open IP sockets (Phase 2 apps).
+- PR #126 is merged on `develop` (`eb178f70`); old USB-only Cursor plan is historical.

--- a/vibe_code_apps_13/docs/PHASE_2_MSTP_MINI_DEVICE.md
+++ b/vibe_code_apps_13/docs/PHASE_2_MSTP_MINI_DEVICE.md
@@ -131,12 +131,13 @@ Review dependency features too; absence of a string is not sufficient if B/IP is
 
 - [ ] Phase 1 gate passed and its helpers/tests remain green.
 - [x] Device executable contains no B/IP/UDP/IP interface in **local** sources (CI source gate).
-- [ ] Two real masters exchange token. **Hardware NOT RUN.**
+- [x] Two real masters exchange token (BASRT+FEC); Rust MAC 3 joins on pin `e3b9edb`.
 - [x] Who-Is/I-Am, RP, RPM, WP, priority/relinquish and negative cases pass **in loopback** (`docs/PHASE2_SOFTWARE_RESULTS.md`).
 - [x] Object_List enumerates the Device + four points **in loopback**.
 - [ ] Standard-frame/APDU limit is enforced without truncation (hardware soak pending).
 - [ ] Restart and sole-master admission tests pass. **Hardware NOT RUN.**
 - [ ] 500-read report and one-hour soak pass. **Hardware NOT RUN.**
+- [x] Mini-device discoverable in Workbench (JENEsys) with points Polled `{ok}` — Gate 4 **PASS** 2026-08-30.
 - [x] Phase 2 behavior is documented as MS/TP-only; hardware runbook prepared (`docs/PHASE2_HARDWARE_RUNBOOK.md`).
 
 See also: [`PHASE2_SOFTWARE_RESULTS.md`](PHASE2_SOFTWARE_RESULTS.md).

--- a/vibe_code_apps_13/docs/mstp-gate3-coexistence-abort.json
+++ b/vibe_code_apps_13/docs/mstp-gate3-coexistence-abort.json
@@ -1,0 +1,24 @@
+{
+  "gate": 3,
+  "overall_ok": false,
+  "hardware_ok": false,
+  "application_exchange_ok": true,
+  "coexistence_ok": false,
+  "exit_reason": "aborted: existing MS/TP trunk went offline",
+  "gate1_crc": "PASS",
+  "gate2_passive": "PASS",
+  "gate3_application_exchange": "PASS",
+  "gate3_network_coexistence": "FAIL",
+  "gate3_overall": "FAIL",
+  "gates_4_6": "BLOCKED",
+  "active_tx": "blocked",
+  "notes": [
+    "Workbench/FEC offline while mstp-fec-diag MAC 3 participated",
+    "Root cause: Clause 9.5.6 DoneWithToken/PFM maintenance (PS=NS+1 reversed scan) and NextStationUnknown Token 3->3",
+    "Not CRC, wiring, latency_timer, APDU timeout, or Max_Master",
+    "20x30s soak not PASS; do not resume live TX until deterministic multi-master tests pass"
+  ],
+  "evidence_oneshot": "captures/mstp-fec-ai1173-oneshot.json",
+  "evidence_partial_30s": "captures/mstp-fec-ai1173-30s.json",
+  "rusty_bacnet_rev_at_fail": "73a1fd41df7df2dfb3fa005cf339f347751f0286"
+}

--- a/vibe_code_apps_13/docs/research/PHASE3_BFR_ROUTER_IDEAS.md
+++ b/vibe_code_apps_13/docs/research/PHASE3_BFR_ROUTER_IDEAS.md
@@ -1,0 +1,18 @@
+# Phase 3 — BFR router research notes (design only)
+
+[BFR](https://bfr.sourceforge.net/) is a BACnet/IP router/firewall. **It does not implement MS/TP.** Do not add it as a Phase 2 dependency.
+
+## Ideas to reuse in Phase 3 Vibe13 router work
+
+- Adapter-based multi-network routing fixtures (virtual LAN + injected NPDUs)
+- Route/filter expectation tests (allowed/denied NPDU forwarding)
+- Hop-count and loop-prevention test vectors
+- Firewall-style service/network rules as documentation-driven tests
+
+## Out of scope for Phase 2 PR #127
+
+- BACnet/IP stack in the mini-device
+- BBMD/NAT/firewall appliance code
+- BFR binary or config import
+
+Phase 3 router remains a separate role from the Phase 2 MS/TP mini-device.

--- a/vibe_code_apps_13/scripts/check_mstp_haystack_trunk.sh
+++ b/vibe_code_apps_13/scripts/check_mstp_haystack_trunk.sh
@@ -7,8 +7,10 @@
 #   restore            — same as check after mini-device should be running
 #
 # Env (never commit secrets):
-#   HAYSTACK_BASE_URL  default https://192.168.204.11/haystack
+#   HAYSTACK_BASE_URL  default https://192.168.204.11/haystack (https only)
 #   HAYSTACK_USER / HAYSTACK_PASS  or source ~/open-fdd/.env
+#   HAYSTACK_CACERT    PEM for private CA (preferred on lab Niagara)
+#   HAYSTACK_INSECURE=1  only when no CA file is available (self-signed bench)
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -24,6 +26,22 @@ fi
 HS_URL="${HAYSTACK_BASE_URL:-https://192.168.204.11/haystack}"
 HS_USER="${HAYSTACK_USER:-${OPENFDD_HAYSTACK_USER:-}}"
 HS_PASS="${HAYSTACK_PASS:-${OPENFDD_HAYSTACK_PASS:-}}"
+
+case "${HS_URL%%://*}" in
+  https) ;;
+  *) bad "HAYSTACK_BASE_URL must use https:// (got ${HS_URL%%://*}://)" ;;
+esac
+
+curl_tls_args() {
+  if [[ -n "${HAYSTACK_CACERT:-}" ]]; then
+    echo --cacert "$HAYSTACK_CACERT"
+  elif [[ "${HAYSTACK_INSECURE:-}" == "1" ]]; then
+    echo -k
+  else
+    # System trust store — no certificate bypass.
+    true
+  fi
+}
 
 RED=$'\033[31m'
 GRN=$'\033[32m'
@@ -42,7 +60,8 @@ hs_nav() {
   local nav_id="$1" out="$2"
   local enc
   enc="$(NAV="$nav_id" python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["NAV"]))')"
-  curl -fsSk --max-time 30 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
+  # shellcheck disable=SC2046
+  curl -fsS $(curl_tls_args) --max-time 30 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
     "$HS_URL/nav?navId=$enc" -o "$out"
 }
 
@@ -78,7 +97,8 @@ hs_read() {
   local filter="$1" out="$2"
   local enc
   enc="$(FILTER="$filter" python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["FILTER"]))')"
-  curl -fsSk --max-time 30 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
+  # shellcheck disable=SC2046
+  curl -fsS $(curl_tls_args) --max-time 30 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
     "$HS_URL/read?filter=$enc" -o "$out"
 }
 
@@ -92,7 +112,8 @@ check_fec_points_nav() {
 check_trunk() {
   require_creds
   hdr "Haystack /about"
-  curl -fsSk --max-time 20 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
+  # shellcheck disable=SC2046
+  curl -fsS $(curl_tls_args) --max-time 20 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
     "$HS_URL/about" -o "$ART/haystack_about.zinc"
   ok "Niagara /about"
 

--- a/vibe_code_apps_13/scripts/check_mstp_haystack_trunk.sh
+++ b/vibe_code_apps_13/scripts/check_mstp_haystack_trunk.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Haystack supervisory gate for BASRT/FEC/Rust MS/TP trunk health (Gate 4b).
+#
+# Modes:
+#   check              — FEC + Rust mini-device points show curStatus/axStatus ok
+#   perturb-stop-mini  — verify trunk/FEC stay ok when local mini-device is stopped
+#   restore            — same as check after mini-device should be running
+#
+# Env (never commit secrets):
+#   HAYSTACK_BASE_URL  default https://192.168.204.11/haystack
+#   HAYSTACK_USER / HAYSTACK_PASS  or source ~/open-fdd/.env
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE="${1:-check}"
+ART="${HAYSTACK_ARTIFACT_DIR:-$ROOT/captures/haystack-trunk}"
+mkdir -p "$ART"
+
+if [[ -f "$HOME/open-fdd/.env" ]]; then
+  # shellcheck disable=SC1091
+  source "$HOME/open-fdd/.env"
+fi
+
+HS_URL="${HAYSTACK_BASE_URL:-https://192.168.204.11/haystack}"
+HS_USER="${HAYSTACK_USER:-${OPENFDD_HAYSTACK_USER:-}}"
+HS_PASS="${HAYSTACK_PASS:-${OPENFDD_HAYSTACK_PASS:-}}"
+
+RED=$'\033[31m'
+GRN=$'\033[32m'
+DIM=$'\033[2m'
+RST=$'\033[0m'
+
+ok() { echo "${GRN}OK${RST}  $*"; }
+bad() { echo "${RED}FAIL${RST} $*" >&2; exit 1; }
+hdr() { echo; echo "== $*"; }
+
+require_creds() {
+  [[ -n "$HS_USER" && -n "$HS_PASS" ]] || bad "HAYSTACK_USER/HAYSTACK_PASS required (see ~/open-fdd/.env)"
+}
+
+hs_nav() {
+  local nav_id="$1" out="$2"
+  local enc
+  enc="$(NAV="$nav_id" python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["NAV"]))')"
+  curl -fsSk --max-time 30 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
+    "$HS_URL/nav?navId=$enc" -o "$out"
+}
+
+extract_status() {
+  RAW="${1:-}" python3 - <<'PY'
+import os, re
+raw = os.environ.get("RAW", "")
+if re.search(r'"ok"', raw) or re.search(r'\boperational\b', raw, re.I):
+    print("ok")
+elif re.search(r'"down"', raw):
+    print("down")
+else:
+    for pat in (r"curStatus\s*:\s*(\S+)", r"axStatus\s*:\s*(\S+)", r"systemStatus\s*:\s*(\S+)"):
+        m = re.search(pat, raw, re.I)
+        if m:
+            print(m.group(1).strip('"'))
+            break
+PY
+}
+
+check_point_ok() {
+  local label="$1" filter="$2" outfile="$3"
+  local body status
+  hs_read "$filter" "$outfile"
+  body="$(cat "$outfile")"
+  status="$(extract_status "$body")"
+  echo "${DIM}  $label status=$status${RST}"
+  [[ "$status" == "ok" || "$status" == "operational" ]] || bad "$label Haystack status=$status (expected ok/operational)"
+  ok "$label online ($status)"
+}
+
+hs_read() {
+  local filter="$1" out="$2"
+  local enc
+  enc="$(FILTER="$filter" python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["FILTER"]))')"
+  curl -fsSk --max-time 30 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
+    "$HS_URL/read?filter=$enc" -o "$out"
+}
+
+check_fec_points_nav() {
+  local outfile="$1"
+  hs_nav "slot:/Drivers/BacnetNetwork/BENS\$20BENCHTEST\$20BOX/points" "$outfile"
+  grep -E '"ok"' "$outfile" >/dev/null || bad "FEC points nav missing curStatus ok"
+  ok "FEC points nav (7 points) curStatus ok"
+}
+
+check_trunk() {
+  require_creds
+  hdr "Haystack /about"
+  curl -fsSk --max-time 20 -u "$HS_USER:$HS_PASS" -H 'Accept: text/zinc' \
+    "$HS_URL/about" -o "$ART/haystack_about.zinc"
+  ok "Niagara /about"
+
+  hdr "FEC bench points (BENS BENCHTEST BOX nav)"
+  check_fec_points_nav "$ART/haystack_fec_points.zinc"
+
+  hdr "Rust mini-device read-only-ai"
+  check_point_ok "read-only-ai" 'point and dis=="read-only-ai"' "$ART/haystack_rust_ai.zinc"
+
+  hdr "Rust MS/TP mini device"
+  hs_read 'device and dis=="Rust MS/TP Mini Device"' "$ART/haystack_rust_device.zinc"
+  grep -q 'Rust MS/TP Mini Device' "$ART/haystack_rust_device.zinc" \
+    || bad "Rust MS/TP Mini Device not present in Haystack export"
+  ok "Rust MS/TP Mini Device present in Haystack"
+}
+
+case "$MODE" in
+  check|restore)
+    check_trunk
+    ;;
+  perturb-stop-mini)
+    require_creds
+    hdr "Perturbation: mini-device should be STOPPED; FEC must stay ok"
+    if pgrep -f 'mstp-mini-device' >/dev/null; then
+      bad "mstp-mini-device still running — stop it before perturb-stop-mini"
+    fi
+    ok "mstp-mini-device not running (MAC 3 absent)"
+    check_fec_points_nav "$ART/haystack_fec_after_stop.zinc"
+    ok "FEC still ok with mini-device stopped"
+    ;;
+  *)
+    bad "usage: $0 {check|perturb-stop-mini|restore}"
+    ;;
+esac
+
+echo
+ok "Haystack trunk gate ($MODE) PASS — artifacts in $ART"

--- a/vibe_code_apps_13/scripts/check_mstp_no_ip.sh
+++ b/vibe_code_apps_13/scripts/check_mstp_no_ip.sh
@@ -51,7 +51,7 @@ if grep -q 'socket2' "$TREE_OUT"; then
   mkdir -p captures
   {
     echo "phase2_no_ip_gate: blocked_dependency_isolation"
-    echo "rusty_bacnet: c77f78445fbf40da15867fec28a36ea120ad1739"
+    echo "rusty_bacnet: 73a1fd41df7df2dfb3fa005cf339f347751f0286"
     echo "socket2: present_via_bacnet_transport"
     echo "local_bip_markers: absent"
     echo "runtime_ip_sockets: forbidden"

--- a/vibe_code_apps_13/scripts/check_mstp_no_ip.sh
+++ b/vibe_code_apps_13/scripts/check_mstp_no_ip.sh
@@ -51,7 +51,7 @@ if grep -q 'socket2' "$TREE_OUT"; then
   mkdir -p captures
   {
     echo "phase2_no_ip_gate: blocked_dependency_isolation"
-    echo "rusty_bacnet: e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
+    echo "rusty_bacnet: af4e88680c51eb4da64dac47f0540a35bf184732"
     echo "socket2: present_via_bacnet_transport"
     echo "local_bip_markers: absent"
     echo "runtime_ip_sockets: forbidden"

--- a/vibe_code_apps_13/scripts/check_mstp_no_ip.sh
+++ b/vibe_code_apps_13/scripts/check_mstp_no_ip.sh
@@ -51,7 +51,7 @@ if grep -q 'socket2' "$TREE_OUT"; then
   mkdir -p captures
   {
     echo "phase2_no_ip_gate: blocked_dependency_isolation"
-    echo "rusty_bacnet: 73a1fd41df7df2dfb3fa005cf339f347751f0286"
+    echo "rusty_bacnet: e3b9edbd5d96d25e21855d5b1ca02f8e070bb1ef"
     echo "socket2: present_via_bacnet_transport"
     echo "local_bip_markers: absent"
     echo "runtime_ip_sockets: forbidden"

--- a/vibe_code_apps_13/scripts/check_mstp_no_ip_runtime.sh
+++ b/vibe_code_apps_13/scripts/check_mstp_no_ip_runtime.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Runtime proof: Phase 2 mini-device opens no AF_INET/AF_INET6 sockets during startup.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BIN="${1:-target/release/mstp-mini-device}"
+if [[ ! -x "$BIN" ]]; then
+  cargo build --release --locked -p mstp-mini-device
+fi
+
+LOG="$(mktemp)"
+cleanup() { rm -f "$LOG"; }
+trap cleanup EXIT
+
+FAKE="/tmp/vibe13-no-ip-gate-$$"
+set +e
+strace -f -e trace=network -o "$LOG" \
+  timeout 6 "$BIN" \
+  --serial "$FAKE" \
+  --baud 38400 --mac 3 --max-master 7 --max-info-frames 1 \
+  --device-instance 123001 >/dev/null 2>&1
+set -e
+
+if grep -E 'socket\(AF_INET6?,' "$LOG"; then
+  echo "FAIL: mini-device opened IP socket(s):"
+  grep -E 'socket\(AF_INET6?,' "$LOG" || true
+  exit 1
+fi
+
+echo "OK: no AF_INET/AF_INET6 socket() during startup (strace captured serial open failure path)"
+exit 0

--- a/vibe_code_apps_13/scripts/check_mstp_no_ip_runtime.sh
+++ b/vibe_code_apps_13/scripts/check_mstp_no_ip_runtime.sh
@@ -10,18 +10,56 @@ if [[ ! -x "$BIN" ]]; then
   cargo build --release --locked -p mstp-mini-device
 fi
 
+PTY_LOG="$(mktemp)"
 LOG="$(mktemp)"
-cleanup() { rm -f "$LOG"; }
+cleanup() {
+  [[ -n "${PTY_PID:-}" ]] && kill "$PTY_PID" 2>/dev/null || true
+  rm -f "$LOG" "$PTY_LOG"
+}
 trap cleanup EXIT
 
-FAKE="/tmp/vibe13-no-ip-gate-$$"
-set +e
-strace -f -e trace=network -o "$LOG" \
-  timeout 6 "$BIN" \
-  --serial "$FAKE" \
+python3 - <<'PY' >"$PTY_LOG" &
+import os
+import pty
+import select
+import time
+
+m, s = pty.openpty()
+print(os.ttyname(s), flush=True)
+deadline = time.monotonic() + 12
+while time.monotonic() < deadline:
+    select.select([m], [], [], 1.0)
+PY
+PTY_PID=$!
+PORT=""
+for _ in $(seq 1 50); do
+  if [[ -s "$PTY_LOG" ]]; then
+    PORT="$(head -1 "$PTY_LOG")"
+    break
+  fi
+  sleep 0.1
+done
+[[ -n "$PORT" && -e "$PORT" ]] || {
+  echo "FAIL: could not allocate PTY serial endpoint"
+  exit 1
+}
+
+strace -f -e trace=network,open,openat,ioctl -o "$LOG" \
+  timeout 8 "$BIN" \
+  --serial "$PORT" \
   --baud 38400 --mac 3 --max-master 7 --max-info-frames 1 \
-  --device-instance 123001 >/dev/null 2>&1
-set -e
+  --device-instance 123001 >/dev/null 2>&1 || true
+
+[[ -s "$LOG" ]] || {
+  echo "FAIL: strace produced no trace output"
+  exit 1
+}
+
+if ! grep -qE "(open|openat).*$(basename "$PORT")" "$LOG"; then
+  echo "FAIL: strace trace missing serial open for $PORT"
+  head -20 "$LOG" >&2 || true
+  exit 1
+fi
 
 if grep -E 'socket\(AF_INET6?,' "$LOG"; then
   echo "FAIL: mini-device opened IP socket(s):"
@@ -29,5 +67,5 @@ if grep -E 'socket\(AF_INET6?,' "$LOG"; then
   exit 1
 fi
 
-echo "OK: no AF_INET/AF_INET6 socket() during startup (strace captured serial open failure path)"
+echo "OK: no AF_INET/AF_INET6 socket() during PTY startup (serial open + server path traced)"
 exit 0

--- a/vibe_code_apps_13/scripts/linux_timing_baseline.sh
+++ b/vibe_code_apps_13/scripts/linux_timing_baseline.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Linux timing baseline for MS/TP bench (research gate — not a conformance claim).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ART="${TIMING_ARTIFACT_DIR:-$ROOT/captures/linux-timing-$(date -u +%Y%m%dT%H%M%SZ)}"
+mkdir -p "$ART"
+
+record() { echo "$*" | tee -a "$ART/summary.txt"; }
+
+record "=== kernel ==="
+uname -a | tee "$ART/uname.txt"
+uname -r | tee "$ART/kernel-release.txt"
+grep -E '^(CONFIG_PREEMPT|CONFIG_PREEMPT_RT|CONFIG_PREEMPT_DYNAMIC|CONFIG_PREEMPT_VOLUNTARY)=' \
+  "/boot/config-$(uname -r)" 2>/dev/null | tee "$ART/preempt-config.txt" || true
+cat /sys/kernel/realtime 2>/dev/null | tee "$ART/realtime.txt" || true
+
+record "=== CPU / governor ==="
+lscpu | tee "$ART/lscpu.txt"
+cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null | tee "$ART/cpu-governor.txt" || true
+
+record "=== FTDI latency_timer (if present) ==="
+PORT="${MSTP_SERIAL:-/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0}"
+if [[ -e "$PORT" ]]; then
+  TTY="$(readlink -f "$PORT")"
+  LAT="/sys/bus/usb-serial/devices/${TTY##*/}/latency_timer"
+  if [[ -f "$LAT" ]]; then
+    cat "$LAT" | tee "$ART/ftdi-latency_timer.txt"
+  fi
+fi
+
+record "=== cyclictest idle (5s) ==="
+if command -v cyclictest >/dev/null; then
+  cyclictest -p 80 -m -n -i 200 -l 10000 -q 2>&1 | tee "$ART/cyclictest-idle.txt" || true
+else
+  record "cyclictest not installed — skip"
+fi
+
+record "=== cyclictest under stress-ng (10s) ==="
+if command -v cyclictest >/dev/null && command -v stress-ng >/dev/null; then
+  stress-ng --cpu 2 --io 1 --vm 1 --timeout 12s >/dev/null 2>&1 &
+  SPID=$!
+  sleep 1
+  cyclictest -p 80 -m -n -i 200 -l 10000 -q 2>&1 | tee "$ART/cyclictest-stress.txt" || true
+  wait "$SPID" 2>/dev/null || true
+else
+  record "stress-ng or cyclictest missing — skip stressed cyclictest"
+fi
+
+record "=== load snapshot ==="
+uptime | tee "$ART/uptime.txt"
+record "artifacts: $ART"
+echo "Timing baseline complete — see $ART"

--- a/vibe_code_apps_13/scripts/linux_timing_baseline.sh
+++ b/vibe_code_apps_13/scripts/linux_timing_baseline.sh
@@ -29,14 +29,14 @@ if [[ -e "$PORT" ]]; then
   fi
 fi
 
-record "=== cyclictest idle (5s) ==="
+record "=== cyclictest idle (~2s at -i 200 -l 10000) ==="
 if command -v cyclictest >/dev/null; then
   cyclictest -p 80 -m -n -i 200 -l 10000 -q 2>&1 | tee "$ART/cyclictest-idle.txt" || true
 else
   record "cyclictest not installed — skip"
 fi
 
-record "=== cyclictest under stress-ng (10s) ==="
+record "=== cyclictest under stress-ng (~2s sample during 12s stress) ==="
 if command -v cyclictest >/dev/null && command -v stress-ng >/dev/null; then
   stress-ng --cpu 2 --io 1 --vm 1 --timeout 12s >/dev/null 2>&1 &
   SPID=$!

--- a/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
@@ -8,13 +8,13 @@ Plain Markdown in **`vibe13_agent_spec/`** is the source of truth for AI agents 
 **Supervisory metrics:** [`SUPERVISORY_METRICS.md`](SUPERVISORY_METRICS.md)  
 **JSON contracts:** [`DATA_CONTRACT.md`](DATA_CONTRACT.md)
 
-## Current phase (2026-08-30)
+## Current phase (2026-08-31)
 
 | Item | Value |
 |------|--------|
 | Baseline | `develop` @ `eb178f70` (PR #126 merged) |
-| Active work | **Phase 2** — Gates 1–4 PASS on pin `19d205d` (lab evidence on `e3b9edb`); Gates 5–6 next |
-| rusty-bacnet pin | `bbartling/rusty-bacnet` @ `19d205d…` — upstream PR [#467](https://github.com/jscott3201/rusty-bacnet/pull/467) |
+| Active work | **Phase 2** — Gates 1–4 PASS on pin `af4e886`; Gates 5–6 next |
+| rusty-bacnet pin | `jscott3201/rusty-bacnet` @ `af4e886…` — #467/#468 merged |
 | Bench | BASRT MAC0 + FEC MAC7 + Waveshare C; Rust MAC **3**; baud 38400 |
 | Historical | Cursor plan `vibe13_ms_tp_usb_fix_*` is **not** active |
 

--- a/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
@@ -8,14 +8,35 @@ Plain Markdown in **`vibe13_agent_spec/`** is the source of truth for AI agents 
 **Supervisory metrics:** [`SUPERVISORY_METRICS.md`](SUPERVISORY_METRICS.md)  
 **JSON contracts:** [`DATA_CONTRACT.md`](DATA_CONTRACT.md)
 
-## Quick start (Phase 1)
+## Current phase (2026-08-30)
+
+| Item | Value |
+|------|--------|
+| Baseline | `develop` @ `eb178f70` (PR #126 merged) |
+| Active work | **Phase 2 Rescue** — Clause 9 CRC + USB stream → passive → FEC client → mini-device → shared endpoint → FEC OA-T mirror |
+| rusty-bacnet pin | `bbartling/rusty-bacnet` @ `73a1fd4…` (upstream [#464](https://github.com/jscott3201/rusty-bacnet/pull/464)) |
+| Bench | BASRT MAC0 + FEC MAC7 + Waveshare C; Rust MAC **3**; baud 38400; Max_Master 127 |
+| Historical | Cursor plan `vibe13_ms_tp_usb_fix_*` is **not** active |
+
+**Do not invent hardware PASS.** Gate evidence lives under `captures/` + `docs/PHASE2_SOFTWARE_RESULTS.md` + `docs/PHASE2_HARDWARE_RUNBOOK.md`.
+
+## Quick start (Phase 1 lab UI)
 
 ```bash
 cd ~/py-bacnet-stacks-playground/vibe_code_apps_13
 ./scripts/run_wire_dashboard.sh
 ```
 
-Requires: `dialout` group for hardware runs; two Waveshare **C** adapters wired A+/B-/REF. Dashboard uses **`./scripts/run_wire_dashboard.sh`** (auto-creates `.venv` — do not `pip install` system-wide on Ubuntu PEP 668).
+Requires: `dialout` for hardware; Waveshare **C** on the live trunk. Dashboard uses `./scripts/run_wire_dashboard.sh` (auto-creates `.venv` — do not `pip install` system-wide on Ubuntu PEP 668).
+
+## Quick start (Phase 2 passive — no TX)
+
+```bash
+PORT=/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_BH001FQ0-if00-port0
+cargo run --release -p mstp-passive-sniff -- \
+  --serial "$PORT" --baud 38400 --seconds 60 \
+  --report captures/mstp-passive-crc-fixed.json
+```
 
 ## Agent rules (additions to root AGENTS.md)
 
@@ -24,6 +45,9 @@ Requires: `dialout` group for hardware runs; two Waveshare **C** adapters wired 
 3. **Subprocess boundary:** Streamlit launches `target/release/serial-wire-test`; do not reimplement serial I/O in Python.
 4. **Evidence paths:** `captures/wire-test-*.json` for gates; update `docs/PHASE1_TEST_RESULTS.md` after hardware runs.
 5. **Phase 2 entry:** read `docs/PHASE_2_MSTP_MINI_DEVICE.md`, pin `rusty-bacnet`, no B/IP in device binary.
+6. **CRC truth:** Token `… 37` is **valid**; wrong polys were the blocker (D-011).
+7. **One tty owner:** never two `MstpTransport`s / BACnetServer+Client opening the same port.
+8. **MAC policy:** never TX as 0 with BASRT present; never use FEC’s 7; use 3 after confirming free.
 
 ## Index
 
@@ -35,3 +59,6 @@ Requires: `dialout` group for hardware runs; two Waveshare **C** adapters wired 
 | [DATA_CONTRACT.md](DATA_CONTRACT.md) | Report / live JSON schemas |
 | [../docs/PHASE1_CHEATSHEET.md](../docs/PHASE1_CHEATSHEET.md) | Wiring + CLI |
 | [../docs/PHASE1_TEST_RESULTS.md](../docs/PHASE1_TEST_RESULTS.md) | Pass/fail log |
+| [../docs/PHASE2_HARDWARE_RUNBOOK.md](../docs/PHASE2_HARDWARE_RUNBOOK.md) | Live BASRT/FEC commands |
+| [../docs/PHASE2_SOFTWARE_RESULTS.md](../docs/PHASE2_SOFTWARE_RESULTS.md) | Pin + gate status |
+| [../docs/DECISIONS.md](../docs/DECISIONS.md) | D-001…D-012 |

--- a/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
@@ -13,12 +13,12 @@ Plain Markdown in **`vibe13_agent_spec/`** is the source of truth for AI agents 
 | Item | Value |
 |------|--------|
 | Baseline | `develop` @ `eb178f70` (PR #126 merged) |
-| Active work | **Phase 2 Rescue** — CRC PASS; Gate 3 coexistence FAIL → Clause 9.5.6 [#465](https://github.com/jscott3201/rusty-bacnet/pull/465); **no live TX** until pin |
-| rusty-bacnet pin | `bbartling/rusty-bacnet` @ `73a1fd4…` (CRC [#464](https://github.com/jscott3201/rusty-bacnet/pull/464)); need 9.5.6 follow-up |
-| Bench | BASRT MAC0 + FEC MAC7 + Waveshare C; Rust MAC **3**; baud 38400; Max_Master 127 |
+| Active work | **Phase 2** — Gates 1–4 PASS on fork pin `e3b9edb`; Gates 5–6 next |
+| rusty-bacnet pin | `bbartling/rusty-bacnet` @ `e3b9edb…` (`vibe13-mstp`, **fork only**) |
+| Bench | BASRT MAC0 + FEC MAC7 + Waveshare C; Rust MAC **3**; baud 38400 |
 | Historical | Cursor plan `vibe13_ms_tp_usb_fix_*` is **not** active |
 
-**Do not invent hardware PASS.** Gate 3 overall is **FAIL** (`captures/mstp-gate3-coexistence-abort.json`). FEC RP success ≠ coexistence. Evidence: `captures/` + `docs/PHASE2_SOFTWARE_RESULTS.md` + `docs/PHASE2_HARDWARE_RUNBOOK.md`.
+**Do not invent hardware PASS.** Evidence: `captures/` + `docs/PHASE2_SOFTWARE_RESULTS.md` + `docs/PHASE2_HARDWARE_RUNBOOK.md`. Gate 4 Workbench discovery is recorded there.
 
 ## Quick start (Phase 1 lab UI)
 

--- a/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
@@ -13,8 +13,8 @@ Plain Markdown in **`vibe13_agent_spec/`** is the source of truth for AI agents 
 | Item | Value |
 |------|--------|
 | Baseline | `develop` @ `eb178f70` (PR #126 merged) |
-| Active work | **Phase 2** — Gates 1–4 PASS on fork pin `e3b9edb`; Gates 5–6 next |
-| rusty-bacnet pin | `bbartling/rusty-bacnet` @ `e3b9edb…` (`vibe13-mstp`, **fork only**) |
+| Active work | **Phase 2** — Gates 1–4 PASS on pin `19d205d` (lab evidence on `e3b9edb`); Gates 5–6 next |
+| rusty-bacnet pin | `bbartling/rusty-bacnet` @ `19d205d…` — upstream PR [#467](https://github.com/jscott3201/rusty-bacnet/pull/467) |
 | Bench | BASRT MAC0 + FEC MAC7 + Waveshare C; Rust MAC **3**; baud 38400 |
 | Historical | Cursor plan `vibe13_ms_tp_usb_fix_*` is **not** active |
 

--- a/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/AGENTS.md
@@ -13,12 +13,12 @@ Plain Markdown in **`vibe13_agent_spec/`** is the source of truth for AI agents 
 | Item | Value |
 |------|--------|
 | Baseline | `develop` @ `eb178f70` (PR #126 merged) |
-| Active work | **Phase 2 Rescue** — Clause 9 CRC + USB stream → passive → FEC client → mini-device → shared endpoint → FEC OA-T mirror |
-| rusty-bacnet pin | `bbartling/rusty-bacnet` @ `73a1fd4…` (upstream [#464](https://github.com/jscott3201/rusty-bacnet/pull/464)) |
+| Active work | **Phase 2 Rescue** — CRC PASS; Gate 3 coexistence FAIL → Clause 9.5.6 [#465](https://github.com/jscott3201/rusty-bacnet/pull/465); **no live TX** until pin |
+| rusty-bacnet pin | `bbartling/rusty-bacnet` @ `73a1fd4…` (CRC [#464](https://github.com/jscott3201/rusty-bacnet/pull/464)); need 9.5.6 follow-up |
 | Bench | BASRT MAC0 + FEC MAC7 + Waveshare C; Rust MAC **3**; baud 38400; Max_Master 127 |
 | Historical | Cursor plan `vibe13_ms_tp_usb_fix_*` is **not** active |
 
-**Do not invent hardware PASS.** Gate evidence lives under `captures/` + `docs/PHASE2_SOFTWARE_RESULTS.md` + `docs/PHASE2_HARDWARE_RUNBOOK.md`.
+**Do not invent hardware PASS.** Gate 3 overall is **FAIL** (`captures/mstp-gate3-coexistence-abort.json`). FEC RP success ≠ coexistence. Evidence: `captures/` + `docs/PHASE2_SOFTWARE_RESULTS.md` + `docs/PHASE2_HARDWARE_RUNBOOK.md`.
 
 ## Quick start (Phase 1 lab UI)
 

--- a/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
@@ -26,7 +26,7 @@ Streamlit **starts** Rust binaries via subprocess. It does not replace them. Pha
 
 Phase 1 **100-round smoke PASS** on bensbench (2026-08-28) is recorded in `docs/PHASE1_TEST_RESULTS.md` — not a substitute for the 10k gate.
 
-**Phase 2 (2026-08-30):** pin `19d205d` (bbartling fork `vibe13-mstp`, upstream PR [#467](https://github.com/jscott3201/rusty-bacnet/pull/467); lab evidence collected on `e3b9edb`). Gate 2 passive **PASS**. Gate 3 app + coexistence **PASS**. Gate 4 mini-device Workbench discover **PASS** (`device:123001`). Gates 5–6 **OPEN**. Limitations: not Clause 9 conformance; no extended frames; no soak claim.
+**Phase 2 (2026-08-31):** pin `af4e886` (`jscott3201/rusty-bacnet` dev; #467/#468 merged). Gate 2 passive **PASS**. Gate 3 FEC **PASS**. Gate 4 mini-device Workbench discover **PASS** (`device:123001`). Gate 4b Haystack trunk **PASS**. Gates 5–6 **OPEN**. Historical evidence on `19d205d`/`e3b9edb` archived. Limitations: not Clause 9 conformance; no extended frames; no soak claim.
 
 ## Repository map (what code does what)
 

--- a/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
@@ -26,7 +26,7 @@ Streamlit **starts** Rust binaries via subprocess. It does not replace them. Pha
 
 Phase 1 **100-round smoke PASS** on bensbench (2026-08-28) is recorded in `docs/PHASE1_TEST_RESULTS.md` — not a substitute for the 10k gate.
 
-**Phase 2 (2026-08-30):** pin `73a1fd4` fixes Clause 9 CRC + USB stream. Hardware Gates 2–6 remain OPEN until reports exist. Do not mark Phase 2 PASS from loopback/CI alone.
+**Phase 2 (2026-08-30):** pin `73a1fd4` fixes Clause 9 CRC + USB stream. Gate 2 passive **PASS**. Gate 3 application **PASS** / coexistence **FAIL** (`captures/mstp-gate3-coexistence-abort.json`). Gates 4–6 **BLOCKED**. Live TX blocked until Clause 9.5.6 PR https://github.com/jscott3201/rusty-bacnet/pull/465 is pinned. Do not mark Phase 2 PASS from loopback/CI or FEC read alone.
 
 ## Repository map (what code does what)
 

--- a/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
@@ -26,7 +26,7 @@ Streamlit **starts** Rust binaries via subprocess. It does not replace them. Pha
 
 Phase 1 **100-round smoke PASS** on bensbench (2026-08-28) is recorded in `docs/PHASE1_TEST_RESULTS.md` — not a substitute for the 10k gate.
 
-**Phase 2 (2026-08-30):** pin `e3b9edb` (bbartling fork `vibe13-mstp` only). Gate 2 passive **PASS**. Gate 3 app + coexistence **PASS**. Gate 4 mini-device Workbench discover **PASS** (`device:123001`). Gates 5–6 **OPEN**. Do not mark soak/Gate 6 PASS without evidence.
+**Phase 2 (2026-08-30):** pin `19d205d` (bbartling fork `vibe13-mstp`, upstream PR [#467](https://github.com/jscott3201/rusty-bacnet/pull/467); lab evidence collected on `e3b9edb`). Gate 2 passive **PASS**. Gate 3 app + coexistence **PASS**. Gate 4 mini-device Workbench discover **PASS** (`device:123001`). Gates 5–6 **OPEN**. Limitations: not Clause 9 conformance; no extended frames; no soak claim.
 
 ## Repository map (what code does what)
 

--- a/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
@@ -26,7 +26,7 @@ Streamlit **starts** Rust binaries via subprocess. It does not replace them. Pha
 
 Phase 1 **100-round smoke PASS** on bensbench (2026-08-28) is recorded in `docs/PHASE1_TEST_RESULTS.md` — not a substitute for the 10k gate.
 
-**Phase 2 (2026-08-30):** pin `73a1fd4` fixes Clause 9 CRC + USB stream. Gate 2 passive **PASS**. Gate 3 application **PASS** / coexistence **FAIL** (`captures/mstp-gate3-coexistence-abort.json`). Gates 4–6 **BLOCKED**. Live TX blocked until Clause 9.5.6 PR https://github.com/jscott3201/rusty-bacnet/pull/465 is pinned. Do not mark Phase 2 PASS from loopback/CI or FEC read alone.
+**Phase 2 (2026-08-30):** pin `e3b9edb` (bbartling fork `vibe13-mstp` only). Gate 2 passive **PASS**. Gate 3 app + coexistence **PASS**. Gate 4 mini-device Workbench discover **PASS** (`device:123001`). Gates 5–6 **OPEN**. Do not mark soak/Gate 6 PASS without evidence.
 
 ## Repository map (what code does what)
 

--- a/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
+++ b/vibe_code_apps_13/vibe13_agent_spec/SPEC.md
@@ -21,29 +21,29 @@ Streamlit **starts** Rust binaries via subprocess. It does not replace them. Pha
 | Phase | Gate | Evidence artifact |
 |-------|------|-------------------|
 | **1** | 10,000 alternating C+C exchanges @ 38,400, zero peer errors; unplug fault bounded | `captures/wire-test-38400.json` |
-| **2** | Two MS/TP masters; Who-Is/I-Am, RP, RPM, WP; 1 h soak; **no IP in device binary** | MS/TP acceptance log + capture |
+| **2** | Rescue gates 1–6: Clause 9 CRC; passive tokens 0+7; FEC RP AI:1173; mini-device; shared endpoint + mirror; soak — **no IP in device binary** | `captures/mstp-passive-*.json`, fec/mini reports |
 | **3** | Routed B/IP → MS/TP; hop count; no broadcast loop; 8 h soak | Router telemetry + pcap |
 
 Phase 1 **100-round smoke PASS** on bensbench (2026-08-28) is recorded in `docs/PHASE1_TEST_RESULTS.md` — not a substitute for the 10k gate.
+
+**Phase 2 (2026-08-30):** pin `73a1fd4` fixes Clause 9 CRC + USB stream. Hardware Gates 2–6 remain OPEN until reports exist. Do not mark Phase 2 PASS from loopback/CI alone.
 
 ## Repository map (what code does what)
 
 ```text
 vibe_code_apps_13/
 ├── apps/serial-wire-test/     # Phase 1 Rust CLI — opens both FTDI ports, alternates framed bytes
+├── apps/mstp-passive-sniff/   # Phase 2 RX-only decode (Gate 2)
+├── apps/mstp-fec-diag/        # Phase 2 client-only FEC RP (Gate 3)
+├── apps/mstp-mini-device/     # Phase 2 MS/TP device (Gate 4+)
+├── apps/mstp-probe/           # Phase 2 acceptance / loopback
 ├── crates/lab-common/         # Shared envelope parser, JSON report, baud policy (no BACnet)
-├── tools/supervisory_console.py  # Phase 1 Streamlit lab UI (start/stop test, health table)
-├── scripts/run_wire_dashboard.sh # Launch Streamlit on :8765
-├── scripts/show-adapters.sh      # lsusb + by-id inventory
-├── captures/                     # JSON reports + *-live.json progress snapshots
-└── docs/                         # Phase plans, cheat sheet, test results
+├── crates/mstp-lab/           # Thin rusty-bacnet boundary
+├── tools/supervisory_console.py  # Phase 1 Streamlit lab UI
+├── scripts/run_wire_dashboard.sh
+├── captures/
+└── docs/
 ```
-
-**Future (placeholders today):**
-
-- `apps/mstp-mini-device/` — Phase 2 BACnet MS/TP device (`rusty-bacnet`)
-- `apps/mstp-probe/` — Phase 2 MS/TP client / acceptance runner
-- `apps/bacnet-router/` — Phase 3 heterogeneous router + Axum status API
 
 ## What Phase 1 proves (honest scope)
 


### PR DESCRIPTION
## Summary

Rebase Phase 2 onto merged upstream `jscott3201/rusty-bacnet` dev (`af4e886` — #467 CRC/token/PFM, #468 Python MS/TP).

- Pin all workspace crates to exact SHA `af4e88680c51eb4da64dac47f0540a35bf184732` (not bbartling fork)
- Extend acceptance: Device PICS properties, Object_List index 0/1, invalid index/property, BI write-denied
- Haystack Gate 4b script (`check_mstp_haystack_trunk.sh`) for FEC + Rust point supervisory checks
- Mini-device: startup logs `rusty_bacnet_rev`, serial-path USB unplug watchdog
- Runtime strace gate: no AF_INET during startup; Linux timing baseline script; BFR Phase 3 research doc

## Audited SHAs

| Repo | SHA |
|------|-----|
| rusty-bacnet upstream dev | `af4e88680c51eb4da64dac47f0540a35bf184732` |
| Vibe13 branch tip | `b51835fa` (after push) |

## Classification

| Class | Status |
|-------|--------|
| Implemented/proven | #467/#468 on upstream; Gate 1–4 historical; **post-pin smoke PASS** (passive, FEC, Haystack, mini-device) |
| Mini-device blocker | Upstream transport health API; sim still remove/re-add AI/BI |
| Mirror blocker | Shared MS/TP endpoint (Gate 5) |
| Router blocker | Extended frames + B/IP routing (Gate 6) |
| Conformance gaps | Six-baud matrix, golden vectors, 1h/24h soak |

## Upstream candidate PRs (local `~/src/rusty-bacnet`)

- `fix/mstp-validate-rust-config` — Rust `MstpConfig` validation
- `fix/mstp-tx-completion-after-drain` — `tcdrain` after serial write

## Hardware evidence (2026-08-31, 38400)

- `captures/mstp-passive-af4e886-60s.json` — PASS
- `captures/mstp-fec-ai1173-af4e886-oneshot.json` — PASS
- Haystack Gate 4b — PASS after ~2 min settle

## Go/no-go

**GO (minimal):** Vibe13 provides a stable, server-only, standard-frame BACnet MS/TP lab device at 38,400 baud on the tested BASRT/FEC/Waveshare topology.

**Not yet:** Clause 9 conformant, BTL, extended MS/TP, segmentation, FEC mirror, router, 1h/24h soak.

## Test plan

- [x] `cargo fmt/clippy/test --workspace`
- [x] `./scripts/check_mstp_no_ip.sh`
- [x] `./scripts/check_mstp_no_ip_runtime.sh`
- [x] Loopback acceptance (CI)
- [x] Passive 60s + FEC one-shot + Haystack @ 38400
- [ ] 1h soak (scheduled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passive MS/TP sniffing with token tracking, frame validation, and stronger acceptance checks.
  * Added serial-device monitoring so the mini-device shuts down safely if its connection disappears.
  * Added supervisory trunk-health checks and Linux timing-baseline tooling.
  * Added BACnet acceptance checks for device properties, object lists, and expected error responses.

* **Documentation**
  * Updated Phase 2 status, hardware runbooks, evidence, limitations, and implementation decisions.
  * Added test captures documenting successful and failed discovery, coexistence, and analog-input scenarios.

* **Bug Fixes**
  * Improved discovery wait timing based on the configured APDU timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->