### PR TITLE
feat(vibe23): T1/T2 cyclic LP optimality gap + comfort net welfare

### DIFF
--- a/vibe_code_apps_23/pyproject.toml
+++ b/vibe_code_apps_23/pyproject.toml
@@ -7,7 +7,14 @@ name = "vibe23-residential-dsm"
 version = "0.3.0"
 description = "Residential heat-pump EnergyPlus DSM lab: DR demo, thermostat grid search, battery co-optimization"
 requires-python = ">=3.12"
-dependencies = ["matplotlib>=3.9", "numpy>=2.0", "pandas>=2.2", "pydantic>=2.6", "tzdata>=2024.1"]
+dependencies = [
+    "matplotlib>=3.9",
+    "numpy>=2.0",
+    "pandas>=2.2",
+    "pydantic>=2.6",
+    "scipy>=1.11",
+    "tzdata>=2024.1",
+]
 
 [project.optional-dependencies]
 studio = ["streamlit>=1.37", "plotly>=5.20"]

--- a/vibe_code_apps_23/requirements-studio.txt
+++ b/vibe_code_apps_23/requirements-studio.txt
@@ -4,4 +4,5 @@ matplotlib>=3.9
 numpy>=2.0
 pandas>=2.2
 pydantic>=2.6
+scipy>=1.11
 tzdata>=2024.1

--- a/vibe_code_apps_23/src/vibe23/battery.py
+++ b/vibe_code_apps_23/src/vibe23/battery.py
@@ -45,11 +45,16 @@ def simulate_dispatch(
     mode: DispatchMode = "price_arbitrage",
     *,
     dt_hours: float = DT_HOURS,
+    cap_purchased_to_house_peak: bool = True,
 ) -> dict[str, list[float] | float]:
     """Greedy battery dispatch on purchased-grid load.
 
     Cannot charge and discharge in the same interval. SOC bounds are enforced.
     Thermal flexibility is assumed already reflected in ``facility_kw``.
+
+    This is a heuristic — compare against ``vibe23.dispatch.cyclic_lp_dispatch``
+    for an optimality gap. When ``cap_purchased_to_house_peak`` is True, charging
+    cannot create a purchased peak above the house facility peak.
     """
 
     load = np.asarray(facility_kw, dtype=float)
@@ -71,6 +76,8 @@ def simulate_dispatch(
 
     mean_price = float(np.mean(price))
     peak_threshold = float(np.quantile(load, 0.8)) if mode == "peak_shave" else None
+    median_load = float(np.median(load))
+    house_peak = float(np.max(load))
 
     for i in range(n):
         kw = float(load[i])
@@ -79,9 +86,13 @@ def simulate_dispatch(
         room_to_discharge = max(0.0, (soc - params.soc_min) * energy_cap * params.eta_d / dt_hours)
         max_c = min(params.max_charge_kw, room_to_charge)
         max_d = min(params.max_discharge_kw, room_to_discharge)
+        if cap_purchased_to_house_peak:
+            max_c = min(max_c, max(0.0, house_peak - kw))
 
         do_charge = False
         do_discharge = False
+        c_kw = 0.0
+        d_kw = 0.0
         if mode in {"price_arbitrage", "battery_only"}:
             if p < mean_price and max_c > 0:
                 do_charge = True
@@ -89,20 +100,25 @@ def simulate_dispatch(
                 do_discharge = True
         elif mode == "peak_shave":
             assert peak_threshold is not None
-            if kw > peak_threshold and max_d > 0:
+            if kw >= peak_threshold and max_d > 0:
                 do_discharge = True
-            elif kw < peak_threshold * 0.5 and max_c > 0:
+            elif kw <= median_load and max_c > 0:
+                # Recharge when at/below median load (old 0.5×P80 trigger was unreachable
+                # under high baseload floors).
                 do_charge = True
 
-        c_kw = 0.0
-        d_kw = 0.0
         if do_charge and not do_discharge:
             c_kw = max_c
             soc = min(params.soc_max, soc + (c_kw * dt_hours * params.eta_c) / energy_cap)
         elif do_discharge and not do_charge:
-            d_kw = min(max_d, kw)  # do not export in this simple demo
+            if mode == "peak_shave" and peak_threshold is not None:
+                target = max(0.0, peak_threshold * 0.95)
+                d_kw = min(max_d, max(0.0, kw - target))
+                if d_kw <= 0 and max_d > 0:
+                    d_kw = min(max_d, kw)
+            else:
+                d_kw = min(max_d, kw)  # do not export
             soc = max(params.soc_min, soc - (d_kw * dt_hours / params.eta_d) / energy_cap)
-
         charge[i] = c_kw
         discharge[i] = d_kw
         purchased[i] = max(0.0, kw + c_kw - d_kw)
@@ -118,4 +134,7 @@ def simulate_dispatch(
         "dt_hours": float(dt_hours),
         "mode": mode,
         "nominal_intervals_per_day": float(INTERVALS_PER_DAY),
+        "purchased_peak_kw": float(np.max(purchased)),
+        "house_peak_kw": house_peak,
+        "cap_purchased_to_house_peak": bool(cap_purchased_to_house_peak),
     }

--- a/vibe_code_apps_23/src/vibe23/comfort/__init__.py
+++ b/vibe_code_apps_23/src/vibe23/comfort/__init__.py
@@ -1,0 +1,15 @@
+"""Comfort monetization helpers."""
+
+from .cost import (
+    comfort_cost_usd,
+    degree_hours_abs_delta,
+    degree_hours_outside_band,
+    net_welfare_usd,
+)
+
+__all__ = [
+    "comfort_cost_usd",
+    "degree_hours_abs_delta",
+    "degree_hours_outside_band",
+    "net_welfare_usd",
+]

--- a/vibe_code_apps_23/src/vibe23/comfort/cost.py
+++ b/vibe_code_apps_23/src/vibe23/comfort/cost.py
@@ -1,0 +1,65 @@
+"""Comfort monetization for net-welfare headlines (ILLUSTRATIVE WTP)."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from ..residential.constants import DT_HOURS, MAX_COOL_F, MAX_HEAT_F
+
+
+def degree_hours_abs_delta(
+    candidate_f: Sequence[float],
+    reference_f: Sequence[float],
+    *,
+    dt_hours: float = DT_HOURS,
+) -> float:
+    """Σ |T_cand − T_ref| · Δt  (°F·h)."""
+    if len(candidate_f) != len(reference_f):
+        raise ValueError("temperature series length mismatch")
+    return float(sum(abs(float(c) - float(r)) * dt_hours for c, r in zip(candidate_f, reference_f, strict=True)))
+
+
+def degree_hours_outside_band(
+    temps_f: Sequence[float],
+    *,
+    low_f: float = MAX_HEAT_F,
+    high_f: float = MAX_COOL_F,
+    dt_hours: float = DT_HOURS,
+) -> dict[str, float]:
+    low_dh = 0.0
+    high_dh = 0.0
+    for t in temps_f:
+        v = float(t)
+        if v < low_f:
+            low_dh += (low_f - v) * dt_hours
+        elif v > high_f:
+            high_dh += (v - high_f) * dt_hours
+    return {
+        "low_degree_hours": low_dh,
+        "high_degree_hours": high_dh,
+        "total_degree_hours": low_dh + high_dh,
+        "low_f": float(low_f),
+        "high_f": float(high_f),
+    }
+
+
+def comfort_cost_usd(degree_hours: float, *, wtp_usd_per_f_h: float) -> float:
+    if wtp_usd_per_f_h < 0:
+        raise ValueError("wtp_usd_per_f_h must be non-negative")
+    return float(degree_hours) * float(wtp_usd_per_f_h)
+
+
+def net_welfare_usd(
+    *,
+    bill_savings_usd: float,
+    degree_hours: float,
+    wtp_usd_per_f_h: float,
+) -> dict[str, float]:
+    """Net welfare = bill savings − ILLUSTRATIVE comfort cost."""
+    comfort = comfort_cost_usd(degree_hours, wtp_usd_per_f_h=wtp_usd_per_f_h)
+    return {
+        "bill_savings_usd": float(bill_savings_usd),
+        "degree_hours": float(degree_hours),
+        "wtp_usd_per_f_h": float(wtp_usd_per_f_h),
+        "comfort_cost_usd": comfort,
+        "net_welfare_usd": float(bill_savings_usd) - comfort,
+    }

--- a/vibe_code_apps_23/src/vibe23/dispatch/__init__.py
+++ b/vibe_code_apps_23/src/vibe23/dispatch/__init__.py
@@ -1,0 +1,5 @@
+"""Battery dispatch solvers (greedy heuristic + cyclic LP bound)."""
+
+from .optimal import cyclic_lp_dispatch, optimality_gap
+
+__all__ = ["cyclic_lp_dispatch", "optimality_gap"]

--- a/vibe_code_apps_23/src/vibe23/dispatch/optimal.py
+++ b/vibe_code_apps_23/src/vibe23/dispatch/optimal.py
@@ -1,0 +1,166 @@
+"""Cyclic LP battery dispatch — PhD-honest bound next to the greedy heuristic."""
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from ..battery import BatteryParams
+from ..residential.constants import DT_HOURS
+
+
+def cyclic_lp_dispatch(
+    facility_kw: Sequence[float],
+    prices: Sequence[float],
+    params: BatteryParams,
+    *,
+    dt_hours: float = DT_HOURS,
+    throughput_cost_per_kwh: float = 0.05,
+    cap_purchased_to_house_peak: bool = True,
+) -> dict[str, list[float] | float | str]:
+    """Minimize bill + throughput cost subject to cyclic SOC and no export.
+
+    Uses ``scipy.optimize.linprog``. Reports an optimality *bound* for the
+    same constraints (continuous LP; simultaneous charge/discharge is weakly
+    dominated when throughput is priced).
+    """
+    from scipy.optimize import linprog
+
+    load = np.asarray(facility_kw, dtype=float)
+    price = np.asarray(prices, dtype=float)
+    if load.ndim != 1 or price.ndim != 1:
+        raise ValueError("facility_kw and prices must be 1-D")
+    if len(load) != len(price) or len(load) < 2:
+        raise ValueError("facility_kw and prices length mismatch / too short")
+
+    n = len(load)
+    dt = float(dt_hours)
+    cap = float(params.capacity_kwh)
+    s_min = float(params.soc_min) * cap
+    s_max = float(params.soc_max) * cap
+    house_peak = float(np.max(load))
+
+    # Variables: [c_0..c_{n-1}, d_0..d_{n-1}, S_0..S_{n-1}]
+    nc = n
+    nd = n
+    ns = n
+    nvar = nc + nd + ns
+
+    def c_i(t: int) -> int:
+        return t
+
+    def d_i(t: int) -> int:
+        return nc + t
+
+    def s_i(t: int) -> int:
+        return nc + nd + t
+
+    c_obj = np.zeros(nvar)
+    for t in range(n):
+        # price * (load + c - d) * dt + throughput_cost * (c+d) * dt
+        c_obj[c_i(t)] += float(price[t]) * dt + float(throughput_cost_per_kwh) * dt
+        c_obj[d_i(t)] += -float(price[t]) * dt + float(throughput_cost_per_kwh) * dt
+    # constant price*load*dt ignored
+
+    bounds: list[tuple[float | None, float | None]] = []
+    for t in range(n):
+        bounds.append((0.0, float(params.max_charge_kw)))
+    for t in range(n):
+        bounds.append((0.0, float(params.max_discharge_kw)))
+    for t in range(n):
+        bounds.append((s_min, s_max))
+
+    a_eq = []
+    b_eq = []
+    # SOC: S_{t+1} - S_t - eta_c*c*dt + d*dt/eta_d = 0  (wrap cyclic)
+    for t in range(n):
+        row = np.zeros(nvar)
+        t_next = (t + 1) % n
+        row[s_i(t_next)] += 1.0
+        row[s_i(t)] -= 1.0
+        row[c_i(t)] -= float(params.eta_c) * dt
+        row[d_i(t)] += dt / float(params.eta_d)
+        a_eq.append(row)
+        b_eq.append(0.0)
+
+    a_ub = []
+    b_ub = []
+    # purchased = load + c - d >= 0  =>  -c + d <= load
+    # purchased <= house_peak (optional) => c - d <= house_peak - load
+    for t in range(n):
+        row = np.zeros(nvar)
+        row[c_i(t)] = -1.0
+        row[d_i(t)] = 1.0
+        a_ub.append(row)
+        b_ub.append(float(load[t]))
+        if cap_purchased_to_house_peak:
+            row2 = np.zeros(nvar)
+            row2[c_i(t)] = 1.0
+            row2[d_i(t)] = -1.0
+            a_ub.append(row2)
+            b_ub.append(house_peak - float(load[t]))
+
+    result = linprog(
+        c_obj,
+        A_ub=np.asarray(a_ub) if a_ub else None,
+        b_ub=np.asarray(b_ub) if b_ub else None,
+        A_eq=np.asarray(a_eq),
+        b_eq=np.asarray(b_eq),
+        bounds=bounds,
+        method="highs",
+    )
+    if not result.success:
+        raise RuntimeError(f"cyclic LP failed: {result.message}")
+
+    x = result.x
+    charge = x[0:n]
+    discharge = x[n : 2 * n]
+    energy = x[2 * n : 3 * n]
+    purchased = load + charge - discharge
+    soc = energy / cap
+
+    bill = float(np.sum(price * purchased * dt))
+    throughput_kwh = float(np.sum((charge + discharge) * dt))
+    return {
+        "purchased_kw": purchased.tolist(),
+        "soc": soc.tolist(),
+        "charge_kw": charge.tolist(),
+        "discharge_kw": discharge.tolist(),
+        "final_soc": float(soc[-1]),
+        "initial_soc_opt": float(soc[0]),
+        "intervals": float(n),
+        "dt_hours": dt,
+        "mode": "cyclic_lp",
+        "bill_usd": bill,
+        "throughput_kwh": throughput_kwh,
+        "throughput_cost_per_kwh": float(throughput_cost_per_kwh),
+        "objective_usd": float(result.fun) + float(np.sum(price * load * dt)),
+        "purchased_peak_kw": float(np.max(purchased)),
+        "house_peak_kw": house_peak,
+        "solver": "scipy.linprog.highs",
+    }
+
+
+def optimality_gap(
+    *,
+    greedy_bill_usd: float,
+    lp_bill_usd: float,
+) -> dict[str, float]:
+    """Fraction of LP bill savings captured by a heuristic (1.0 = matches LP)."""
+    if lp_bill_usd <= 0 and greedy_bill_usd <= 0:
+        return {"gap_fraction": 1.0, "greedy_bill_usd": greedy_bill_usd, "lp_bill_usd": lp_bill_usd}
+    # Lower bill is better. Capture ratio relative to a no-battery reference is
+    # computed by callers; here report greedy/lp bill ratio inverted carefully.
+    if greedy_bill_usd <= 0:
+        return {"gap_fraction": 1.0, "greedy_bill_usd": greedy_bill_usd, "lp_bill_usd": lp_bill_usd}
+    # If LP bill is lower, fraction of LP value = (ref - greedy)/(ref - lp) needs ref.
+    # Without ref, report how close greedy bill is to LP bill (1 = equal, <1 if worse).
+    if lp_bill_usd <= 0:
+        return {"gap_fraction": 0.0, "greedy_bill_usd": greedy_bill_usd, "lp_bill_usd": lp_bill_usd}
+    ratio = float(lp_bill_usd / greedy_bill_usd)
+    return {
+        "bill_ratio_lp_over_greedy": ratio,
+        "greedy_bill_usd": float(greedy_bill_usd),
+        "lp_bill_usd": float(lp_bill_usd),
+        "greedy_minus_lp_usd": float(greedy_bill_usd - lp_bill_usd),
+    }

--- a/vibe_code_apps_23/src/vibe23/studio/demo_data.py
+++ b/vibe_code_apps_23/src/vibe23/studio/demo_data.py
@@ -152,6 +152,7 @@ def run_battery_on_load(
     soc_max: float = 0.95,
     initial_soc: float = 0.5,
     season: str = "summer",
+    compare_lp: bool = True,
 ) -> dict[str, Any]:
     tariff = _tariff_for_season(season)
     params = BatteryParams(
@@ -164,26 +165,54 @@ def run_battery_on_load(
         soc_max=float(soc_max),
         initial_soc=float(initial_soc),
     )
+    rates = list(tariff.energy_rates_per_kwh)
     dispatch = simulate_dispatch(
         facility_kw,
-        list(tariff.energy_rates_per_kwh),
+        rates,
         params,
         mode="price_arbitrage",
+        cap_purchased_to_house_peak=True,
     )
     purchased = list(dispatch["purchased_kw"])  # type: ignore[arg-type]
     bill = billing_cost(purchased, tariff=tariff, opening_state=BillingState())
     house_kwh = daily_kwh(facility_kw)
     purchased_kwh = daily_kwh(purchased)
-    return {
+    baseline_bill = day_bill(facility_kw, season=season)
+    out: dict[str, Any] = {
         **dispatch,
         "params": params.to_dict(),
         "billing_cost": float(bill["total_cost_usd"]),
-        "baseline_billing_cost": day_bill(facility_kw, season=season),
+        "baseline_billing_cost": baseline_bill,
         "house_kwh": house_kwh,
         "purchased_kwh": purchased_kwh,
         "energy_kwh_bill": float(bill["energy_kwh"]),
-        "rates": list(tariff.energy_rates_per_kwh),
+        "rates": rates,
+        "dispatch_kind": "greedy",
     }
+    if compare_lp:
+        from ..dispatch import cyclic_lp_dispatch, optimality_gap
+
+        lp = cyclic_lp_dispatch(facility_kw, rates, params, cap_purchased_to_house_peak=True)
+        lp_purchased = list(lp["purchased_kw"])  # type: ignore[arg-type]
+        lp_bill = float(billing_cost(lp_purchased, tariff=tariff, opening_state=BillingState())["total_cost_usd"])
+        greedy_save = baseline_bill - float(bill["total_cost_usd"])
+        lp_save = baseline_bill - lp_bill
+        capture = (greedy_save / lp_save) if lp_save > 1e-9 else 1.0
+        out["lp"] = {
+            "billing_cost": lp_bill,
+            "purchased_kwh": daily_kwh(lp_purchased),
+            "purchased_peak_kw": float(lp["purchased_peak_kw"]),
+            "bill_savings_usd": lp_save,
+            "throughput_kwh": float(lp["throughput_kwh"]),
+        }
+        out["optimality"] = {
+            **optimality_gap(greedy_bill_usd=float(bill["total_cost_usd"]), lp_bill_usd=lp_bill),
+            "greedy_savings_usd": greedy_save,
+            "lp_savings_usd": lp_save,
+            "greedy_captures_lp_savings_fraction": float(capture),
+        }
+    return out
+
 
 
 def illustrative_grid_ranking(*, season: str = "summer") -> dict[str, Any]:

--- a/vibe_code_apps_23/streamlit_app.py
+++ b/vibe_code_apps_23/streamlit_app.py
@@ -91,6 +91,7 @@ def _init_state() -> None:
         "soc_max": 0.95,
         "initial_soc": 0.50,
         "attach_battery": True,
+        "comfort_wtp": 0.10,
         "idf_text": None,
         "idf_name": MODEL_IDF.name,
         "outdoor_override": None,
@@ -659,16 +660,66 @@ def main() -> None:
             b2.metric("Save vs house-only", f"${house_bill - net_bill:.2f}")
             b3.metric("Purchased peak kW", f"{max(purchased or [0.0]):.2f}")
             b4.metric("Purchased day kWh", f"{purchased_day_kwh:.1f}", delta=f"house {house_day_kwh:.1f}")
+        opt = batt_dr.get("optimality") or batt_base.get("optimality")
+        if opt:
+            st.caption(
+                f"Greedy is a heuristic. On DR load it captures "
+                f"**{100 * float(opt.get('greedy_captures_lp_savings_fraction', 0)):.0f}%** of cyclic-LP bill savings "
+                f"(greedy save ${float(opt.get('greedy_savings_usd', 0)):.2f} vs LP "
+                f"${float(opt.get('lp_savings_usd', 0)):.2f}). Purchased peak is capped ≤ house peak."
+            )
+            lp_dr = batt_dr.get("lp") or {}
+            if lp_dr:
+                st.write(
+                    {
+                        "greedy_dr_bill": round(float(batt_dr["billing_cost"]), 3),
+                        "lp_dr_bill": round(float(lp_dr["billing_cost"]), 3),
+                        "lp_purchased_peak_kw": round(float(lp_dr["purchased_peak_kw"]), 3),
+                        "house_peak_kw": round(float(batt_dr.get("house_peak_kw") or max(event_kw)), 3),
+                    }
+                )
 
     with tab_dr:
         st.subheader(f"Stage 1 thermal — {day.get('label', season_key)}")
+        from vibe23.comfort import degree_hours_abs_delta, degree_hours_outside_band, net_welfare_usd
+        from vibe23.residential.thermostat import comfort_ok
+
         base_kwh = daily_kwh(list(day["baseline_kw"]))
         event_kwh = daily_kwh(list(day["event_kw"]))
+        base_bill = day_bill(list(day["baseline_kw"]), season=season_key)
+        event_bill = day_bill(list(day["event_kw"]), season=season_key)
+        bill_savings = base_bill - event_bill
+        dh_vs_base = degree_hours_abs_delta(list(day["event_temp_f"]), list(day["baseline_temp_f"]))
+        band = degree_hours_outside_band(list(day["event_temp_f"]))
+        wtp = st.slider(
+            "ILLUSTRATIVE comfort WTP ($/°F·h vs baseline)",
+            min_value=0.0,
+            max_value=0.50,
+            value=0.10,
+            step=0.05,
+            key="comfort_wtp",
+            help="Willingness-to-pay for thermal deviation from the paired baseline trajectory.",
+        )
+        welfare = net_welfare_usd(bill_savings_usd=bill_savings, degree_hours=dh_vs_base, wtp_usd_per_f_h=wtp)
         d1, d2, d3, d4 = st.columns(4)
         d1.metric("Baseline peak kW", f"{max(day['baseline_kw']):.2f}")
         d2.metric("Event peak kW", f"{max(day['event_kw']):.2f}")
-        d3.metric("Baseline day kWh", f"{base_kwh:.1f}")
-        d4.metric("Event day kWh", f"{event_kwh:.1f}", delta=f"{event_kwh - base_kwh:+.1f}")
+        d3.metric("Bill savings $/day", f"${bill_savings:.2f}")
+        d4.metric(
+            "Net welfare $/day",
+            f"${welfare['net_welfare_usd']:.2f}",
+            delta=f"comfort −${welfare['comfort_cost_usd']:.2f}",
+        )
+        st.caption(
+            f"Comfort OK (hard band {band['low_f']:.1f}–{band['high_f']:.1f}°F): "
+            f"**{comfort_ok(list(day['event_temp_f']))}** · "
+            f"|ΔT| vs baseline = **{dh_vs_base:.2f} °F·h** · "
+            f"band exceedance = **{band['total_degree_hours']:.2f} °F·h**. "
+            "Net welfare = bill savings − WTP×°F·h (ILLUSTRATIVE)."
+        )
+        d5, d6 = st.columns(2)
+        d5.metric("Baseline day kWh", f"{base_kwh:.1f}")
+        d6.metric("Event day kWh", f"{event_kwh:.1f}", delta=f"{event_kwh - base_kwh:+.1f}")
         base_disp = downsample_mean(list(day["baseline_kw"]), block)
         event_disp = downsample_mean(list(day["event_kw"]), block)
         base_temp = downsample_mean(list(day["baseline_temp_f"]), block)
@@ -690,7 +741,7 @@ def main() -> None:
         fig.add_trace(go.Scatter(x=hours[:end], y=base_temp[:end], name="Baseline °F", line=dict(color="#8FB8FF")), row=3, col=1)
         fig.add_trace(go.Scatter(x=hours[:end], y=event_temp[:end], name="DR °F", line=dict(color="#FF6B6B")), row=3, col=1)
         if season_key == "summer":
-            fig.add_vrect(x0=14, x1=18, fillcolor="#E8A838", opacity=0.12, line_width=0, row=1, col=1)
+            fig.add_vrect(x0=15, x1=20, fillcolor="#E8A838", opacity=0.12, line_width=0, row=1, col=1)
         else:
             fig.add_vrect(x0=6, x1=9, fillcolor="#8FB8FF", opacity=0.12, line_width=0, row=1, col=1)
         fig.add_vline(x=hours[step], line_dash="dash", line_color="#94A3B8")

--- a/vibe_code_apps_23/tests/test_battery.py
+++ b/vibe_code_apps_23/tests/test_battery.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
 from vibe23.battery import BatteryParams, simulate_dispatch
+from vibe23.comfort import degree_hours_abs_delta, net_welfare_usd
+from vibe23.dispatch import cyclic_lp_dispatch
 
 
 def test_battery_price_arbitrage_and_soc_bounds():
@@ -15,12 +19,39 @@ def test_battery_price_arbitrage_and_soc_bounds():
     out = simulate_dispatch(load, prices, params, mode="price_arbitrage")
     assert len(out["purchased_kw"]) == 288
     assert all(0.1 <= s <= 0.95 for s in out["soc"])
-    # never charge and discharge same step
     for c, d in zip(out["charge_kw"], out["discharge_kw"], strict=True):
         assert not (c > 0 and d > 0)
+    assert float(out["purchased_peak_kw"]) <= float(out["house_peak_kw"]) + 1e-9
 
 
-def test_battery_rejects_simultaneous_by_construction():
-    params = BatteryParams(capacity_kwh=5.0, max_charge_kw=2.0, max_discharge_kw=2.0)
-    out = simulate_dispatch([3.0] * 24, [0.2] * 24, params, mode="peak_shave", dt_hours=1.0)
+def test_peak_shave_recharges_on_valley():
+    params = BatteryParams(capacity_kwh=5.0, max_charge_kw=2.0, max_discharge_kw=2.0, initial_soc=0.5)
+    # Distinct peak and valley so median recharge can fire under house-peak cap.
+    load = [1.0] * 12 + [4.0] * 12
+    out = simulate_dispatch(load, [0.2] * 24, params, mode="peak_shave", dt_hours=1.0)
     assert out["intervals"] == 24.0
+    assert sum(out["charge_kw"]) > 0.0
+    assert sum(out["discharge_kw"]) > 0.0
+    assert float(out["purchased_peak_kw"]) <= float(out["house_peak_kw"]) + 1e-9
+
+
+def test_cyclic_lp_feasible_and_peak_capped():
+    params = BatteryParams(capacity_kwh=13.5, max_charge_kw=5.0, max_discharge_kw=5.0, initial_soc=0.5)
+    prices = [0.08] * 96 + [0.55] * 96 + [0.14] * 96
+    load = [1.5] * 288
+    no_batt_bill = sum(p * k * (1 / 12) for p, k in zip(prices, load, strict=True))
+    lp = cyclic_lp_dispatch(load, prices, params)
+    assert float(lp["bill_usd"]) <= no_batt_bill + 1e-6
+    assert float(lp["purchased_peak_kw"]) <= float(lp["house_peak_kw"]) + 1e-6
+    assert abs(float(lp["initial_soc_opt"]) - float(lp["soc"][0])) < 1e-9
+    # Greedy may beat LP on *day* bill by ending at high SOC (non-cyclic free lunch).
+    greedy = simulate_dispatch(load, prices, params, mode="price_arbitrage")
+    assert float(greedy["purchased_peak_kw"]) <= float(greedy["house_peak_kw"]) + 1e-9
+
+
+def test_net_welfare_can_go_negative():
+    dh = degree_hours_abs_delta([74.0] * 12, [72.0] * 12, dt_hours=1.0)
+    assert dh == pytest.approx(24.0)
+    welfare = net_welfare_usd(bill_savings_usd=0.50, degree_hours=dh, wtp_usd_per_f_h=0.10)
+    assert welfare["comfort_cost_usd"] == pytest.approx(2.4)
+    assert welfare["net_welfare_usd"] < 0


### PR DESCRIPTION
## Summary
- Cyclic LP battery dispatch (`scipy.linprog`) with SOC wrap + purchased peak ≤ house peak
- Greedy reports optimality / LP savings capture; peak_shave recharge fixed
- Studio DR tab: comfort °F·h vs baseline, WTP slider, **net welfare** beside bill savings
- `scipy>=1.11` added to package + studio requirements

## Test plan
- [x] `pytest` battery/studio/streamlit
- [x] `ruff check`
- [ ] CI `vibe23-ci` green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comfort-impact and net-welfare calculations, including adjustable willingness-to-pay.
  - Added an optimization-based battery dispatch comparison and optimality metrics.
  - Added battery peak-cap reporting and improved peak-shaving recharge behavior.
  - Enhanced the Battery Lab and demand-response views with savings, comfort, and welfare insights.
  - Added SciPy as a runtime requirement.

- **Bug Fixes**
  - Improved dispatch behavior to keep purchased power within the facility peak when enabled.

- **Tests**
  - Expanded coverage for optimized dispatch, peak caps, recharge behavior, and negative net welfare.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->