### PR TITLE
feat(vibe23): finish PhD economics plan (T3/T4 + BESS lifecycle)

### DIFF
--- a/vibe_code_apps_23/src/vibe23/economics/__init__.py
+++ b/vibe_code_apps_23/src/vibe23/economics/__init__.py
@@ -1,0 +1,34 @@
+"""DSM / BESS economics helpers (break-even, lifecycle, uncertainty, methods)."""
+
+from .breakeven import (
+    bess_usable_kwh,
+    price_discovery_summary,
+    required_incentive_per_kwh_shed,
+    required_peak_rate_for_bess_payback,
+)
+from .lifecycle import LifecycleAssumptions, lifecycle_report
+from .methods import methods_appendix_markdown
+from .uncertainty import (
+    default_day_type_weights,
+    distribution_bands,
+    tornado_one_at_a_time,
+    weighted_annual_from_days,
+)
+from .value_stack import ValueLayer, residential_day_value_stack, value_stack_total
+
+__all__ = [
+    "LifecycleAssumptions",
+    "ValueLayer",
+    "bess_usable_kwh",
+    "default_day_type_weights",
+    "distribution_bands",
+    "lifecycle_report",
+    "methods_appendix_markdown",
+    "price_discovery_summary",
+    "required_incentive_per_kwh_shed",
+    "required_peak_rate_for_bess_payback",
+    "residential_day_value_stack",
+    "tornado_one_at_a_time",
+    "value_stack_total",
+    "weighted_annual_from_days",
+]

--- a/vibe_code_apps_23/src/vibe23/economics/breakeven.py
+++ b/vibe_code_apps_23/src/vibe23/economics/breakeven.py
@@ -1,0 +1,139 @@
+"""Inverse economics — what price / incentive is required (not just savings)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def required_incentive_per_kwh_shed(
+    *,
+    target_usd_per_event: float,
+    kwh_shed: float,
+    existing_tou_savings_usd: float = 0.0,
+) -> dict[str, float]:
+    """Incentive $/kWh shed on top of existing TOU savings to hit a per-event target."""
+    if kwh_shed <= 0:
+        raise ValueError("kwh_shed must be positive")
+    gap = float(target_usd_per_event) - float(existing_tou_savings_usd)
+    needed = max(0.0, gap) / float(kwh_shed)
+    return {
+        "target_usd_per_event": float(target_usd_per_event),
+        "kwh_shed": float(kwh_shed),
+        "existing_tou_savings_usd": float(existing_tou_savings_usd),
+        "gap_usd": float(gap),
+        "required_usd_per_kwh_shed": needed,
+    }
+
+
+def required_incentive_per_kw_event(
+    *,
+    target_usd_per_event: float,
+    avg_kw_shed: float,
+    existing_tou_savings_usd: float = 0.0,
+) -> dict[str, float]:
+    if avg_kw_shed <= 0:
+        raise ValueError("avg_kw_shed must be positive")
+    gap = float(target_usd_per_event) - float(existing_tou_savings_usd)
+    needed = max(0.0, gap) / float(avg_kw_shed)
+    return {
+        "target_usd_per_event": float(target_usd_per_event),
+        "avg_kw_shed": float(avg_kw_shed),
+        "existing_tou_savings_usd": float(existing_tou_savings_usd),
+        "required_usd_per_kw_event": needed,
+    }
+
+
+def required_peak_rate_for_bess_payback(
+    *,
+    net_capex_usd: float,
+    usable_kwh_per_cycle: float,
+    round_trip_efficiency: float,
+    cycles_per_year: float,
+    payback_years: float,
+    off_peak_usd_per_kwh: float,
+) -> dict[str, float]:
+    """Retail arbitrage break-even peak rate assuming one deep cycle value per cycle day.
+
+    Net value per cycle ≈ usable_kwh * (peak - off_peak / η_rt) roughly; we solve for
+    the spread that yields ``net_capex / payback_years`` annual cash, then peak rate.
+    """
+    if usable_kwh_per_cycle <= 0 or round_trip_efficiency <= 0:
+        raise ValueError("usable energy / efficiency must be positive")
+    if cycles_per_year <= 0 or payback_years <= 0:
+        raise ValueError("cycles_per_year and payback_years must be positive")
+    annual_needed = float(net_capex_usd) / float(payback_years)
+    per_cycle_needed = annual_needed / float(cycles_per_year)
+    # Delivered kWh on discharge ≈ usable * sqrt(η) style; use round_trip on energy out.
+    # Value ≈ E_out * peak - E_in * off_peak with E_out = usable, E_in = usable / η_rt
+    # per_cycle = usable * peak - (usable / η) * off_peak
+    # peak = (per_cycle / usable) + off_peak / η
+    eta = float(round_trip_efficiency)
+    usable = float(usable_kwh_per_cycle)
+    peak = (per_cycle_needed / usable) + float(off_peak_usd_per_kwh) / eta
+    net_spread = per_cycle_needed / usable
+    return {
+        "net_capex_usd": float(net_capex_usd),
+        "payback_years": float(payback_years),
+        "cycles_per_year": float(cycles_per_year),
+        "usable_kwh_per_cycle": usable,
+        "round_trip_efficiency": eta,
+        "off_peak_usd_per_kwh": float(off_peak_usd_per_kwh),
+        "annual_cash_needed_usd": annual_needed,
+        "usd_per_cycle_needed": per_cycle_needed,
+        "required_net_spread_usd_per_kwh": net_spread,
+        "required_peak_usd_per_kwh": peak,
+        "claim": "ILLUSTRATIVE_ARBITRAGE_ONLY",
+    }
+
+
+def bess_usable_kwh(*, capacity_kwh: float, soc_min: float = 0.1, soc_max: float = 0.95) -> float:
+    return float(capacity_kwh) * (float(soc_max) - float(soc_min))
+
+
+def price_discovery_summary(
+    *,
+    kwh_shed: float,
+    event_hours: float,
+    tou_savings_usd: float,
+    capacity_kwh: float,
+    eta_rt: float,
+    net_capex_usd: float,
+    off_peak: float,
+    targets_usd: tuple[float, ...] = (2.0, 5.0, 10.0),
+    cycles_per_year: float = 250.0,
+    payback_years: float = 10.0,
+) -> dict[str, Any]:
+    avg_kw = float(kwh_shed) / max(float(event_hours), 1e-9)
+    usable = bess_usable_kwh(capacity_kwh=capacity_kwh)
+    incentives = [
+        {
+            **required_incentive_per_kwh_shed(
+                target_usd_per_event=t,
+                kwh_shed=kwh_shed,
+                existing_tou_savings_usd=tou_savings_usd,
+            ),
+            **{
+                "required_usd_per_kw_event": required_incentive_per_kw_event(
+                    target_usd_per_event=t,
+                    avg_kw_shed=avg_kw,
+                    existing_tou_savings_usd=tou_savings_usd,
+                )["required_usd_per_kw_event"]
+            },
+        }
+        for t in targets_usd
+    ]
+    peak = required_peak_rate_for_bess_payback(
+        net_capex_usd=net_capex_usd,
+        usable_kwh_per_cycle=usable,
+        round_trip_efficiency=eta_rt,
+        cycles_per_year=cycles_per_year,
+        payback_years=payback_years,
+        off_peak_usd_per_kwh=off_peak,
+    )
+    return {
+        "schema": "vibe23.price_discovery.v1",
+        "claim": "ILLUSTRATIVE",
+        "avg_kw_shed": avg_kw,
+        "incentive_table": incentives,
+        "bess_arbitrage_breakeven": peak,
+        "note": "Extreme-day TOU savings are not annual value; cycles/yr and day-type weights matter.",
+    }

--- a/vibe_code_apps_23/src/vibe23/economics/lifecycle.py
+++ b/vibe_code_apps_23/src/vibe23/economics/lifecycle.py
@@ -1,0 +1,115 @@
+"""Homeowner BESS lifecycle economics — NPV / payback / LCOS (no hardcoded ITC)."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+TaxCreditEvidence = Literal["NONE", "ILLUSTRATIVE", "VERIFIED"]
+
+
+@dataclass(frozen=True)
+class LifecycleAssumptions:
+    net_capex_usd: float
+    annual_arbitrage_usd: float
+    discount_rate: float = 0.07
+    lifetime_years: int = 10
+    warranty_years: int = 10
+    annual_om_usd: float = 0.0
+    annual_degradation_frac: float = 0.025
+    throughput_kwh_per_year: float = 0.0
+    tax_credit_frac: float = 0.0
+    tax_credit_evidence: TaxCreditEvidence = "NONE"
+    tax_credit_reference: str = ""
+
+    def __post_init__(self) -> None:
+        if self.net_capex_usd < 0:
+            raise ValueError("net_capex_usd must be non-negative")
+        if self.lifetime_years < 1 or self.warranty_years < 1:
+            raise ValueError("lifetime/warranty years must be >= 1")
+        if not 0 <= self.discount_rate < 1:
+            raise ValueError("discount_rate out of range")
+        if self.tax_credit_frac < 0 or self.tax_credit_frac > 1:
+            raise ValueError("tax_credit_frac must be in [0, 1]")
+        if self.tax_credit_frac > 0 and self.tax_credit_evidence == "NONE":
+            raise ValueError("non-zero tax credit requires ILLUSTRATIVE or VERIFIED evidence")
+        if self.tax_credit_evidence == "VERIFIED" and not self.tax_credit_reference.strip():
+            raise ValueError("VERIFIED tax credit requires tax_credit_reference (statute + period)")
+
+
+def effective_capex(assumptions: LifecycleAssumptions) -> float:
+    return float(assumptions.net_capex_usd) * (1.0 - float(assumptions.tax_credit_frac))
+
+
+def annual_cashflows(assumptions: LifecycleAssumptions) -> list[float]:
+    """Year-1..N cashflows after CapEx at t=0 (returned separately)."""
+    years = min(int(assumptions.lifetime_years), int(assumptions.warranty_years))
+    flows: list[float] = []
+    fade = 1.0
+    for _ in range(years):
+        arb = float(assumptions.annual_arbitrage_usd) * fade
+        flows.append(arb - float(assumptions.annual_om_usd))
+        fade *= 1.0 - float(assumptions.annual_degradation_frac)
+    return flows
+
+
+def npv(assumptions: LifecycleAssumptions) -> float:
+    capex = effective_capex(assumptions)
+    r = float(assumptions.discount_rate)
+    total = -capex
+    for t, cf in enumerate(annual_cashflows(assumptions), start=1):
+        total += cf / ((1.0 + r) ** t)
+    return float(total)
+
+
+def simple_payback_years(assumptions: LifecycleAssumptions) -> float | None:
+    """Undiscounted payback; None if never recovers within warranty/lifetime."""
+    capex = effective_capex(assumptions)
+    cum = 0.0
+    for t, cf in enumerate(annual_cashflows(assumptions), start=1):
+        if cf <= 0:
+            continue
+        cum += cf
+        if cum >= capex:
+            # interpolate within year
+            prev = cum - cf
+            need = capex - prev
+            return float(t - 1) + float(need / cf)
+    return None
+
+
+def lcos_usd_per_kwh(assumptions: LifecycleAssumptions) -> float | None:
+    """Levelized cost of storage $/kWh-cycled (ILLUSTRATIVE)."""
+    thr = float(assumptions.throughput_kwh_per_year)
+    years = min(int(assumptions.lifetime_years), int(assumptions.warranty_years))
+    if thr <= 0 or years < 1:
+        return None
+    r = float(assumptions.discount_rate)
+    capex = effective_capex(assumptions)
+    pv_om = sum(float(assumptions.annual_om_usd) / ((1.0 + r) ** t) for t in range(1, years + 1))
+    # Discounted throughput with degradation of capacity ≈ fade on cycles
+    fade = 1.0
+    pv_kwh = 0.0
+    for t in range(1, years + 1):
+        pv_kwh += thr * fade / ((1.0 + r) ** t)
+        fade *= 1.0 - float(assumptions.annual_degradation_frac)
+    if pv_kwh <= 0:
+        return None
+    return float((capex + pv_om) / pv_kwh)
+
+
+def lifecycle_report(assumptions: LifecycleAssumptions) -> dict[str, Any]:
+    payback = simple_payback_years(assumptions)
+    return {
+        "schema": "vibe23.bess_lifecycle.v1",
+        "claim": "ILLUSTRATIVE",
+        "assumptions": asdict(assumptions),
+        "effective_capex_usd": effective_capex(assumptions),
+        "npv_usd": npv(assumptions),
+        "simple_payback_years": payback,
+        "lcos_usd_per_kwh": lcos_usd_per_kwh(assumptions),
+        "cashflows_usd": annual_cashflows(assumptions),
+        "warning": (
+            "Retail TOU arbitrage alone often does not pay back residential BESS "
+            "inside warranty; resilience value is not in this cashflow."
+        ),
+    }

--- a/vibe_code_apps_23/src/vibe23/economics/methods.py
+++ b/vibe_code_apps_23/src/vibe23/economics/methods.py
@@ -1,0 +1,80 @@
+"""Exportable methods appendix from run provenance + studio assumptions."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+def methods_appendix_markdown(
+    *,
+    day: Mapping[str, Any] | None = None,
+    equipment: Mapping[str, Any] | None = None,
+    battery: Mapping[str, Any] | None = None,
+    economics: Mapping[str, Any] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    lines = [
+        "# Vibe 23 methods appendix",
+        "",
+        f"- Generated (UTC): `{now}`",
+        "- Model claim: `HYPOTHETICAL_GL14_TUNED_DEMO_MODEL`",
+        "- Tariff / money claim: `ILLUSTRATIVE_*` unless a layer is explicitly evidence-gated",
+        "- Do not treat demo-day dollars as calibrated GL14 savings",
+        "",
+        "## Studio day fixture",
+    ]
+    if day:
+        lines.extend(
+            [
+                f"- Label: {day.get('label', '—')}",
+                f"- Season / class: {day.get('season', '—')} / {day.get('day_class', '—')}",
+                f"- Calendar: {day.get('month', '—')}/{day.get('day', '—')}",
+                f"- Intervals: {day.get('intervals', '—')} · dt_hours={day.get('dt_hours', '—')}",
+                f"- Baseline kWh: {day.get('baseline_daily_kwh', '—')} · Event kWh: {day.get('event_daily_kwh', '—')}",
+                f"- Energy note: {day.get('energy_note', '—')}",
+            ]
+        )
+    else:
+        lines.append("- (no day payload)")
+
+    lines.extend(["", "## Equipment / internal gains provenance"])
+    if equipment:
+        for key in sorted(equipment):
+            lines.append(f"- `{key}`: {equipment[key]}")
+    else:
+        lines.append("- (none)")
+
+    lines.extend(["", "## Battery params (if used)"])
+    if battery:
+        lines.append("```json")
+        lines.append(json.dumps(dict(battery), indent=2, sort_keys=True))
+        lines.append("```")
+    else:
+        lines.append("- (none)")
+
+    lines.extend(["", "## Economics snapshot"])
+    if economics:
+        lines.append("```json")
+        lines.append(json.dumps(dict(economics), indent=2, sort_keys=True, default=str))
+        lines.append("```")
+    else:
+        lines.append("- (none)")
+
+    if extra:
+        lines.extend(["", "## Extra provenance"])
+        lines.append("```json")
+        lines.append(json.dumps(dict(extra), indent=2, sort_keys=True, default=str))
+        lines.append("```")
+
+    lines.extend(
+        [
+            "",
+            "## Reproducibility",
+            "- Prefer `idf_sha256`, `epw_sha256`, `patched_idf_sha256`, and EnergyPlus version from live runs",
+            "- Fixture demos are regenerated via `scripts/export_studio_extreme_days.py`",
+            "",
+        ]
+    )
+    return "\n".join(lines) + "\n"

--- a/vibe_code_apps_23/src/vibe23/economics/uncertainty.py
+++ b/vibe_code_apps_23/src/vibe23/economics/uncertainty.py
@@ -1,0 +1,108 @@
+"""Uncertainty helpers — tornado + weighted representative-day bands."""
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Sequence
+
+
+def weighted_annual_from_days(
+    day_values_usd: Mapping[str, float],
+    weights: Mapping[str, float],
+) -> dict[str, float]:
+    """Annualize with explicit day-type weights (must sum ~1.0 * 365 or to days/year).
+
+    ``weights[day]`` = number of days/year represented by that day type.
+    """
+    missing = set(day_values_usd) - set(weights)
+    if missing:
+        raise ValueError(f"missing weights for day types: {sorted(missing)}")
+    annual = 0.0
+    weight_sum = 0.0
+    for key, value in day_values_usd.items():
+        w = float(weights[key])
+        annual += float(value) * w
+        weight_sum += w
+    return {
+        "annual_usd": float(annual),
+        "weight_sum_days": float(weight_sum),
+        "mean_usd_per_weighted_day": float(annual / weight_sum) if weight_sum else 0.0,
+    }
+
+
+def percentile(sorted_vals: Sequence[float], p: float) -> float:
+    if not sorted_vals:
+        raise ValueError("empty sample")
+    if not 0.0 <= p <= 100.0:
+        raise ValueError("percentile must be in [0, 100]")
+    xs = list(sorted_vals)
+    if len(xs) == 1:
+        return float(xs[0])
+    k = (len(xs) - 1) * (p / 100.0)
+    f = int(k)
+    c = min(f + 1, len(xs) - 1)
+    if f == c:
+        return float(xs[f])
+    return float(xs[f] + (xs[c] - xs[f]) * (k - f))
+
+
+def distribution_bands(samples_usd: Sequence[float]) -> dict[str, float]:
+    xs = sorted(float(v) for v in samples_usd)
+    return {
+        "n": float(len(xs)),
+        "p10_usd": percentile(xs, 10),
+        "p50_usd": percentile(xs, 50),
+        "p90_usd": percentile(xs, 90),
+        "mean_usd": float(sum(xs) / len(xs)),
+        "min_usd": float(xs[0]),
+        "max_usd": float(xs[-1]),
+    }
+
+
+def tornado_one_at_a_time(
+    base_params: Mapping[str, float],
+    *,
+    evaluate: Callable[[Mapping[str, float]], float],
+    low_mult: float = 0.8,
+    high_mult: float = 1.2,
+) -> dict[str, Any]:
+    """OAT tornado: each param ±20% (or absolute if base is 0)."""
+    base_val = float(evaluate(dict(base_params)))
+    bars: list[dict[str, float | str]] = []
+    for key, base in base_params.items():
+        b = float(base)
+        low_p = dict(base_params)
+        high_p = dict(base_params)
+        if abs(b) < 1e-12:
+            low_p[key] = -0.1
+            high_p[key] = 0.1
+        else:
+            low_p[key] = b * low_mult
+            high_p[key] = b * high_mult
+        low_v = float(evaluate(low_p))
+        high_v = float(evaluate(high_p))
+        bars.append(
+            {
+                "param": key,
+                "low_usd": low_v,
+                "high_usd": high_v,
+                "swing_usd": abs(high_v - low_v),
+                "base_usd": base_val,
+            }
+        )
+    bars.sort(key=lambda row: float(row["swing_usd"]), reverse=True)
+    return {
+        "schema": "vibe23.tornado.v1",
+        "claim": "ILLUSTRATIVE_OAT",
+        "base_usd": base_val,
+        "bars": bars,
+    }
+
+
+def default_day_type_weights() -> dict[str, float]:
+    """Explicit representative-day weights (not 365× extreme day)."""
+    return {
+        "summer_hot": 30.0,
+        "summer_typical": 90.0,
+        "winter_design": 10.0,
+        "winter_typical": 80.0,
+        "shoulder": 155.0,
+    }

--- a/vibe_code_apps_23/src/vibe23/economics/value_stack.py
+++ b/vibe_code_apps_23/src/vibe23/economics/value_stack.py
@@ -1,0 +1,72 @@
+"""Toggleable value-stack waterfall for DSM / BESS dollars."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+@dataclass(frozen=True)
+class ValueLayer:
+    name: str
+    usd: float
+    enabled: bool = True
+    evidence: str = "ILLUSTRATIVE"
+    note: str = ""
+
+
+def value_stack_total(layers: Sequence[ValueLayer]) -> dict[str, Any]:
+    active = [layer for layer in layers if layer.enabled]
+    total = float(sum(layer.usd for layer in active))
+    waterfall = []
+    running = 0.0
+    for layer in active:
+        running += float(layer.usd)
+        waterfall.append(
+            {
+                "name": layer.name,
+                "usd": float(layer.usd),
+                "cumulative_usd": running,
+                "evidence": layer.evidence,
+                "note": layer.note,
+            }
+        )
+    return {
+        "schema": "vibe23.value_stack.v1",
+        "total_usd": total,
+        "layers": [
+            {
+                "name": layer.name,
+                "usd": float(layer.usd),
+                "enabled": layer.enabled,
+                "evidence": layer.evidence,
+                "note": layer.note,
+            }
+            for layer in layers
+        ],
+        "waterfall": waterfall,
+    }
+
+
+def residential_day_value_stack(
+    *,
+    tou_arbitrage_usd: float,
+    demand_charge_usd: float = 0.0,
+    dr_incentive_usd: float = 0.0,
+    capacity_usd: float = 0.0,
+    resilience_usd: float = 0.0,
+    carbon_usd: float = 0.0,
+    include_demand: bool = False,
+    include_dr_incentive: bool = False,
+    include_capacity: bool = False,
+    include_resilience: bool = False,
+    include_carbon: bool = False,
+) -> dict[str, Any]:
+    layers = (
+        ValueLayer("TOU arbitrage", tou_arbitrage_usd, True, "ILLUSTRATIVE", "Retail energy bill delta"),
+        ValueLayer("Demand charge", demand_charge_usd, include_demand, "ILLUSTRATIVE", "Often $0 residential"),
+        ValueLayer("DR incentive", dr_incentive_usd, include_dr_incentive, "ILLUSTRATIVE", "Program pay"),
+        ValueLayer("Capacity / avoided T&D", capacity_usd, include_capacity, "ILLUSTRATIVE", "Utility view"),
+        ValueLayer("Resilience", resilience_usd, include_resilience, "ILLUSTRATIVE", "Not default-on"),
+        ValueLayer("Carbon", carbon_usd, include_carbon, "ILLUSTRATIVE", "May conflict with $"),
+    )
+    return value_stack_total(layers)

--- a/vibe_code_apps_23/streamlit_app.py
+++ b/vibe_code_apps_23/streamlit_app.py
@@ -416,8 +416,8 @@ def main() -> None:
         width="stretch",
     )
 
-    tab_inputs, tab_twin, tab_model, tab_batt, tab_dr, tab_grid = st.tabs(
-        ["Inputs", "Twin replay", "IDF dashboard", "Battery lab", "DR event", "Grid search"]
+    tab_inputs, tab_twin, tab_model, tab_batt, tab_dr, tab_grid, tab_econ = st.tabs(
+        ["Inputs", "Twin replay", "IDF dashboard", "Battery lab", "DR event", "Grid search", "Economics"]
     )
 
     with tab_inputs:
@@ -794,6 +794,201 @@ def main() -> None:
                         st.json(result.get("ranking") or result)
                     except Exception as exc:  # noqa: BLE001
                         st.error(f"Live grid failed: {exc}")
+
+    with tab_econ:
+        from vibe23.economics import (
+            LifecycleAssumptions,
+            default_day_type_weights,
+            distribution_bands,
+            lifecycle_report,
+            methods_appendix_markdown,
+            price_discovery_summary,
+            residential_day_value_stack,
+            tornado_one_at_a_time,
+            weighted_annual_from_days,
+        )
+        from vibe23.residential.constants import SUMMER_TOU_PEAK_END, SUMMER_TOU_PEAK_START
+
+        st.subheader("What price / incentive is required?")
+        st.caption(
+            "ILLUSTRATIVE inverse economics on the active demo day — not a calibrated ROI tool. "
+            "Never annualize one extreme day ×365 without explicit day-type weights."
+        )
+        base_kw = list(day["baseline_kw"])
+        event_kw = list(day["event_kw"])
+        base_bill = day_bill(base_kw, season=season_key)
+        event_bill = day_bill(event_kw, season=season_key)
+        tou_save = base_bill - event_bill
+
+        def _period_kwh(kw: list[float], start: float, end: float) -> float:
+            n = len(kw)
+            total = 0.0
+            for i, v in enumerate(kw):
+                hour = (i + 1) * 24.0 / max(n, 1)
+                if start < hour <= end:
+                    total += float(v) * dt_hours
+            return total
+
+        if season_key == "summer":
+            p0, p1 = SUMMER_TOU_PEAK_START, SUMMER_TOU_PEAK_END
+        else:
+            p0, p1 = 6.0, 9.0
+        kwh_shed = max(0.0, _period_kwh(base_kw, p0, p1) - _period_kwh(event_kw, p0, p1))
+        event_hours = max(0.25, p1 - p0)
+
+        c1, c2, c3 = st.columns(3)
+        with c1:
+            target_event = st.number_input("Target $/event", min_value=0.0, value=5.0, step=1.0, key="econ_target")
+        with c2:
+            net_capex = st.number_input("BESS net CapEx $", min_value=0.0, value=9800.0, step=100.0, key="econ_capex")
+        with c3:
+            cycles_yr = st.number_input("Cycles / year", min_value=1.0, value=250.0, step=10.0, key="econ_cycles")
+        off_peak = 0.08
+        eta_rt = float(st.session_state.eta) ** 2
+        disc = price_discovery_summary(
+            kwh_shed=max(kwh_shed, 1e-6),
+            event_hours=event_hours,
+            tou_savings_usd=tou_save,
+            capacity_kwh=float(st.session_state.capacity_kwh),
+            eta_rt=eta_rt,
+            net_capex_usd=float(net_capex),
+            off_peak=off_peak,
+            targets_usd=(2.0, float(target_event), 10.0),
+            cycles_per_year=float(cycles_yr),
+            payback_years=10.0,
+        )
+        e1, e2, e3, e4 = st.columns(4)
+        e1.metric("TOU bill save $/day", f"${tou_save:.2f}")
+        e2.metric("Peak-window kWh shed", f"{kwh_shed:.2f}")
+        row = next(
+            r for r in disc["incentive_table"] if abs(float(r["target_usd_per_event"]) - float(target_event)) < 1e-9
+        )
+        e3.metric("Required $/kWh shed", f"${float(row['required_usd_per_kwh_shed']):.2f}")
+        br = disc["bess_arbitrage_breakeven"]
+        e4.metric("Peak $/kWh for 10-yr arb", f"${float(br['required_peak_usd_per_kwh']):.2f}")
+
+        include_dr = st.checkbox("Include DR incentive layer", value=True, key="econ_incl_dr")
+        include_res = st.checkbox("Include resilience layer (off by default)", value=False, key="econ_incl_res")
+        dr_pay = st.number_input("DR incentive $/event", min_value=0.0, value=float(target_event), key="econ_dr_pay")
+        res_val = st.number_input("Resilience $/day (ILLUSTRATIVE)", min_value=0.0, value=3.0, key="econ_res")
+        stack = residential_day_value_stack(
+            tou_arbitrage_usd=tou_save,
+            dr_incentive_usd=float(dr_pay),
+            include_dr_incentive=include_dr,
+            resilience_usd=float(res_val),
+            include_resilience=include_res,
+        )
+        st.write("Value stack (enabled layers only)")
+        st.dataframe(stack["waterfall"], hide_index=True, width="stretch")
+        st.metric("Stack total $/day", f"${float(stack['total_usd']):.2f}")
+
+        st.subheader("BESS lifecycle (arbitrage cashflows only)")
+        annual_arb = st.number_input(
+            "Assumed annual arbitrage $ (not day×365)",
+            min_value=0.0,
+            value=400.0,
+            step=50.0,
+            key="econ_annual_arb",
+            help="Set explicitly. Extreme demo-day ×365 is forbidden.",
+        )
+        life = lifecycle_report(
+            LifecycleAssumptions(
+                net_capex_usd=float(net_capex),
+                annual_arbitrage_usd=float(annual_arb),
+                discount_rate=0.07,
+                lifetime_years=10,
+                warranty_years=10,
+                throughput_kwh_per_year=float(st.session_state.capacity_kwh) * 0.85 * float(cycles_yr),
+                tax_credit_frac=0.0,
+                tax_credit_evidence="NONE",
+            )
+        )
+        l1, l2, l3 = st.columns(3)
+        l1.metric("NPV $", f"${float(life['npv_usd']):.0f}")
+        pb = life["simple_payback_years"]
+        l2.metric("Simple payback yr", "—" if pb is None else f"{float(pb):.1f}")
+        lcos = life["lcos_usd_per_kwh"]
+        l3.metric("LCOS $/kWh", "—" if lcos is None else f"${float(lcos):.3f}")
+        st.warning(life["warning"])
+
+        st.subheader("Uncertainty — weighted days + tornado")
+        weights = default_day_type_weights()
+        # Map active season day into hot/design; keep other types modest ILLUSTRATIVE.
+        day_vals = {
+            "summer_hot": tou_save if season_key == "summer" else 0.4,
+            "summer_typical": max(0.0, tou_save * 0.35) if season_key == "summer" else 0.2,
+            "winter_design": tou_save if season_key == "winter" else 1.0,
+            "winter_typical": 0.5,
+            "shoulder": 0.15,
+        }
+        annual = weighted_annual_from_days(day_vals, weights)
+        # Build a small sample around weighted mean for P10/P50/P90 display.
+        samples = [
+            annual["annual_usd"] * m for m in (0.4, 0.6, 0.8, 1.0, 1.1, 1.3, 1.6)
+        ]
+        bands = distribution_bands(samples)
+        u1, u2, u3, u4 = st.columns(4)
+        u1.metric("Weighted annual $", f"${annual['annual_usd']:.0f}")
+        u2.metric("P10", f"${bands['p10_usd']:.0f}")
+        u3.metric("P50", f"${bands['p50_usd']:.0f}")
+        u4.metric("P90", f"${bands['p90_usd']:.0f}")
+        st.caption(f"Day-type weights (days/yr): {weights}")
+
+        def _eval(params: dict) -> float:
+            return float(params["tou_save"]) * float(params["event_days"]) + float(params["dr_pay"]) * float(
+                params["event_days"]
+            ) * (1.0 if include_dr else 0.0) - 0.01 * float(params["capex"])
+
+        tornado = tornado_one_at_a_time(
+            {
+                "tou_save": max(tou_save, 0.01),
+                "event_days": 20.0,
+                "dr_pay": float(dr_pay),
+                "capex": float(net_capex),
+            },
+            evaluate=_eval,
+        )
+        st.dataframe(
+            [
+                {
+                    "param": b["param"],
+                    "low $": round(float(b["low_usd"]), 1),
+                    "high $": round(float(b["high_usd"]), 1),
+                    "swing $": round(float(b["swing_usd"]), 1),
+                }
+                for b in tornado["bars"]
+            ],
+            hide_index=True,
+            width="stretch",
+        )
+
+        appendix = methods_appendix_markdown(
+            day=day,
+            equipment=equipment_provenance(),
+            battery={
+                "capacity_kwh": float(st.session_state.capacity_kwh),
+                "max_power_kw": float(st.session_state.max_power_kw),
+                "eta": float(st.session_state.eta),
+            },
+            economics={
+                "tou_save_usd": tou_save,
+                "kwh_shed": kwh_shed,
+                "price_discovery": disc,
+                "value_stack_total": stack["total_usd"],
+                "lifecycle_npv": life["npv_usd"],
+                "weighted_annual_usd": annual["annual_usd"],
+                "bands": bands,
+            },
+        )
+        st.download_button(
+            "Download methods appendix (.md)",
+            data=appendix,
+            file_name="vibe23_methods_appendix.md",
+            mime="text/markdown",
+            key="econ_methods_dl",
+        )
+        with st.expander("Methods appendix preview"):
+            st.code(appendix, language="markdown")
 
     _queue_play_tick(n)
 

--- a/vibe_code_apps_23/tests/test_economics.py
+++ b/vibe_code_apps_23/tests/test_economics.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+
+from vibe23.economics import (
+    LifecycleAssumptions,
+    default_day_type_weights,
+    distribution_bands,
+    lifecycle_report,
+    methods_appendix_markdown,
+    price_discovery_summary,
+    required_incentive_per_kwh_shed,
+    residential_day_value_stack,
+    tornado_one_at_a_time,
+    weighted_annual_from_days,
+)
+from vibe23.economics.lifecycle import effective_capex
+
+
+def test_required_incentive_accounts_for_existing_tou():
+    out = required_incentive_per_kwh_shed(
+        target_usd_per_event=5.0,
+        kwh_shed=2.5,
+        existing_tou_savings_usd=0.5,
+    )
+    assert out["required_usd_per_kwh_shed"] == pytest.approx(1.8)
+
+
+def test_price_discovery_and_value_stack():
+    disc = price_discovery_summary(
+        kwh_shed=2.0,
+        event_hours=5.0,
+        tou_savings_usd=0.8,
+        capacity_kwh=13.5,
+        eta_rt=0.9025,
+        net_capex_usd=9800.0,
+        off_peak=0.08,
+    )
+    assert disc["avg_kw_shed"] == pytest.approx(0.4)
+    assert len(disc["incentive_table"]) == 3
+    assert disc["bess_arbitrage_breakeven"]["required_peak_usd_per_kwh"] > 0.08
+    stack = residential_day_value_stack(
+        tou_arbitrage_usd=1.2,
+        dr_incentive_usd=5.0,
+        include_dr_incentive=True,
+        resilience_usd=10.0,
+        include_resilience=False,
+    )
+    assert stack["total_usd"] == pytest.approx(6.2)
+
+
+def test_lifecycle_rejects_unguarded_tax_credit():
+    with pytest.raises(ValueError, match="tax credit"):
+        LifecycleAssumptions(net_capex_usd=10000, annual_arbitrage_usd=500, tax_credit_frac=0.3)
+
+
+def test_lifecycle_payback_and_npv():
+    a = LifecycleAssumptions(
+        net_capex_usd=10000.0,
+        annual_arbitrage_usd=2000.0,
+        discount_rate=0.0,
+        lifetime_years=10,
+        warranty_years=10,
+        annual_degradation_frac=0.0,
+        throughput_kwh_per_year=3000.0,
+    )
+    report = lifecycle_report(a)
+    assert effective_capex(a) == 10000.0
+    assert report["simple_payback_years"] == pytest.approx(5.0)
+    assert report["npv_usd"] == pytest.approx(10000.0)  # 10*2000 - 10000
+    assert report["lcos_usd_per_kwh"] is not None
+
+
+def test_weighted_annual_not_365x_and_tornado():
+    weights = default_day_type_weights()
+    assert abs(sum(weights.values()) - 365.0) < 1e-6
+    days = {
+        "summer_hot": 2.0,
+        "summer_typical": 0.5,
+        "winter_design": 4.0,
+        "winter_typical": 1.0,
+        "shoulder": 0.2,
+    }
+    annual = weighted_annual_from_days(days, weights)
+    naive = 2.0 * 365
+    assert annual["annual_usd"] < naive
+    bands = distribution_bands([0.2, 0.5, 1.0, 2.0, 4.0])
+    assert bands["p10_usd"] <= bands["p50_usd"] <= bands["p90_usd"]
+
+    def evaluate(params):
+        return float(params["spread"]) * float(params["cycles"]) - float(params["capex"]) * 0.01
+
+    tornado = tornado_one_at_a_time(
+        {"spread": 0.2, "cycles": 250.0, "capex": 9800.0},
+        evaluate=evaluate,
+    )
+    assert tornado["bars"][0]["swing_usd"] >= tornado["bars"][-1]["swing_usd"]
+
+
+def test_methods_appendix_contains_claims():
+    md = methods_appendix_markdown(
+        day={"label": "test", "baseline_daily_kwh": 28.0},
+        equipment={"internal_gains": "diurnal"},
+        economics={"note": "ILLUSTRATIVE"},
+    )
+    assert "HYPOTHETICAL_GL14_TUNED_DEMO_MODEL" in md
+    assert "ILLUSTRATIVE" in md
+    assert "28.0" in md


### PR DESCRIPTION
## Summary
- New `vibe23.economics`: break-even / price discovery, value stack, lifecycle NPV-payback-LCOS (no hardcoded ITC), tornado + weighted annual bands, methods appendix MD
- Studio **Economics** tab: required \$/kWh shed, peak rate for arb payback, stack waterfall, lifecycle, P10/P50/P90, tornado, download methods appendix
- Completes plan priority B+C+T4; T5 physics stays explicitly later

## Test plan
- [x] `pytest` economics + studio/streamlit/battery
- [x] `ruff check`
- [ ] CI `vibe23-ci` green on PR + develop after merge


Made with [Cursor](https://cursor.com)