### PR TITLE
docs(vibe23): clarify native EnergyPlus backend vs Cloud pip limits

### DIFF
--- a/vibe_code_apps_23/.env.example
+++ b/vibe_code_apps_23/.env.example
@@ -1,10 +1,16 @@
-# Native EnergyPlus (copy to `.env` and edit). Used by CLI + Streamlit studio.
+# Native EnergyPlus 26.1 FULL distribution (copy to `.env` and edit).
+# Used by CLI + Streamlit studio. Not a pip package — root must include Energy+.idd,
+# ExpandObjects, and bundled libs (runner uses `energyplus -x …`).
+#
 # Windows
 ENERGYPLUS_EXE=C:\EnergyPlusV26-1-0\energyplus.exe
 ENERGYPLUS_ROOT=C:\EnergyPlusV26-1-0
 ENERGYPLUS_WEATHER=C:\EnergyPlusV26-1-0\WeatherData\USA_CO_Golden-NREL.724666_TMY3.epw
 
-# Linux example
+# Linux example (official Ubuntu 24.04 x86-64 build; /opt or /usr/local)
+# ENERGYPLUS_EXE=/opt/EnergyPlus-26-1-0/energyplus
+# ENERGYPLUS_ROOT=/opt/EnergyPlus-26-1-0
+# ENERGYPLUS_WEATHER=/opt/EnergyPlus-26-1-0/WeatherData/USA_CO_Golden-NREL.724666_TMY3.epw
 # ENERGYPLUS_EXE=/usr/local/EnergyPlus-26-1-0/energyplus
 # ENERGYPLUS_ROOT=/usr/local/EnergyPlus-26-1-0
 # ENERGYPLUS_WEATHER=/usr/local/EnergyPlus-26-1-0/WeatherData/USA_CO_Golden-NREL.724666_TMY3.epw

--- a/vibe_code_apps_23/README.md
+++ b/vibe_code_apps_23/README.md
@@ -60,17 +60,27 @@ up the studio dependency set; it pulls in [`requirements-studio.txt`](requiremen
 plus an editable install of this package (the app imports `vibe23`). Run it with
 `vibe_code_apps_23` as the working directory so `-e .` resolves.
 
+**EnergyPlus is not a Python package.** Putting it in `requirements.txt` does nothing useful —
+that file only installs pip deps. Live runs need a **full native EnergyPlus 26.1 distribution**
+(executable + `Energy+.idd` + `ExpandObjects` + bundled libs/weather), because the runner invokes
+`energyplus -x -w … -d … -r in.idf`. Copying only the `energyplus` binary is insufficient.
+
 Energy is charted as **kW** and **cumulative kWh**, with full-day totals from `kWh = Σ(kW × 5/60 h)`. Twin replay can coarsen the playhead to **5 / 15 / 30 / 60 min** DSM viewing levels (native fixture stays 5-min). Studio tabs: **Inputs** → **Grid search** (13×13 center-setpoint Q-table, live EnergyPlus with fixture fallback) → **Twin replay** (baseline or promoted winner traces) → **Grid flex calculator** (baseline vs winner flex) → **Economics**. Regenerated fixtures (diurnal lights/plugs, no ALWAYS_ON phantom): Jul-15 ≈ **28 kWh**; Jan-3 winter design-cold ≈ **245 kWh**; mild Jan-15 ≈ **41 kWh** (`winter_typical_jan15_dr_day.json`). ~**3,500 ft²** / 5-ton box.
 
 Each browser gets a UUID session workspace under `{temp}/vibe23/{session_id}/` (Clear session wipes only that visitor). Isolation is not a password gate.
 
 ### Deployment note (Streamlit Community Cloud)
 
-**Live EnergyPlus on Community Cloud is not verified here, and we do not believe it is practical.** EnergyPlus is not in the Debian apt set that `packages.txt` draws from, so it cannot be requested that way; there is no sudo for a runtime install; and the Ubuntu x86_64 tarball is ~234 MB against a ~1 GB-class container. We have not attempted or measured a workaround, so treat "EnergyPlus on Cloud" as untested rather than proven impossible.
+**Live EnergyPlus on Community Cloud is not verified here, and we do not believe it is practical.** Reasons:
+
+1. **pip vs native install** — `requirements.txt` cannot provision EnergyPlus; Cloud installs OS software only via Debian apt entries in `packages.txt`, and EnergyPlus 26.1 is not an apt package there.
+2. **OS mismatch** — Community Cloud documents a Debian 11-class runtime; the official EnergyPlus 26.1 Linux build targets **Ubuntu 24.04 x86-64**. Community Cloud also does not let the app supply its own Docker image.
+3. **Size / process limits** — the official Linux tarball is ~229 MB compressed (~234 MB class); a full 13×13 search is up to **170 sequential** day sims at up to **600 s** timeout each, which will block the Streamlit web process if run in-process.
+4. Startup download/commit of the full distribution is an unverified experiment, not a dependable deployment.
 
 What *is* supported on Community Cloud is the **fixture demo**: the Studio opens, every tab renders, and the grid-search Q-table replays committed fixtures. Those fixtures are `ILLUSTRATIVE_PHYSICS_PROXY` (see below), so the demo is a UI/UX artifact, not a source of engineering results.
 
-**Recommended architecture** if you want both: keep the Streamlit frontend on Community Cloud and run EnergyPlus in a **separate worker** with the binary baked into its image (Docker on Hugging Face Spaces / Fly.io / Render, or a local machine), having the frontend read the worker's `ranking.json` / `twin_export.json`. Running frontend and simulator in one Community Cloud container is the option we do not recommend.
+**Recommended architecture** if you want both: keep the Streamlit frontend on Community Cloud (or any Python host) and run EnergyPlus in a **separate worker** whose image bakes the full 26.1 tree (Docker on Hugging Face Spaces / Fly.io / Render, Ubuntu 24.04 host, or a local machine). The worker needs writable per-job temp dirs, subprocess permission, Golden/NREL EPW (or uploaded EPW), and `ENERGYPLUS_EXE` / `ENERGYPLUS_ROOT` / `ENERGYPLUS_WEATHER`. The frontend should consume that worker's `ranking.json` / `twin_export.json` rather than launching 170 sims inside the Streamlit process.
 
 `.env` is for local native EnergyPlus on Windows, Linux, or macOS — never commit secrets.
 

--- a/vibe_code_apps_23/packages.txt
+++ b/vibe_code_apps_23/packages.txt
@@ -1,3 +1,10 @@
 # System packages for optional Linux hosts (none required for fixture demo mode).
-# Native EnergyPlus is not installable via apt on Streamlit Community Cloud —
-# run locally or bake EnergyPlus into a Docker image (HF Spaces / Fly.io / Render).
+#
+# Streamlit Community Cloud installs OS deps from this file via Debian apt only.
+# EnergyPlus 26.1 is NOT an apt package and cannot be requested here.
+# Official Linux build targets Ubuntu 24.04 x86-64 (~229 MB compressed tarball) and
+# needs the FULL distribution (energyplus + Energy+.idd + ExpandObjects + libs),
+# not a single binary — see README "Deployment note".
+#
+# For live sims: run locally or bake EnergyPlus into a separate worker image
+# (HF Spaces / Fly.io / Render / Ubuntu 24.04 host). Cloud = fixture demo only.

--- a/vibe_code_apps_23/requirements.txt
+++ b/vibe_code_apps_23/requirements.txt
@@ -2,6 +2,9 @@
 #
 # Nested -r paths are resolved relative to this file, so the pinned studio set stays in
 # one place (requirements-studio.txt) and cannot drift from this file.
+#
+# EnergyPlus is NOT installable via this file (pip only). Live sims need a full native
+# EnergyPlus 26.1 tree — see README "Deployment note" and packages.txt.
 -r requirements-studio.txt
 
 # The app imports `vibe23`, so the package itself must be installed. pip resolves this

--- a/vibe_code_apps_23/src/vibe23/cli.py
+++ b/vibe_code_apps_23/src/vibe23/cli.py
@@ -54,6 +54,9 @@ def _residential_doctor(args: argparse.Namespace) -> None:
         native.parent if native else DEFAULT_WINDOWS_ENERGYPLUS.parent
     )
     datasets = root / "DataSets"
+    expand = root / ("ExpandObjects.exe" if sys.platform.startswith("win") else "ExpandObjects")
+    idd = root / "Energy+.idd"
+    full_tree_ok = expand.is_file() and idd.is_file()
     result = {
         "schema": "vibe23.residential_doctor.v1",
         "ok": bool(cap.native_version),
@@ -67,6 +70,12 @@ def _residential_doctor(args: argparse.Namespace) -> None:
         "native_executable": cap.native_executable,
         "native_version": cap.native_version,
         "default_eplus_path": str(DEFAULT_WINDOWS_ENERGYPLUS),
+        "energyplus_root": str(root),
+        "expand_objects_path": str(expand),
+        "expand_objects_present": expand.is_file(),
+        "energyplus_idd_path": str(idd),
+        "energyplus_idd_present": idd.is_file(),
+        "full_distribution_ok": full_tree_ok,
         "datasets_path": str(datasets),
         "datasets_present": datasets.is_dir(),
         "rooftop_dataset": str(datasets / "RooftopPackagedHeatPump.idf"),
@@ -80,7 +89,11 @@ def _residential_doctor(args: argparse.Namespace) -> None:
         "claim_assumptions": CLAIM_ASSUMPTIONS,
         "claim_tariff": CLAIM_TARIFF,
         "capability": cap.to_dict(),
-        "note": "Copy .env.example to .env. Docker/WSL is optional; native EnergyPlus is used when present. Streamlit Community Cloud runs fixture-only demo mode.",
+        "note": (
+            "Copy .env.example to .env. Live runs need a FULL EnergyPlus 26.1 tree "
+            "(energyplus + Energy+.idd + ExpandObjects); pip/requirements.txt cannot install it. "
+            "Streamlit Community Cloud = fixture demo only; use a separate E+ worker for sims."
+        ),
     }
     _emit_json(result, args.out)
     if not result["ok"]:


### PR DESCRIPTION
## Summary
- Documents that EnergyPlus cannot be installed via `requirements.txt` (pip only) and that live runs need the full 26.1 tree (`Energy+.idd` + `ExpandObjects`) because the runner uses `energyplus -x`.
- Tightens Community Cloud guidance: Debian apt / OS mismatch vs Ubuntu 24.04 build, ~170 sequential sims / 600s timeouts, frontend + separate worker recommendation.
- `residential-doctor` now reports ExpandObjects / IDD presence; `.env.example` includes `/opt` Linux paths.

## Test plan
- [x] ruff + focused pytest
- [ ] vibe23-ci green; squash-merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that live simulations require the complete native EnergyPlus 26.1 distribution rather than a Python or apt package.
  - Added Ubuntu 24.04 x86-64 configuration guidance and documented supported deployment approaches.
  - Explained Community Cloud fixture-demo limitations and recommended using a separate worker for live simulations.

- **Bug Fixes**
  - Improved the residential diagnostics report with platform-aware paths and clearer checks for required EnergyPlus files and distribution completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->