### PR TITLE
fix(vibe13): correct Linux timing evidence semantics

### DIFF
--- a/vibe_code_apps_13/README.md
+++ b/vibe_code_apps_13/README.md
@@ -1,6 +1,17 @@
 # Checkpoint 13 - Rust BACnet MS/TP Router Appliance
 
-**Status: Prototype closed (historical)** — Phase 2 evidence frozen on pin `af4e886` (`jscott3201/rusty-bacnet`; #467/#468 **merged**). Gates 1–4 + 4b **PASS** on `af4e886` (2026-08-31 smoke). Gates 5–6, 1h/24h soak, and router work are **out of scope** here. See [`docs/PHASE2_PROTOTYPE_CLOSEOUT.md`](docs/PHASE2_PROTOTYPE_CLOSEOUT.md), [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md), and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
+**Status: Prototype closed (historical)** — Phase 2 evidence frozen on pin `af4e886` (`jscott3201/rusty-bacnet`; #467/#468 **merged**). Gates 1–4 + 4b **PASS** on `af4e886` (2026-08-31 smoke). Gates 5–6, 1h/24h *instrumented* soak, and router work are **out of scope** here. See [`docs/PHASE2_PROTOTYPE_CLOSEOUT.md`](docs/PHASE2_PROTOTYPE_CLOSEOUT.md), [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md), and [`docs/PHASE2_HARDWARE_RUNBOOK.md`](docs/PHASE2_HARDWARE_RUNBOOK.md).
+
+## Stress / timing research results (linked)
+
+| Stress | Result | Report |
+|--------|--------|--------|
+| **Host scheduler (cyclictest)** idle+loaded @ pin `af4e886` | **measurement_complete** — idle max 239 µs **under** 1562.5 µs indicator; loaded max **2639 µs exceeded**; **not** Clause 9 wire timing | [`captures/linux-timing-af4e886-20260901T201201Z/README.md`](captures/linux-timing-af4e886-20260901T201201Z/README.md) · [`ASSESSMENT.md`](captures/linux-timing-af4e886-20260901T201201Z/ASSESSMENT.md) · narrative [`docs/PHASE2_SOFTWARE_RESULTS.md`](docs/PHASE2_SOFTWARE_RESULTS.md) |
+| **Prior cyclictest attempt** (invalid loaded) | **PARTIAL** | [`captures/linux-timing-af4e886-20260901T134454Z/ERRATA.md`](captures/linux-timing-af4e886-20260901T134454Z/ERRATA.md) |
+| **24h mini-device continuity** | **PASS** — same PID / etimes>86400 = process continuity + discoverability **only** (not CRC/token counter soak) | [`captures/mini-device-24h-continuity-20260901T200935Z.txt`](captures/mini-device-24h-continuity-20260901T200935Z.txt) |
+| **On-wire Clause 9 MS/TP timing** (logic analyzer / high-Z RS-485) | **DEFERRED** — no substitute cyclictest | capture ASSESSMENT + diy-bacnet-router M4 carry-forward |
+
+**Honest bottom line for researchers:** Vibe13 shows a **stable standard-frame MS/TP mini-device at 38.4 kbps** on the Waveshare C / BASRT / FEC trunk, with **host scheduler characterization** complete. It does **not** claim measured on-wire turnaround, USB-adapter Clause 9 conformance, extended frames, segmentation, router, or BTL.
 
 ## Limitations (current)
 

--- a/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/.gate_result
+++ b/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/.gate_result
@@ -1,1 +1,1 @@
-pass
+measurement_complete

--- a/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/ASSESSMENT.md
+++ b/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/ASSESSMENT.md
@@ -1,0 +1,29 @@
+# Assessment correction — 201201Z Linux timing capture
+
+**Date:** 2026-09-03  
+**Raw evidence:** preserved (`cyclictest-idle.txt`, `cyclictest-loaded.txt`, histograms, stress-ng logs)  
+**Pin:** `af4e88680c51eb4da64dac47f0540a35bf184732` (frozen)
+
+## What was wrong
+
+1. Docs claimed loaded max **2639 µs** was **under** the **1562.5 µs** comparison value. **2639 > 1562.5** → must be **exceeded**.
+2. Bare gate **PASS** could be read as Clause 9 / wire-timing compliance. The gate only proved cyclictest produced `T:` lines + stress-ng exit 0.
+3. cyclictest measures **scheduler latency**, not Clause 9 wire turnaround.
+4. `-m` was easy to misread as SMP workers; it means **mlockall**. Capture used **one** cyclictest worker.
+5. The 60-bit interval is **not** a universal response deadline / not blanket `T_frame_abort`.
+
+## Corrected labels
+
+| Field | Value |
+|-------|-------|
+| result / gate label | `measurement_complete` |
+| measurement_execution | pass |
+| stress_ng_execution | pass |
+| haystack_before / after | pass |
+| scheduling_threshold_assessment | **exceeded** (driven by loaded max 2639) |
+| wire_timing_measured | false |
+| clause9_conformance | not_claimed |
+
+## On-wire qualification
+
+**DEFERRED** until a suitable high-impedance logic analyzer / oscilloscope / differential RS-485 analyzer is available. Do **not** rerun cyclictest and call it Clause 9 evidence. Do **not** add a third Waveshare C as a passive analyzer (onboard ~120 Ω termination).

--- a/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/README.md
+++ b/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/README.md
@@ -1,28 +1,47 @@
-# Linux timing gate — `af4e886` (2026-09-01, post-fix)
+# Linux timing gate — `af4e886` (2026-09-01 capture; semantics corrected 2026-09-03)
 
-**Verdict:** PASS  
+**Gate result label:** `measurement_complete` (not Clause 9 PASS)  
 **Artifact window:** 2026-09-01T20:12:01Z → 2026-09-01T20:37:26Z (~25 min)  
-**rusty-bacnet pin:** `af4e88680c51eb4da64dac47f0540a35bf184732`  
-**Mini-device PID:** 646770 (unchanged; ~28.8h elapsed at start; retrospective 24h+ **Y**)  
-**cyclictest mode:** privileged Docker (`--pid=host`) fallback — 1 thread reported despite `-m` SMP  
-**stress-ng mode:** Docker (`ubuntu:24.04`) — exit code 0
+**rusty-bacnet pin:** `af4e88680c51eb4da64dac47f0540a35bf184732` (frozen — unchanged)  
+**Mini-device PID:** 646770 (unchanged; ~28.8h elapsed at start; retrospective 24h+ continuity **Y**)  
+**cyclictest mode:** privileged Docker (`--pid=host`) fallback — **1 worker** reported; `-m` means **mlockall**, not one worker per CPU  
+**stress-ng mode:** Docker (`ubuntu:24.04`) — exit code 0  
+**git_dirty at capture:** `true` (preserved historical fact)
 
-## Cyclictest vs 60 bit times @ 38400 baud (1.5625 ms scheduling-risk indicator only)
+## Assessments (corrected)
 
-| Phase | Duration | Threads | Min (µs) | Avg (µs) | Max (µs) |
-|-------|----------|---------|----------|----------|----------|
-| Idle | 600 s | 1 | 4 | 5 | 239 |
-| Loaded (`stress-ng`) | 900 s | 1 | 4 | 11 | 2639 |
+| Field | Value |
+|-------|-------|
+| measurement_execution | **pass** |
+| stress_ng_execution | **pass** |
+| haystack_before / after | **pass** |
+| scheduling_threshold_assessment (idle max 239 µs) | **under** 1562.5 µs |
+| scheduling_threshold_assessment (loaded max **2639** µs) | **exceeded** 1562.5 µs |
+| wire_timing_measured | **false** |
+| clause9_conformance | **not_claimed** |
 
-**stress-ng:** Docker fallback; `stress-ng.exit` = 0. Loaded max 2639 µs still below multiple bit-times but higher than idle — expected under load.
+Raw `cyclictest-*.txt` / histograms are **unchanged**. See [`ASSESSMENT.md`](ASSESSMENT.md).
 
-**Clause 9:** Scheduling latency below 1,562.5 µs is a **host-risk** measurement only — not wire-timing conformance.
+## Cyclictest vs 60 bit times @ 38400 baud (1.5625 ms host-risk indicator only)
+
+| Phase | Duration | Threads | Min (µs) | Avg (µs) | Max (µs) | vs 1562.5 µs |
+|-------|----------|---------|----------|----------|----------|--------------|
+| Idle | 600 s | 1 | 4 | 5 | 239 | **under** |
+| Loaded (`stress-ng`) | 900 s | 1 | 4 | 11 | **2639** | **exceeded** |
+
+**stress-ng:** Docker fallback; `stress-ng.exit` = 0. Loaded max **2639 µs > 1562.5 µs** — host scheduling-risk indicator **exceeded** under load. This is **not** Clause 9 wire turnaround and **not** a T_frame_abort miss.
+
+**Clause 9 / on-wire:** **not measured** in this capture. Deferred pending high-impedance differential / logic-analyzer qualification (do not substitute another cyclictest run).
 
 ## Trunk health
 
 - Haystack `check` PASS before and after gate (`haystack-before/`, `haystack-after/`)
 - No FTDI/USB disconnect/reset in `kernel-usb-*.txt`
 - MS/TP counter deltas: N/A (mini-device does not export CRC counters)
+
+## 24h continuity (related, separate artifact)
+
+[`../mini-device-24h-continuity-20260901T200935Z.txt`](../mini-device-24h-continuity-20260901T200935Z.txt) proves **process continuity** and periodic discoverability (same PID, etimes>86400). It does **not** prove a fully instrumented protocol soak with CRC/token counter deltas.
 
 ## Kernel / RT
 

--- a/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/cyclictest-summary-idle.json
+++ b/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/cyclictest-summary-idle.json
@@ -18,5 +18,10 @@
       "max_us": 239
     }
   ],
-  "overall_avg_us_rounded": 5
+  "overall_avg_us_rounded": 5,
+  "host_risk_threshold_us": 1562.5,
+  "scheduling_threshold_assessment": "under",
+  "wire_timing_measured": false,
+  "clause9_conformance": "not_claimed",
+  "notes": "cyclictest measures host scheduler latency, not Clause 9 wire turnaround; 60-bit interval is an informational host-risk indicator only; cyclictest -m means mlockall, not one worker per CPU"
 }

--- a/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/cyclictest-summary-loaded.json
+++ b/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/cyclictest-summary-loaded.json
@@ -18,5 +18,10 @@
       "max_us": 2639
     }
   ],
-  "overall_avg_us_rounded": 11
+  "overall_avg_us_rounded": 11,
+  "host_risk_threshold_us": 1562.5,
+  "scheduling_threshold_assessment": "exceeded",
+  "wire_timing_measured": false,
+  "clause9_conformance": "not_claimed",
+  "notes": "cyclictest measures host scheduler latency, not Clause 9 wire turnaround; 60-bit interval is an informational host-risk indicator only; cyclictest -m means mlockall, not one worker per CPU"
 }

--- a/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/manifest.json
+++ b/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/manifest.json
@@ -1,6 +1,6 @@
 {
   "gate": "linux_timing_baseline",
-  "result": "pass",
+  "result": "measurement_complete",
   "stop_reason": null,
   "project_git_sha": "c5a1f7ff4a1f5c1de0348e2d4b7c03c658a15c5d",
   "git_dirty": true,
@@ -33,5 +33,15 @@
   "started_utc": "2026-09-01T20:12:01Z",
   "ended_utc": "2026-09-01T20:37:26Z",
   "baseline_exit_code": 0,
-  "artifacts_dir": "/home/ben/py-bacnet-stacks-playground/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z"
+  "artifacts_dir": "/home/ben/py-bacnet-stacks-playground/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z",
+  "measurement_execution": "pass",
+  "stress_ng_execution": "pass",
+  "scheduling_threshold_assessment_idle": "under",
+  "scheduling_threshold_assessment_loaded": "exceeded",
+  "scheduling_threshold_assessment": "exceeded",
+  "host_risk_threshold_us": 1562.5,
+  "wire_timing_measured": false,
+  "clause9_conformance": "not_claimed",
+  "cyclictest_m_flag_means": "mlockall (not one worker per CPU)",
+  "semantics_correction_note": "2026-09-03: renamed bare PASS; loaded max 2639 \u00b5s exceeds 1562.5 \u00b5s host-risk indicator; raw cyclictest logs preserved unchanged"
 }

--- a/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/result.md
+++ b/vibe_code_apps_13/captures/linux-timing-af4e886-20260901T201201Z/result.md
@@ -1,9 +1,24 @@
 # Linux timing gate result
 
-**Verdict:** pass
+**Gate result label:** measurement_complete
 
-Scheduling latency below 1,562.5 µs (60 bit times @ 38400 baud) is a **host-risk**
-measurement only — not BACnet Clause 9 wire-timing conformance.
+This gate records **host scheduler latency** (cyclictest), not Clause 9 wire turnaround.
+Comparison value 1562.5 µs = 60 bit times @ 38400 baud — **informational host-risk only**,
+not a universal response deadline and not T_frame_abort conformance.
+
+## Assessments
+- measurement_execution: pass
+- stress_ng_execution: pass
+- haystack_before: pass
+- haystack_after: pass
+- scheduling_threshold_assessment (idle): under
+- scheduling_threshold_assessment (loaded): exceeded
+- scheduling_threshold_assessment (overall): exceeded
+- wire_timing_measured: false
+- clause9_conformance: not_claimed
+
+Note: cyclictest `-m` means **mlockall**, not one worker per CPU.
+Historical fact preserved: capture recorded `git_dirty=true`.
 
 ## cyclictest-idle.txt
 - threads: 1
@@ -11,7 +26,9 @@ measurement only — not BACnet Clause 9 wire-timing conformance.
 - avg: 5 us (sample-weighted across threads)
 - max: 239 us
 - sched: SCHED_FIFO priority 80
-- vs 1562 us (60 bit @ 38400): scheduling-risk indicator only — not Clause 9 conformance
+- scheduling_threshold_assessment vs 1562.5 us: **under**
+- host-risk indicator only (60 bit @ 38400) — not Clause 9 / not wire turnaround
+- wire_timing_measured: false; clause9_conformance: not_claimed
 
 ## cyclictest-loaded.txt
 - threads: 1
@@ -19,5 +36,7 @@ measurement only — not BACnet Clause 9 wire-timing conformance.
 - avg: 11 us (sample-weighted across threads)
 - max: 2639 us
 - sched: SCHED_FIFO priority 80
-- vs 1562 us (60 bit @ 38400): scheduling-risk indicator only — not Clause 9 conformance
+- scheduling_threshold_assessment vs 1562.5 us: **exceeded**
+- host-risk indicator only (60 bit @ 38400) — not Clause 9 / not wire turnaround
+- wire_timing_measured: false; clause9_conformance: not_claimed
 

--- a/vibe_code_apps_13/docs/PHASE2_HARDWARE_EVIDENCE.md
+++ b/vibe_code_apps_13/docs/PHASE2_HARDWARE_EVIDENCE.md
@@ -35,9 +35,10 @@ Historical captures (`19d205d`, `e3b9edb`, `6a70b85`, `bbartling` fork) are **no
 
 | Gate | Script | Status |
 |------|--------|--------|
-| Linux timing baseline | **PASS** (post-fix; PR timing evidence closeout) | [`captures/linux-timing-af4e886-20260901T201201Z/`](../captures/linux-timing-af4e886-20260901T201201Z/) |
+| Linux timing baseline | **measurement_complete** (host scheduler; loaded max **exceeded** 1562.5 µs; not Clause 9) | [`captures/linux-timing-af4e886-20260901T201201Z/`](../captures/linux-timing-af4e886-20260901T201201Z/) |
 | Linux timing (prior) | **PARTIAL** — loaded invalid | [`captures/linux-timing-af4e886-20260901T134454Z/`](../captures/linux-timing-af4e886-20260901T134454Z/) (`ERRATA.md`) |
-| 24h mini-device continuity | **PASS** (PID 646770 unchanged, etimes>86400) | [`captures/mini-device-24h-continuity-20260901T200935Z.txt`](../captures/mini-device-24h-continuity-20260901T200935Z.txt) |
+| On-wire Clause 9 timing | **DEFERRED** (needs high-Z analyzer; not cyclictest) | capture `ASSESSMENT.md` |
+| 24h mini-device continuity | **PASS** (process continuity + discoverability; not CRC/token soak) | [`captures/mini-device-24h-continuity-20260901T200935Z.txt`](../captures/mini-device-24h-continuity-20260901T200935Z.txt) |
 | 1h mini-device soak | [`scripts/run_mstp_mini_soak.sh`](../scripts/run_mstp_mini_soak.sh) | see `captures/mstp-soak-af4e886-*` |
 | USB unplug | [`scripts/run_mstp_usb_unplug_gate.sh`](../scripts/run_mstp_usb_unplug_gate.sh) | **DEFERRED** — operator gate |
 

--- a/vibe_code_apps_13/docs/PHASE2_PROTOTYPE_CLOSEOUT.md
+++ b/vibe_code_apps_13/docs/PHASE2_PROTOTYPE_CLOSEOUT.md
@@ -20,9 +20,9 @@ A **stable, historical lab prototype**: server-only, standard-frame BACnet MS/TP
 | 4b — Haystack trunk | PASS | `captures/haystack-trunk/` |
 | 5–6 — shared endpoint / mirror | **OUT OF SCOPE** | not attempted |
 | 1h hardware soak | run [`scripts/run_mstp_mini_soak.sh`](../scripts/run_mstp_mini_soak.sh) | see `captures/mstp-soak-af4e886-*` |
-| 24h continuity (same PID) | **PASS** | [`captures/mini-device-24h-continuity-20260901T200935Z.txt`](../captures/mini-device-24h-continuity-20260901T200935Z.txt) |
+| 24h continuity (same PID) | **PASS** (process continuity only) | [`captures/mini-device-24h-continuity-20260901T200935Z.txt`](../captures/mini-device-24h-continuity-20260901T200935Z.txt) |
 | USB unplug gate | **DEFERRED** | [`scripts/run_mstp_usb_unplug_gate.sh`](../scripts/run_mstp_usb_unplug_gate.sh) |
-| Linux timing baseline | **PASS** | [`captures/linux-timing-af4e886-20260901T201201Z/`](../captures/linux-timing-af4e886-20260901T201201Z/) |
+| Linux timing baseline | **measurement_complete** (loaded host-risk **exceeded**) | [`captures/linux-timing-af4e886-20260901T201201Z/`](../captures/linux-timing-af4e886-20260901T201201Z/) |
 
 Full manifest: [`PHASE2_HARDWARE_EVIDENCE.md`](PHASE2_HARDWARE_EVIDENCE.md).
 

--- a/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
+++ b/vibe_code_apps_13/docs/PHASE2_SOFTWARE_RESULTS.md
@@ -53,18 +53,28 @@ Historical captures with `19d205d` / `e3b9edb` / `bbartling` fork are **not** ev
 | Haystack Gate 4b (after ~2 min settle) | PASS | `captures/haystack-trunk/` |
 | Mini-device MAC 3 @ 38400 | PASS (read-only-ai ok) | `captures/mstp-mini-device-af4e886.log` |
 | 1h soak script | **NOT RUN** — scripts ready | [`scripts/run_mstp_mini_soak.sh`](../scripts/run_mstp_mini_soak.sh) |
-| 24h continuity (same PID) | **PASS** — PID 646770, etimes>86400 at 2026-09-01T20:09:35Z | [`captures/mini-device-24h-continuity-20260901T200935Z.txt`](../captures/mini-device-24h-continuity-20260901T200935Z.txt) |
+| 24h continuity (same PID) | **PASS** — process continuity + discoverability only (not instrumented CRC/token soak) — PID 646770, etimes>86400 at 2026-09-01T20:09:35Z | [`captures/mini-device-24h-continuity-20260901T200935Z.txt`](../captures/mini-device-24h-continuity-20260901T200935Z.txt) |
 | USB unplug gate | **DEFERRED** — operator gate | [`scripts/run_mstp_usb_unplug_gate.sh`](../scripts/run_mstp_usb_unplug_gate.sh) |
-| Linux timing baseline | **PASS** (10m idle + 15m loaded; stress-ng exit 0) | [`captures/linux-timing-af4e886-20260901T201201Z/`](../captures/linux-timing-af4e886-20260901T201201Z/) |
+| Linux timing baseline | **measurement_complete** — host scheduler only; loaded max **exceeded** 1562.5 µs indicator | [`captures/linux-timing-af4e886-20260901T201201Z/`](../captures/linux-timing-af4e886-20260901T201201Z/) |
+| On-wire Clause 9 timing | **DEFERRED** — needs high-Z analyzer; not cyclictest | see capture `ASSESSMENT.md` |
 
-### Linux cyclictest summary (2026-09-01, bensbench — post-fix capture)
+### Linux cyclictest summary (2026-09-01 capture; semantics corrected 2026-09-03)
 
-Scheduling latency below **1,562.5 µs** (60 bit times @ 38400 baud) is a **host scheduling-risk** indicator only — **not BACnet Clause 9 wire-timing conformance**.
+cyclictest measures **host scheduler latency**, not Clause 9 wire turnaround. Comparison value **1,562.5 µs** (60 bit times @ 38400 baud) is an **informational host-risk indicator only** — not a universal response deadline and **not** `T_frame_abort` conformance. cyclictest `-m` = **mlockall** (capture used **1 worker**).
 
-| Phase | Duration | Min (µs) | Avg (µs) | Max (µs) | vs 1562 µs |
-|-------|----------|----------|----------|----------|------------|
-| Idle | 600 s | 4 | 5 | 239 | under |
-| Loaded (`stress-ng`, docker) | 900 s | 4 | 11 | 2639 | under (loaded max higher, expected) |
+| Phase | Duration | Min (µs) | Avg (µs) | Max (µs) | vs 1562.5 µs |
+|-------|----------|----------|----------|----------|--------------|
+| Idle | 600 s | 4 | 5 | 239 | **under** |
+| Loaded (`stress-ng`, docker) | 900 s | 4 | 11 | **2639** | **exceeded** |
+
+| Assessment | Value |
+|------------|-------|
+| measurement_execution | pass |
+| stress_ng_execution | pass |
+| haystack_before / after | pass |
+| scheduling_threshold_assessment | **exceeded** |
+| wire_timing_measured | false |
+| clause9_conformance | not_claimed |
 
 Prior capture **PARTIAL** (loaded invalid — stress-ng failure + gate bug): [`captures/linux-timing-af4e886-20260901T134454Z/`](../captures/linux-timing-af4e886-20260901T134454Z/) — see `ERRATA.md`.
 
@@ -79,4 +89,4 @@ With mini-device running on trunk @ 38400:
 
 Use `HAYSTACK_INSECURE=1` (or `HAYSTACK_CACERT`) with `~/open-fdd/.env` on the bench.
 
-**Go/no-go:** **GO** for Gates 2–4+4b, Linux timing host-risk gate, and 24h mini-device continuity. **No-go** for USB unplug gate or Clause 9 conformance claims until operator runs unplug script in [`PHASE2_HARDWARE_RUNBOOK.md`](PHASE2_HARDWARE_RUNBOOK.md).
+**Go/no-go:** **GO** for Gates 2–4+4b and mini-device process continuity. Linux timing = **host-risk characterization complete** with loaded indicator **exceeded** — **not** wire timing PASS. **No-go** for USB unplug, on-wire Clause 9 qualification, or conformance claims until analyzer runbook in [`PHASE2_HARDWARE_RUNBOOK.md`](PHASE2_HARDWARE_RUNBOOK.md) is satisfied.

--- a/vibe_code_apps_13/scripts/cyclictest_summary.py
+++ b/vibe_code_apps_13/scripts/cyclictest_summary.py
@@ -5,6 +5,13 @@ overall_min = minimum of all worker Min values
 overall_max = maximum of all worker Max values
 overall_avg = sample-weighted mean: sum(Avg_i * samples_i) / sum(samples_i)
   where samples_i is the parenthesized count on each T: line.
+
+Host-risk indicator (NOT Clause 9 wire timing):
+  60 bit times @ 38400 baud = 60 / 38400 s = 1.5625 ms = 1562.5 µs.
+  This is an informational scheduling-risk comparison only.
+  It is NOT a universal response deadline and NOT T_frame_abort conformance.
+
+cyclictest -m means mlockall (lock memory), NOT one worker per CPU.
 """
 from __future__ import annotations
 
@@ -13,12 +20,17 @@ import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 THREAD_RE = re.compile(
     r"^T:\s*(\d+)\s*\(\s*(\d+)\s*\)\s*P:(\d+)\s*I:(\d+)\s*C:\s*(\d+)\s*"
     r"Min:\s*(\d+)\s*Act:\s*(\d+)\s*Avg:\s*(\d+)\s*Max:\s*(\d+)"
 )
+
+# Informational host scheduling-risk indicator only (60 bit @ 38400).
+HOST_RISK_THRESHOLD_US = 1562.5
+
+ThresholdAssessment = Literal["under", "exceeded", "unknown"]
 
 
 @dataclass
@@ -46,6 +58,13 @@ class CyclictestSummary:
 
     def rounded_avg_us(self) -> int:
         return int(round(self.overall_avg_us))
+
+    def scheduling_threshold_assessment(
+        self, threshold_us: float = HOST_RISK_THRESHOLD_US
+    ) -> ThresholdAssessment:
+        if self.overall_max_us > threshold_us:
+            return "exceeded"
+        return "under"
 
 
 def parse_cyclictest_text(text: str) -> CyclictestSummary | None:
@@ -92,15 +111,21 @@ def parse_cyclictest_text(text: str) -> CyclictestSummary | None:
 def summary_to_dict(summary: CyclictestSummary) -> dict[str, Any]:
     data = asdict(summary)
     data["overall_avg_us_rounded"] = summary.rounded_avg_us()
+    data["host_risk_threshold_us"] = HOST_RISK_THRESHOLD_US
+    data["scheduling_threshold_assessment"] = summary.scheduling_threshold_assessment()
+    data["wire_timing_measured"] = False
+    data["clause9_conformance"] = "not_claimed"
+    data["notes"] = (
+        "cyclictest measures host scheduler latency, not Clause 9 wire turnaround; "
+        "60-bit interval is an informational host-risk indicator only; "
+        "cyclictest -m means mlockall, not one worker per CPU"
+    )
     return data
-
-
-def write_summary_json(path: Path, summary: CyclictestSummary) -> None:
-    path.write_text(json.dumps(summary_to_dict(summary), indent=2) + "\n")
 
 
 def format_result_section(name: str, summary: CyclictestSummary) -> list[str]:
     avg_display = summary.rounded_avg_us()
+    assessment = summary.scheduling_threshold_assessment()
     return [
         f"## {name}",
         f"- threads: {summary.thread_count}",
@@ -108,7 +133,9 @@ def format_result_section(name: str, summary: CyclictestSummary) -> list[str]:
         f"- avg: {avg_display} us (sample-weighted across threads)",
         f"- max: {summary.overall_max_us} us",
         f"- sched: {summary.sched_policy} priority {summary.sched_priority}",
-        f"- vs 1562 us (60 bit @ 38400): scheduling-risk indicator only — not Clause 9 conformance",
+        f"- scheduling_threshold_assessment vs {HOST_RISK_THRESHOLD_US} us: **{assessment}**",
+        f"- host-risk indicator only (60 bit @ 38400) — not Clause 9 / not wire turnaround",
+        f"- wire_timing_measured: false; clause9_conformance: not_claimed",
         "",
     ]
 

--- a/vibe_code_apps_13/scripts/run_linux_timing_gate.sh
+++ b/vibe_code_apps_13/scripts/run_linux_timing_gate.sh
@@ -146,8 +146,6 @@ if [[ "$SCHED_LOADED" == "exceeded" || "$SCHED_IDLE" == "exceeded" ]]; then
   SCHED_OVERALL="exceeded"
 elif [[ "$SCHED_IDLE" == "under" && "$SCHED_LOADED" == "under" ]]; then
   SCHED_OVERALL="under"
-elif [[ "$SCHED_IDLE" == "under" || "$SCHED_LOADED" == "under" ]]; then
-  SCHED_OVERALL="under"
 fi
 
 STRESS_EXEC="fail"
@@ -157,13 +155,22 @@ elif [[ "$STRESS_EXIT" == "null" ]]; then
   STRESS_EXEC="unknown"
 fi
 
-python3 - <<PY
-import json, pathlib, sys
-sys.path.insert(0, "$ROOT/scripts")
+export ROOT ART RESULT MEASUREMENT_EXECUTION STRESS_EXEC HAYSTACK_BEFORE HAYSTACK_AFTER \
+  SCHED_IDLE SCHED_LOADED SCHED_OVERALL PROJECT_SHA GIT_DIRTY RUSTY_REV KERNEL ARCH \
+  PREEMPT_CONFIG PORT LATENCY_TIMER MINI_PID MINI_ELAPSED RETROSPECTIVE_24H \
+  CYCLIC_IDLE CYCLIC_LOADED THREADS_IDLE THREADS_LOADED CYCLICTEST_VERSION \
+  CYCLICTEST_COMMAND CYCLICTEST_MODE CONTAINER_DIGEST STRESS_CMD STRESS_EXIT \
+  START_UTC END_UTC BASELINE_RC STOP_REASON
+export TIMING_IDLE_SECS="${TIMING_IDLE_SECS:-600}"
+export TIMING_LOADED_SECS="${TIMING_LOADED_SECS:-900}"
+
+python3 - <<'PY'
+import json, pathlib, sys, os
+sys.path.insert(0, os.environ["ROOT"] + "/scripts")
 from cyclictest_summary import HOST_RISK_THRESHOLD_US, format_result_section, parse_cyclictest_text
 
-art = pathlib.Path("$ART")
-result = "$RESULT"
+art = pathlib.Path(os.environ["ART"])
+result = os.environ["RESULT"]
 lines = [
     "# Linux timing gate result",
     "",
@@ -174,13 +181,13 @@ lines = [
     "not a universal response deadline and not T_frame_abort conformance.",
     "",
     "## Assessments",
-    f"- measurement_execution: $MEASUREMENT_EXECUTION",
-    f"- stress_ng_execution: $STRESS_EXEC",
-    f"- haystack_before: $HAYSTACK_BEFORE",
-    f"- haystack_after: $HAYSTACK_AFTER",
-    f"- scheduling_threshold_assessment (idle): $SCHED_IDLE",
-    f"- scheduling_threshold_assessment (loaded): $SCHED_LOADED",
-    f"- scheduling_threshold_assessment (overall): $SCHED_OVERALL",
+    f"- measurement_execution: {os.environ['MEASUREMENT_EXECUTION']}",
+    f"- stress_ng_execution: {os.environ['STRESS_EXEC']}",
+    f"- haystack_before: {os.environ['HAYSTACK_BEFORE']}",
+    f"- haystack_after: {os.environ['HAYSTACK_AFTER']}",
+    f"- scheduling_threshold_assessment (idle): {os.environ['SCHED_IDLE']}",
+    f"- scheduling_threshold_assessment (loaded): {os.environ['SCHED_LOADED']}",
+    f"- scheduling_threshold_assessment (overall): {os.environ['SCHED_OVERALL']}",
     "- wire_timing_measured: false",
     "- clause9_conformance: not_claimed",
     "",
@@ -197,52 +204,53 @@ for name in ("cyclictest-idle.txt", "cyclictest-loaded.txt"):
     lines.extend(format_result_section(name, summary))
 (art / "result.md").write_text("\n".join(lines) + "\n")
 
+stress_exit = os.environ["STRESS_EXIT"]
 manifest = {
     "gate": "linux_timing_baseline",
-    "result": "$RESULT",
-    "stop_reason": "$STOP_REASON" or None,
-    "measurement_execution": "$MEASUREMENT_EXECUTION",
-    "stress_ng_execution": "$STRESS_EXEC",
-    "haystack_before": "$HAYSTACK_BEFORE",
-    "haystack_after": "$HAYSTACK_AFTER",
-    "scheduling_threshold_assessment_idle": "$SCHED_IDLE",
-    "scheduling_threshold_assessment_loaded": "$SCHED_LOADED",
-    "scheduling_threshold_assessment": "$SCHED_OVERALL",
+    "result": result,
+    "stop_reason": os.environ.get("STOP_REASON") or None,
+    "measurement_execution": os.environ["MEASUREMENT_EXECUTION"],
+    "stress_ng_execution": os.environ["STRESS_EXEC"],
+    "haystack_before": os.environ["HAYSTACK_BEFORE"],
+    "haystack_after": os.environ["HAYSTACK_AFTER"],
+    "scheduling_threshold_assessment_idle": os.environ["SCHED_IDLE"],
+    "scheduling_threshold_assessment_loaded": os.environ["SCHED_LOADED"],
+    "scheduling_threshold_assessment": os.environ["SCHED_OVERALL"],
     "host_risk_threshold_us": HOST_RISK_THRESHOLD_US,
     "wire_timing_measured": False,
     "clause9_conformance": "not_claimed",
-    "project_git_sha": "$PROJECT_SHA",
-    "git_dirty": "$GIT_DIRTY" == "true",
-    "rusty_bacnet_rev": "$RUSTY_REV",
-    "kernel": "$KERNEL",
-    "arch": "$ARCH",
-    "preempt_config": "$PREEMPT_CONFIG" or None,
-    "serial_by_id": "$PORT",
-    "ftdi_latency_timer": int("$LATENCY_TIMER") if "$LATENCY_TIMER".isdigit() else None,
-    "mini_device_pid": int("$MINI_PID") if "$MINI_PID".isdigit() else None,
-    "mini_device_elapsed_secs": int("$MINI_ELAPSED") if "$MINI_ELAPSED".isdigit() else None,
-    "retrospective_24h_endurance": "$RETROSPECTIVE_24H" == "true",
-    "cyclictest_idle": "$CYCLIC_IDLE",
-    "cyclictest_loaded": "$CYCLIC_LOADED",
-    "cyclictest_threads_idle": int("$THREADS_IDLE"),
-    "cyclictest_threads_loaded": int("$THREADS_LOADED"),
-    "cyclictest_version": "$CYCLICTEST_VERSION" or None,
-    "cyclictest_command": "$CYCLICTEST_COMMAND" or None,
+    "project_git_sha": os.environ["PROJECT_SHA"],
+    "git_dirty": os.environ["GIT_DIRTY"] == "true",
+    "rusty_bacnet_rev": os.environ["RUSTY_REV"],
+    "kernel": os.environ["KERNEL"],
+    "arch": os.environ["ARCH"],
+    "preempt_config": os.environ.get("PREEMPT_CONFIG") or None,
+    "serial_by_id": os.environ["PORT"],
+    "ftdi_latency_timer": int(os.environ["LATENCY_TIMER"]) if os.environ.get("LATENCY_TIMER", "").isdigit() else None,
+    "mini_device_pid": int(os.environ["MINI_PID"]) if os.environ.get("MINI_PID", "").isdigit() else None,
+    "mini_device_elapsed_secs": int(os.environ["MINI_ELAPSED"]) if os.environ.get("MINI_ELAPSED", "").isdigit() else None,
+    "retrospective_24h_endurance": os.environ["RETROSPECTIVE_24H"] == "true",
+    "cyclictest_idle": os.environ["CYCLIC_IDLE"],
+    "cyclictest_loaded": os.environ["CYCLIC_LOADED"],
+    "cyclictest_threads_idle": int(os.environ["THREADS_IDLE"]),
+    "cyclictest_threads_loaded": int(os.environ["THREADS_LOADED"]),
+    "cyclictest_version": os.environ.get("CYCLICTEST_VERSION") or None,
+    "cyclictest_command": os.environ.get("CYCLICTEST_COMMAND") or None,
     "sched_policy": "SCHED_FIFO",
     "sched_priority": 80,
-    "cyclictest_mode": "$CYCLICTEST_MODE" or None,
+    "cyclictest_mode": os.environ.get("CYCLICTEST_MODE") or None,
     "cyclictest_m_flag_means": "mlockall (not one worker per CPU)",
-    "container_image_digest": "$CONTAINER_DIGEST" or None,
-    "stress_ng_command": "$STRESS_CMD" or None,
-    "stress_ng_exit_code": $STRESS_EXIT,
-    "timing_idle_secs": int("${TIMING_IDLE_SECS:-600}"),
-    "timing_loaded_secs": int("${TIMING_LOADED_SECS:-900}"),
-    "started_utc": "$START_UTC",
-    "ended_utc": "$END_UTC",
-    "baseline_exit_code": $BASELINE_RC,
-    "artifacts_dir": "$ART",
+    "container_image_digest": os.environ.get("CONTAINER_DIGEST") or None,
+    "stress_ng_command": os.environ.get("STRESS_CMD") or None,
+    "stress_ng_exit_code": None if stress_exit == "null" else int(stress_exit),
+    "timing_idle_secs": int(os.environ.get("TIMING_IDLE_SECS", "600")),
+    "timing_loaded_secs": int(os.environ.get("TIMING_LOADED_SECS", "900")),
+    "started_utc": os.environ["START_UTC"],
+    "ended_utc": os.environ["END_UTC"],
+    "baseline_exit_code": int(os.environ["BASELINE_RC"]),
+    "artifacts_dir": os.environ["ART"],
 }
-pathlib.Path("$ART/manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+pathlib.Path(os.environ["ART"] + "/manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
 PY
 
 echo "Timing gate complete: result=$RESULT scheduling_threshold=$SCHED_OVERALL artifacts=$ART"

--- a/vibe_code_apps_13/scripts/run_linux_timing_gate.sh
+++ b/vibe_code_apps_13/scripts/run_linux_timing_gate.sh
@@ -115,6 +115,17 @@ if [[ "$RESULT" == "pass" && "$CYCLIC_LOADED" == "pass" && "$STRESS_EXIT" == "nu
   fi
 fi
 
+# Presence of T: lines means measurement_execution completed — NOT Clause 9 PASS.
+# Rename bare "pass" so it cannot be mistaken for protocol timing compliance.
+MEASUREMENT_EXECUTION="fail"
+if [[ "$CYCLIC_IDLE" == "pass" && ( "$CYCLIC_LOADED" == "pass" || "$CYCLIC_LOADED" == "invalid" ) ]]; then
+  MEASUREMENT_EXECUTION="pass"
+fi
+if [[ "$RESULT" == "pass" ]]; then
+  RESULT="measurement_complete"
+  echo "measurement_complete" >"$ART/.gate_result"
+fi
+
 RETROSPECTIVE_24H="false"
 if [[ -n "$MINI_ELAPSED" && "$MINI_ELAPSED" -ge 86400 ]]; then
   RETROSPECTIVE_24H="true"
@@ -128,20 +139,52 @@ python3 "$ROOT/scripts/cyclictest_summary.py" "$ART/cyclictest-loaded.txt" \
 THREADS_IDLE="$(python3 -c "import json; print(json.load(open('$ART/cyclictest-summary-idle.json')).get('thread_count', 0))" 2>/dev/null || echo 0)"
 THREADS_LOADED="$(python3 -c "import json; print(json.load(open('$ART/cyclictest-summary-loaded.json')).get('thread_count', 0))" 2>/dev/null || echo 0)"
 
+SCHED_IDLE="$(python3 -c "import json; print(json.load(open('$ART/cyclictest-summary-idle.json')).get('scheduling_threshold_assessment', 'unknown'))" 2>/dev/null || echo unknown)"
+SCHED_LOADED="$(python3 -c "import json; print(json.load(open('$ART/cyclictest-summary-loaded.json')).get('scheduling_threshold_assessment', 'unknown'))" 2>/dev/null || echo unknown)"
+SCHED_OVERALL="unknown"
+if [[ "$SCHED_LOADED" == "exceeded" || "$SCHED_IDLE" == "exceeded" ]]; then
+  SCHED_OVERALL="exceeded"
+elif [[ "$SCHED_IDLE" == "under" && "$SCHED_LOADED" == "under" ]]; then
+  SCHED_OVERALL="under"
+elif [[ "$SCHED_IDLE" == "under" || "$SCHED_LOADED" == "under" ]]; then
+  SCHED_OVERALL="under"
+fi
+
+STRESS_EXEC="fail"
+if [[ "$STRESS_EXIT" == "0" ]]; then
+  STRESS_EXEC="pass"
+elif [[ "$STRESS_EXIT" == "null" ]]; then
+  STRESS_EXEC="unknown"
+fi
+
 python3 - <<PY
 import json, pathlib, sys
 sys.path.insert(0, "$ROOT/scripts")
-from cyclictest_summary import format_result_section, parse_cyclictest_text
+from cyclictest_summary import HOST_RISK_THRESHOLD_US, format_result_section, parse_cyclictest_text
 
 art = pathlib.Path("$ART")
 result = "$RESULT"
 lines = [
     "# Linux timing gate result",
     "",
-    f"**Verdict:** {result}",
+    f"**Gate result label:** {result}",
     "",
-    "Scheduling latency below 1,562.5 µs (60 bit times @ 38400 baud) is a **host-risk**",
-    "measurement only — not BACnet Clause 9 wire-timing conformance.",
+    "This gate records **host scheduler latency** (cyclictest), not Clause 9 wire turnaround.",
+    f"Comparison value {HOST_RISK_THRESHOLD_US} µs = 60 bit times @ 38400 baud — **informational host-risk only**,",
+    "not a universal response deadline and not T_frame_abort conformance.",
+    "",
+    "## Assessments",
+    f"- measurement_execution: $MEASUREMENT_EXECUTION",
+    f"- stress_ng_execution: $STRESS_EXEC",
+    f"- haystack_before: $HAYSTACK_BEFORE",
+    f"- haystack_after: $HAYSTACK_AFTER",
+    f"- scheduling_threshold_assessment (idle): $SCHED_IDLE",
+    f"- scheduling_threshold_assessment (loaded): $SCHED_LOADED",
+    f"- scheduling_threshold_assessment (overall): $SCHED_OVERALL",
+    "- wire_timing_measured: false",
+    "- clause9_conformance: not_claimed",
+    "",
+    "Note: cyclictest `-m` means **mlockall**, not one worker per CPU.",
     "",
 ]
 for name in ("cyclictest-idle.txt", "cyclictest-loaded.txt"):
@@ -158,6 +201,16 @@ manifest = {
     "gate": "linux_timing_baseline",
     "result": "$RESULT",
     "stop_reason": "$STOP_REASON" or None,
+    "measurement_execution": "$MEASUREMENT_EXECUTION",
+    "stress_ng_execution": "$STRESS_EXEC",
+    "haystack_before": "$HAYSTACK_BEFORE",
+    "haystack_after": "$HAYSTACK_AFTER",
+    "scheduling_threshold_assessment_idle": "$SCHED_IDLE",
+    "scheduling_threshold_assessment_loaded": "$SCHED_LOADED",
+    "scheduling_threshold_assessment": "$SCHED_OVERALL",
+    "host_risk_threshold_us": HOST_RISK_THRESHOLD_US,
+    "wire_timing_measured": False,
+    "clause9_conformance": "not_claimed",
     "project_git_sha": "$PROJECT_SHA",
     "git_dirty": "$GIT_DIRTY" == "true",
     "rusty_bacnet_rev": "$RUSTY_REV",
@@ -178,11 +231,10 @@ manifest = {
     "sched_policy": "SCHED_FIFO",
     "sched_priority": 80,
     "cyclictest_mode": "$CYCLICTEST_MODE" or None,
+    "cyclictest_m_flag_means": "mlockall (not one worker per CPU)",
     "container_image_digest": "$CONTAINER_DIGEST" or None,
     "stress_ng_command": "$STRESS_CMD" or None,
     "stress_ng_exit_code": $STRESS_EXIT,
-    "haystack_before": "$HAYSTACK_BEFORE",
-    "haystack_after": "$HAYSTACK_AFTER",
     "timing_idle_secs": int("${TIMING_IDLE_SECS:-600}"),
     "timing_loaded_secs": int("${TIMING_LOADED_SECS:-900}"),
     "started_utc": "$START_UTC",
@@ -193,8 +245,11 @@ manifest = {
 pathlib.Path("$ART/manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
 PY
 
-echo "Timing gate complete: result=$RESULT artifacts=$ART"
+echo "Timing gate complete: result=$RESULT scheduling_threshold=$SCHED_OVERALL artifacts=$ART"
 if [[ "$RESULT" == "partial" ]]; then
   echo "NOTE: timing evidence incomplete — see cyclictest artifacts and summary.txt"
+fi
+if [[ "$SCHED_OVERALL" == "exceeded" ]]; then
+  echo "NOTE: host scheduling-risk indicator EXCEEDED (not Clause 9 wire timing)"
 fi
 exit "$BASELINE_RC"

--- a/vibe_code_apps_13/scripts/test_cyclictest_summary.py
+++ b/vibe_code_apps_13/scripts/test_cyclictest_summary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unit tests for cyclictest_summary aggregation."""
+"""Unit tests for cyclictest_summary aggregation and host-risk assessment."""
 from __future__ import annotations
 
 import sys
@@ -9,7 +9,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT))
 
-from cyclictest_summary import parse_cyclictest_text  # noqa: E402
+from cyclictest_summary import (  # noqa: E402
+    HOST_RISK_THRESHOLD_US,
+    format_result_section,
+    parse_cyclictest_text,
+    summary_to_dict,
+)
 
 FIXTURES = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "cyclictest"
 
@@ -25,6 +30,7 @@ class CyclictestSummaryTests(unittest.TestCase):
         self.assertEqual(summary.rounded_avg_us(), 5)
         self.assertEqual(summary.sched_policy, "SCHED_FIFO")
         self.assertEqual(summary.sched_priority, 80)
+        self.assertEqual(summary.scheduling_threshold_assessment(), "under")
 
     def test_multi_thread_aggregates_all_workers(self) -> None:
         text = (FIXTURES / "multi-thread.txt").read_text()
@@ -43,6 +49,29 @@ class CyclictestSummaryTests(unittest.TestCase):
     def test_no_summary_returns_none(self) -> None:
         text = (FIXTURES / "no-summary.txt").read_text()
         self.assertIsNone(parse_cyclictest_text(text))
+
+    def test_loaded_2639_us_is_exceeded_never_under(self) -> None:
+        """Retained 201201Z loaded max must render exceeded, never under."""
+        text = (FIXTURES / "loaded-2639us.txt").read_text()
+        summary = parse_cyclictest_text(text)
+        assert summary is not None
+        self.assertEqual(summary.overall_max_us, 2639)
+        self.assertGreater(summary.overall_max_us, HOST_RISK_THRESHOLD_US)
+        self.assertEqual(summary.scheduling_threshold_assessment(), "exceeded")
+        data = summary_to_dict(summary)
+        self.assertEqual(data["scheduling_threshold_assessment"], "exceeded")
+        self.assertFalse(data["wire_timing_measured"])
+        self.assertEqual(data["clause9_conformance"], "not_claimed")
+        section = "\n".join(format_result_section("cyclictest-loaded.txt", summary))
+        self.assertIn("**exceeded**", section)
+        self.assertNotIn("**under**", section)
+
+    def test_idle_239_us_is_under(self) -> None:
+        text = (FIXTURES / "idle-239us.txt").read_text()
+        summary = parse_cyclictest_text(text)
+        assert summary is not None
+        self.assertEqual(summary.overall_max_us, 239)
+        self.assertEqual(summary.scheduling_threshold_assessment(), "under")
 
 
 if __name__ == "__main__":

--- a/vibe_code_apps_13/tests/fixtures/cyclictest/idle-239us.txt
+++ b/vibe_code_apps_13/tests/fixtures/cyclictest/idle-239us.txt
@@ -1,0 +1,3 @@
+# Synthetic T: line matching retained 201201Z idle overall max (239 µs).
+# Max Latency: 239
+T: 0 (3000000) P:80 I:200 C: 3000000 Min:      4 Act:      5 Avg:      5 Max:    239

--- a/vibe_code_apps_13/tests/fixtures/cyclictest/loaded-2639us.txt
+++ b/vibe_code_apps_13/tests/fixtures/cyclictest/loaded-2639us.txt
@@ -1,0 +1,4 @@
+# Synthetic T: line matching retained 201201Z loaded overall max (2639 µs).
+# Used only for threshold-assessment regression — not a re-run of the gate.
+# Max Latency: 2639
+T: 0 (4500000) P:80 I:200 C: 4500000 Min:      4 Act:     11 Avg:     11 Max:   2639


### PR DESCRIPTION
## Summary
- Correct docs/manifests: loaded max **2639 µs exceeds** 1562.5 µs host-risk indicator (was wrongly \"under\")
- Split assessments: `measurement_execution`, `stress_ng_execution`, `scheduling_threshold_assessment`, `wire_timing_measured=false`, `clause9_conformance=not_claimed`
- Gate no longer leaves a bare **PASS** that looks like Clause 9 compliance
- Regression tests for 2639 → **exceeded**; README links both stress result reports
- Pin `af4e886` unchanged; raw cyclictest logs preserved
- On-wire MS/TP timing qualification **DEFERRED** (needs high-Z analyzer)

## rusty-bacnet issues (read-only)
- jscott3201/rusty-bacnet #498–#502 still **OPEN** (TIOCSRS485, tcdrain, absolute deadlines, deterministic Linux mode, on-wire timing). Pin not moved.

## Test plan
- [x] `python3 scripts/test_cyclictest_summary.py`
- [ ] vibe13-ci green
- [ ] CodeRabbit review addressed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prototype closeout and research documentation with corrected Linux timing results.
  * Clarified that loaded scheduling latency exceeded the informational threshold.
  * Documented that 24-hour testing demonstrates process continuity only.
  * Marked on-wire Clause 9 timing qualification as deferred and not claimed.

* **Bug Fixes**
  * Corrected timing assessment semantics and clarified cyclictest limitations.

* **Tests**
  * Added coverage for idle and loaded latency threshold assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->