### PR TITLE
feat(vibe23): Render EnergyPlus worker client for Studio

### DIFF
--- a/vibe_code_apps_23/.env.example
+++ b/vibe_code_apps_23/.env.example
@@ -19,3 +19,11 @@ ENERGYPLUS_WEATHER=C:\EnergyPlusV26-1-0\WeatherData\USA_CO_Golden-NREL.724666_TM
 # ENERGYPLUS_EXE=/Applications/EnergyPlus-26-1-0/energyplus
 # ENERGYPLUS_ROOT=/Applications/EnergyPlus-26-1-0
 # ENERGYPLUS_WEATHER=/Applications/EnergyPlus-26-1-0/WeatherData/USA_CO_Golden-NREL.724666_TMY3.epw
+
+# Optional Render EnergyPlus worker (Streamlit Cloud secrets use the same keys).
+# auto = native exe if present, else worker when URL+key set
+# local = native only · worker = always remote
+# EPLUS_BACKEND=auto
+# EPLUS_WORKER_URL=https://vibe23-energyplus-worker.onrender.com
+# EPLUS_WORKER_API_KEY=paste-same-value-as-Render-API_KEY
+# EPLUS_WORKER_FORCE=0

--- a/vibe_code_apps_23/AGENTS.md
+++ b/vibe_code_apps_23/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Vibe 23 residential heat-pump DSM
 
-**Mission:** run a transparent residential EnergyPlus DSM lab (Grid flex calculator → 13×13 thermostat center search → battery co-opt) on native Windows EnergyPlus 26.1.
+**Mission:** run a transparent residential EnergyPlus DSM lab (Grid flex calculator → 13×13 thermostat center search → battery co-opt) on native Windows EnergyPlus 26.1 **or** the Render EnergyPlus worker (`EPLUS_BACKEND=worker`).
 
 **Claim boundary:** `HYPOTHETICAL_GL14_TUNED_DEMO_MODEL`. Never fabricate Guideline 14 NMBE/CV(RMSE). Tariffs are `ILLUSTRATIVE_HIGH_VALUE_TOU_TARIFF`.
 
@@ -12,7 +12,7 @@
 5. [`../lessons/grid_search/INDEX.md`](../lessons/grid_search/INDEX.md) (preserve Day 10 BESS ideas)
 
 ## Hard rules
-- Native `C:\EnergyPlusV26-1-0\energyplus.exe` is the acceptance path; Docker/WSL/MCP are optional helpers only
+- Native `C:\EnergyPlusV26-1-0\energyplus.exe` **or** Render worker (`EPLUS_WORKER_URL` + `EPLUS_BACKEND=worker`) for live sims; Docker/WSL/MCP are optional helpers only
 - Do not resurrect LBNL B59 calibration as the active product
 - Do not duplicate grid-search engines; reuse `vibe23.grid`
 - Default thermostat is **71/73°F** (2°F deadband); search is **13×13 centers** (169) with battery-co-optimized ranking

--- a/vibe_code_apps_23/README.md
+++ b/vibe_code_apps_23/README.md
@@ -80,9 +80,17 @@ Each browser gets a UUID session workspace under `{temp}/vibe23/{session_id}/` (
 
 What *is* supported on Community Cloud is the **fixture demo**: the Studio opens, every tab renders, and the grid-search Q-table replays committed fixtures. Those fixtures are `ILLUSTRATIVE_PHYSICS_PROXY` (see below), so the demo is a UI/UX artifact, not a source of engineering results.
 
-**Recommended architecture** if you want both: keep the Streamlit frontend on Community Cloud (or any Python host) and run EnergyPlus in a **separate worker** whose image bakes the full 26.1 tree (Docker on Hugging Face Spaces / Fly.io / Render, Ubuntu 24.04 host, or a local machine). The worker needs writable per-job temp dirs, subprocess permission, Golden/NREL EPW (or uploaded EPW), and `ENERGYPLUS_EXE` / `ENERGYPLUS_ROOT` / `ENERGYPLUS_WEATHER`. The frontend should consume that worker's `ranking.json` / `twin_export.json` rather than launching 170 sims inside the Streamlit process.
+**Recommended architecture** if you want both: keep the Streamlit frontend on Community Cloud (or any Python host) and run EnergyPlus on the **Render worker** (`bbartling/vibe23-energyplus-worker`). Studio sidebar **EnergyPlus backend**: `auto` | `local` | `worker`. Live grid search calls `run_residential_day` → either native `energyplus` or `POST /v1/jobs` on the worker. Set secrets (local `.env.local` or Streamlit Cloud Secrets):
 
-`.env` is for local native EnergyPlus on Windows, Linux, or macOS — never commit secrets.
+```toml
+EPLUS_WORKER_URL = "https://vibe23-energyplus-worker.onrender.com"
+EPLUS_WORKER_API_KEY = "same-as-Render-service-API_KEY"
+EPLUS_BACKEND = "worker"
+```
+
+On Community Cloud without a native exe, choose `worker` (or `auto` once URL+key are set). Keep candidate counts low on free Render tiers; a full 169-cell campaign is a paid-instance / overnight job.
+
+`.env` / `.env.local` are for local native EnergyPlus and worker keys — never commit secrets.
 
 ### Fixture rankings are a proxy, not simulation output
 

--- a/vibe_code_apps_23/src/vibe23/energyplus_worker.py
+++ b/vibe_code_apps_23/src/vibe23/energyplus_worker.py
@@ -1,0 +1,205 @@
+"""HTTP client for the Vibe 23 EnergyPlus Render worker."""
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+class EnergyPlusWorkerError(RuntimeError):
+    """Remote EnergyPlus worker failed or returned an unexpected response."""
+
+
+def worker_configured() -> bool:
+    return bool(os.environ.get("EPLUS_WORKER_URL", "").strip()) and bool(
+        os.environ.get("EPLUS_WORKER_API_KEY", "").strip()
+    )
+
+
+def worker_base_url() -> str:
+    return os.environ.get("EPLUS_WORKER_URL", "").strip().rstrip("/")
+
+
+def worker_api_key() -> str:
+    return os.environ.get("EPLUS_WORKER_API_KEY", "").strip()
+
+
+def prefer_worker_backend() -> bool:
+    """Decide whether run_residential_day should use the remote worker."""
+    backend = os.environ.get("EPLUS_BACKEND", "auto").strip().lower() or "auto"
+    if backend in {"worker", "remote", "render", "cloud"}:
+        return worker_configured()
+    if backend in {"local", "native"}:
+        return False
+    # auto / force: remote when configured and either forced or no native exe
+    if os.environ.get("EPLUS_WORKER_FORCE", "").strip().lower() in {"1", "true", "yes"}:
+        return worker_configured()
+    from .energyplus import resolve_native_energyplus
+
+    if resolve_native_energyplus() is not None:
+        return False
+    return worker_configured()
+
+
+def _request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    data: bytes | None = None,
+    timeout: float = 120.0,
+) -> tuple[int, bytes]:
+    req = urllib.request.Request(url, data=data, headers=headers or {}, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return int(resp.status), resp.read()
+    except urllib.error.HTTPError as exc:
+        body = exc.read()
+        raise EnergyPlusWorkerError(f"{method} {url} -> HTTP {exc.code}: {body[:500]!r}") from exc
+
+
+def healthz(*, timeout: float = 60.0) -> dict[str, Any]:
+    _, body = _request("GET", f"{worker_base_url()}/healthz", timeout=timeout)
+    return json.loads(body)
+
+
+def _multipart(fields: dict[str, str], files: dict[str, tuple[str, bytes]]) -> tuple[bytes, str]:
+    boundary = "----vibe23WorkerBoundary7a3f"
+    chunks: list[bytes] = []
+    for name, value in fields.items():
+        chunks.append(f"--{boundary}\r\n".encode())
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode())
+        chunks.append(value.encode() + b"\r\n")
+    for name, (filename, content) in files.items():
+        chunks.append(f"--{boundary}\r\n".encode())
+        chunks.append(
+            (
+                f'Content-Disposition: form-data; name="{name}"; '
+                f'filename="{filename}"\r\n'
+            ).encode()
+        )
+        chunks.append(b"Content-Type: application/octet-stream\r\n\r\n")
+        chunks.append(content)
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode())
+    return b"".join(chunks), f"multipart/form-data; boundary={boundary}"
+
+
+def submit_job(
+    *,
+    idf_path: Path,
+    epw_path: Path,
+    expand_objects: bool = True,
+) -> dict[str, Any]:
+    if not worker_configured():
+        raise EnergyPlusWorkerError("EPLUS_WORKER_URL / EPLUS_WORKER_API_KEY not configured")
+    body, content_type = _multipart(
+        {"expand_objects": "true" if expand_objects else "false"},
+        {
+            "idf": (idf_path.name, idf_path.read_bytes()),
+            "epw": (epw_path.name, epw_path.read_bytes()),
+        },
+    )
+    headers = {
+        "Authorization": f"Bearer {worker_api_key()}",
+        "Content-Type": content_type,
+    }
+    _, raw = _request("POST", f"{worker_base_url()}/v1/jobs", headers=headers, data=body, timeout=180.0)
+    return json.loads(raw)
+
+
+def get_job(job_id: str) -> dict[str, Any]:
+    headers = {"Authorization": f"Bearer {worker_api_key()}"}
+    _, raw = _request("GET", f"{worker_base_url()}/v1/jobs/{job_id}", headers=headers, timeout=60.0)
+    return json.loads(raw)
+
+
+def download_results_zip(job_id: str) -> bytes:
+    headers = {"Authorization": f"Bearer {worker_api_key()}"}
+    _, raw = _request(
+        "GET",
+        f"{worker_base_url()}/v1/jobs/{job_id}/results",
+        headers=headers,
+        timeout=180.0,
+    )
+    return raw
+
+
+def wait_for_job(
+    job_id: str,
+    *,
+    poll_seconds: float = 5.0,
+    timeout_seconds: float = 960.0,
+) -> dict[str, Any]:
+    deadline = time.time() + timeout_seconds
+    payload: dict[str, Any] = {}
+    while time.time() < deadline:
+        payload = get_job(job_id)
+        if payload.get("status") in {"succeeded", "failed"}:
+            return payload
+        time.sleep(poll_seconds)
+    raise EnergyPlusWorkerError(f"timed out waiting for job {job_id}")
+
+
+def extract_results_zip(zip_bytes: bytes, output_dir: Path) -> None:
+    """Unpack worker results.zip into output_dir.
+
+    Render worker archives use ``output/`` as the zip root (``make_archive(..., base_dir=\"output\")``).
+    Flatten that prefix so callers find ``eplusout.csv`` directly under ``output_dir``.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        zf.extractall(output_dir)
+    nested = output_dir / "output"
+    if nested.is_dir():
+        for child in nested.iterdir():
+            target = output_dir / child.name
+            if target.exists():
+                if target.is_dir():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink()
+            shutil.move(str(child), str(target))
+        nested.rmdir()
+
+
+def run_day_via_worker(
+    *,
+    idf_path: Path,
+    epw_path: Path,
+    output_dir: Path,
+    expand_objects: bool = True,
+    timeout_seconds: float = 960.0,
+) -> dict[str, Any]:
+    """Submit → poll → download → extract. Returns job metadata."""
+    started = time.perf_counter()
+    created = submit_job(idf_path=idf_path, epw_path=epw_path, expand_objects=expand_objects)
+    job_id = str(created["job_id"])
+    meta = wait_for_job(job_id, timeout_seconds=timeout_seconds)
+    zip_bytes = download_results_zip(job_id)
+    extract_results_zip(zip_bytes, output_dir)
+    meta = dict(meta)
+    meta["worker_job_id"] = job_id
+    meta["worker_wall_seconds"] = round(time.perf_counter() - started, 3)
+    (output_dir / "worker_job.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    return meta
+
+
+__all__ = [
+    "EnergyPlusWorkerError",
+    "extract_results_zip",
+    "get_job",
+    "healthz",
+    "prefer_worker_backend",
+    "run_day_via_worker",
+    "submit_job",
+    "wait_for_job",
+    "worker_configured",
+]

--- a/vibe_code_apps_23/src/vibe23/envfile.py
+++ b/vibe_code_apps_23/src/vibe23/envfile.py
@@ -11,16 +11,22 @@ _ENV_KEYS = (
     "ENERGYPLUS_ROOT",
     "ENERGYPLUS_WEATHER",
     "ENERGYPLUS_WEATHER_DIR",
+    "EPLUS_WORKER_URL",
+    "EPLUS_WORKER_API_KEY",
+    "EPLUS_BACKEND",
+    "EPLUS_WORKER_FORCE",
 )
 
 
 def env_file_candidates() -> tuple[Path, ...]:
     cwd = Path.cwd()
+    home_worker = Path.home() / "Documents" / "vibe23-energyplus-worker" / ".env.render.local"
     return (
         cwd / ".env",
         cwd / ".env.local",
         PACKAGE_ROOT / ".env",
         PACKAGE_ROOT / ".env.local",
+        home_worker,
     )
 
 
@@ -44,7 +50,11 @@ def parse_env_file(path: Path) -> dict[str, str]:
 
 
 def load_energyplus_env(*, override: bool = False) -> dict[str, str]:
-    """Populate os.environ from the first existing .env (does not override by default)."""
+    """Populate os.environ from .env candidates (does not override by default).
+
+    Scans all candidates so ENERGYPLUS_* and EPLUS_WORKER_* can come from
+    different files (e.g. package ``.env`` + worker ``.env.render.local``).
+    """
     loaded: dict[str, str] = {}
     for path in env_file_candidates():
         parsed = parse_env_file(path)
@@ -56,7 +66,6 @@ def load_energyplus_env(*, override: bool = False) -> dict[str, str]:
             if override or not os.environ.get(key):
                 os.environ[key] = value
             loaded[key] = os.environ.get(key, value)
-        break
     for key in _ENV_KEYS:
         if os.environ.get(key):
             loaded[key] = os.environ[key]

--- a/vibe_code_apps_23/src/vibe23/residential/runner.py
+++ b/vibe_code_apps_23/src/vibe23/residential/runner.py
@@ -112,11 +112,21 @@ def run_residential_day(
     cool_f: Sequence[float] | None = None,
     timeout_seconds: int = 600,
 ) -> dict[str, Any]:
-    """Run one weather-file day and return metrics with provenance hashes."""
+    """Run one weather-file day and return metrics with provenance hashes.
 
+    When ``EPLUS_BACKEND=worker`` (or auto + ``EPLUS_WORKER_FORCE``) and worker
+    URL/API key are configured, the day is executed on the remote Render worker.
+    Otherwise a native EnergyPlus executable is required.
+    """
+    from ..energyplus_worker import prefer_worker_backend, run_day_via_worker
+
+    use_worker = prefer_worker_backend()
     exe = resolve_native_energyplus(eplus_path)
-    if exe is None:
-        raise RuntimeError("native EnergyPlus executable not found")
+    if not use_worker and exe is None:
+        raise RuntimeError(
+            "native EnergyPlus executable not found "
+            "(set ENERGYPLUS_EXE, or configure EPLUS_WORKER_URL + EPLUS_BACKEND=worker)"
+        )
     epw_path = find_denver_epw(epw)
     if epw_path is None:
         raise FileNotFoundError("Denver/Golden EPW not found")
@@ -144,29 +154,55 @@ def run_residential_day(
     staged_idf = out / "in.idf"
     staged_idf.write_text(patched, encoding="utf-8")
 
-    cmd = [str(exe), "-x", "-w", str(epw_path), "-d", str(out), "-r", str(staged_idf)]
-    started = time.perf_counter()
-    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_seconds, check=False)
-    wall_seconds = time.perf_counter() - started
-    (out / "console.log").write_text((proc.stdout or "") + "\n" + (proc.stderr or ""), encoding="utf-8")
-
     version = None
-    ver = subprocess.run([str(exe), "--version"], capture_output=True, text=True, check=False)
-    if ver.returncode == 0:
-        version = (ver.stdout or ver.stderr or "").strip() or None
+    worker_meta: dict[str, Any] = {}
+    if use_worker:
+        started = time.perf_counter()
+        worker_meta = run_day_via_worker(
+            idf_path=staged_idf,
+            epw_path=Path(epw_path),
+            output_dir=out,
+            expand_objects=True,
+            timeout_seconds=max(float(timeout_seconds), 960.0),
+        )
+        wall_seconds = time.perf_counter() - started
+        # Re-write staged IDF if extract overwrote the folder oddly; ensure in.idf exists.
+        if not staged_idf.is_file():
+            staged_idf.write_text(patched, encoding="utf-8")
+        proc_rc = int(worker_meta.get("return_code") if worker_meta.get("return_code") is not None else (0 if worker_meta.get("status") == "succeeded" else 1))
+        version = "26.1.0-worker"
+        inspection = {
+            "fatal_count": int(worker_meta.get("fatal_count") or 0),
+            "severe_count": int(worker_meta.get("severe_count") or 0),
+            "warning_count": int(worker_meta.get("warning_count") or 0),
+            "process_returncode": proc_rc,
+            "backend": "worker",
+            "worker_job_id": worker_meta.get("worker_job_id") or worker_meta.get("job_id"),
+        }
+    else:
+        assert exe is not None
+        cmd = [str(exe), "-x", "-w", str(epw_path), "-d", str(out), "-r", str(staged_idf)]
+        started = time.perf_counter()
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_seconds, check=False)
+        wall_seconds = time.perf_counter() - started
+        (out / "console.log").write_text((proc.stdout or "") + "\n" + (proc.stderr or ""), encoding="utf-8")
+        ver = subprocess.run([str(exe), "--version"], capture_output=True, text=True, check=False)
+        if ver.returncode == 0:
+            version = (ver.stdout or ver.stderr or "").strip() or None
+        inspection = inspect_energyplus_run(
+            out,
+            idf=staged_idf,
+            epw=epw_path,
+            energyplus_version=version,
+            process_returncode=proc.returncode,
+            require_zero_warnings=False,
+        )
+        proc_rc = proc.returncode
 
-    inspection = inspect_energyplus_run(
-        out,
-        idf=staged_idf,
-        epw=epw_path,
-        energyplus_version=version,
-        process_returncode=proc.returncode,
-        require_zero_warnings=False,
-    )
     fatal = int(inspection.get("fatal_count") or 0)
     severe = int(inspection.get("severe_count") or 0)
     csv_ok = bool((out / "eplusout.csv").is_file())
-    soft_ok = proc.returncode == 0 and fatal == 0 and csv_ok
+    soft_ok = proc_rc == 0 and fatal == 0 and csv_ok
 
     facility_kw: list[float] = []
     zone_temp_f: list[float] = []
@@ -183,7 +219,7 @@ def run_residential_day(
         "schema": "vibe23.residential_day_metrics.v1",
         "ok": soft_ok and severe == 0,
         "soft_ok": soft_ok,
-        "process_returncode": proc.returncode,
+        "process_returncode": proc_rc,
         "fatal_count": fatal,
         "severe_count": severe,
         "warning_count": int(inspection.get("warning_count") or 0),
@@ -204,4 +240,6 @@ def run_residential_day(
         "equipment": equipment_provenance(),
         "claim_model": "HYPOTHETICAL_GL14_TUNED_DEMO_MODEL",
         "inspection": inspection,
+        "backend": "worker" if use_worker else "local",
+        "worker_job_id": worker_meta.get("worker_job_id") or worker_meta.get("job_id"),
     }

--- a/vibe_code_apps_23/streamlit_app.py
+++ b/vibe_code_apps_23/streamlit_app.py
@@ -106,6 +106,61 @@ PROXY_WARNING = "SYNTHETIC / ILLUSTRATIVE_PHYSICS_PROXY — not EnergyPlus simul
 
 load_energyplus_env()
 
+
+def _apply_cloud_secrets() -> None:
+    """Pull Streamlit Cloud secrets into os.environ when present (no-op locally)."""
+    try:
+        secrets = st.secrets  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001
+        return
+    for key in (
+        "EPLUS_WORKER_URL",
+        "EPLUS_WORKER_API_KEY",
+        "EPLUS_BACKEND",
+        "ENERGYPLUS_EXE",
+        "ENERGYPLUS_ROOT",
+        "ENERGYPLUS_WEATHER",
+    ):
+        try:
+            value = secrets.get(key)  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001
+            value = None
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text and not os.environ.get(key):
+            os.environ[key] = text
+
+
+def _sync_eplus_backend_env() -> str:
+    """Mirror sidebar backend choice into os.environ (do not mutate widget state)."""
+    backend = str(st.session_state.get("eplus_backend") or os.environ.get("EPLUS_BACKEND") or "auto").strip().lower()
+    if backend not in {"auto", "local", "worker"}:
+        backend = "auto"
+    os.environ["EPLUS_BACKEND"] = backend
+    return backend
+
+
+def _live_sim_ready() -> tuple[bool, str]:
+    """Return (ready, human label) for live EnergyPlus search buttons."""
+    from vibe23.energyplus_worker import worker_configured
+
+    backend = _sync_eplus_backend_env()
+    local = resolve_native_energyplus() is not None
+    remote = worker_configured()
+    if backend == "worker":
+        return remote, "Render EnergyPlus worker" if remote else "worker URL/API key missing"
+    if backend == "local":
+        return local, "native EnergyPlus" if local else "ENERGYPLUS_EXE not found"
+    if local:
+        return True, "native EnergyPlus (auto)"
+    if remote:
+        return True, "Render EnergyPlus worker (auto)"
+    return False, "no native EnergyPlus and no worker configured"
+
+
+_apply_cloud_secrets()
+
 st.set_page_config(
     page_title="Vibe 23 Residential DSM Studio",
     layout="wide",
@@ -265,6 +320,7 @@ def _init_state() -> None:
         "grid_max_candidates": 2,
         "comfort_low_f": MAX_HEAT_F,
         "comfort_high_f": MAX_COOL_F,
+        "eplus_backend": (os.environ.get("EPLUS_BACKEND") or "auto").strip().lower() or "auto",
         "epw_upload_name": None,
         "tariff_upload_name": None,
     }
@@ -665,21 +721,25 @@ def _render_grid_board(session_id: str, season_key: str, eplus) -> None:
             for row in board["rows"]
         ]
     )
+    live_ready, live_label = _live_sim_ready()
     st.markdown("**Legacy live run (optional)**")
     st.caption(
-        "Requires ENERGYPLUS_EXE on this machine · "
+        f"Backend: {live_label} · "
         f"max candidates {int(st.session_state.grid_max_candidates)} · comfort band "
         f"{float(st.session_state.comfort_low_f):.1f}–{float(st.session_state.comfort_high_f):.1f}°F."
     )
     if st.button("Run thermostat grid for selected season", key="legacy_run_grid"):
-        if eplus is None:
-            st.error("No native EnergyPlus found. Set ENERGYPLUS_EXE in .env.")
+        if not live_ready:
+            st.error(
+                "No live EnergyPlus backend. Set ENERGYPLUS_EXE for local, or "
+                "EPLUS_WORKER_URL + EPLUS_WORKER_API_KEY (+ EPLUS_BACKEND=worker) for Render."
+            )
         else:
             try:
                 from vibe23.residential.campaign import run_thermostat_grid
 
                 out = exports_dir(session_id) / "studio_grid" / season_key
-                with st.spinner("Running EnergyPlus candidates…"):
+                with st.spinner(f"Running EnergyPlus candidates via {live_label}…"):
                     result = run_thermostat_grid(
                         season=season_key,
                         output_root=out,
@@ -720,12 +780,13 @@ def main() -> None:
 
     eplus = resolve_native_energyplus()
     epw = find_denver_epw()
+    live_ready, live_label = _live_sim_ready()
 
     st.title("Vibe 23 — Residential DSM Studio")
     st.caption(
         "Illustrative TOU · HYPOTHETICAL_GL14_TUNED_DEMO_MODEL · Golden/NREL EPW · Carrier 50EZ060 · "
         f"~{DEMO_FLOOR_FT2:,.0f} ft² · {sys.platform} · "
-        f"{'EnergyPlus ready' if eplus else 'fixture demo mode (no EnergyPlus on this machine)'}."
+        f"{'EnergyPlus ready' if live_ready else 'fixture demo mode'} · backend={live_label}."
     )
 
     with st.sidebar:
@@ -741,6 +802,22 @@ def main() -> None:
             help="Coarsen twin replay for DSM viewing. Native fixture stays 5-min / 288.",
         )
         st.caption(f"Session `{session_id[:8]}…` · per-browser workspace")
+        st.divider()
+        with st.expander("EnergyPlus backend", expanded=True):
+            st.radio(
+                "Live simulation backend",
+                ["auto", "local", "worker"],
+                key="eplus_backend",
+                help=(
+                    "auto = native EnergyPlus if installed, else Render worker. "
+                    "worker = always use EPLUS_WORKER_URL (Streamlit Cloud secrets / .env). "
+                    "local = native ENERGYPLUS_EXE only."
+                ),
+            )
+            live_ready, live_label = _live_sim_ready()
+            st.caption(f"Active: **{live_label}**")
+            if os.environ.get("EPLUS_WORKER_URL"):
+                st.caption(f"Worker URL configured · API key {'set' if os.environ.get('EPLUS_WORKER_API_KEY') else 'MISSING'}")
         st.divider()
         st.header("Demo day")
         st.radio(
@@ -1333,13 +1410,14 @@ def main() -> None:
             else:
                 st.success("Live EnergyPlus ranking from this session's search.")
 
-        if eplus is not None:
+        live_ready, live_label = _live_sim_ready()
+        if live_ready:
             if st.button("Run live EnergyPlus search", type="primary", key="grid_run_live"):
                 try:
                     from vibe23.residential.campaign import run_thermostat_grid
 
                     out = exports_dir(session_id) / "studio_grid" / season_key
-                    with st.spinner("Running EnergyPlus candidates…"):
+                    with st.spinner(f"Running EnergyPlus candidates via {live_label}…"):
                         result = run_thermostat_grid(
                             season=season_key,
                             output_root=out,
@@ -1361,18 +1439,19 @@ def main() -> None:
                         st.session_state.promoted_has_trace = bool(
                             ((result.get("twin_export") or {}).get("winner") or {}).get("facility_kw")
                         )
-                    st.success(f"Live search finished · {out}")
+                    st.success(f"Live search finished via {live_label} · {out}")
                     st.rerun()
                 except Exception as exc:  # noqa: BLE001
                     st.error(f"Live grid failed: {exc}")
             st.caption(
-                f"Live path writes `ranking.json` + `twin_export.json` under the session workspace · "
-                f"max candidates {int(st.session_state.grid_max_candidates)} of 169."
+                f"Live path ({live_label}) writes `ranking.json` + `twin_export.json` under the session "
+                f"workspace · max candidates {int(st.session_state.grid_max_candidates)} of 169."
             )
         else:
             st.caption(
-                "No native EnergyPlus on this machine — **Run search** below replays the committed fixture "
-                "ranking (same schema, pre-computed scores). Set `ENERGYPLUS_EXE` in `.env` for live runs."
+                "No live EnergyPlus backend — **Run search** below replays the committed fixture "
+                "ranking. Set `ENERGYPLUS_EXE` for local, or worker URL/API key + `EPLUS_BACKEND=worker` "
+                "for Render (Streamlit Cloud: paste into Secrets)."
             )
 
         evaluated = int(st.session_state.get("cand_step", 0))

--- a/vibe_code_apps_23/tests/test_energyplus_worker.py
+++ b/vibe_code_apps_23/tests/test_energyplus_worker.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import io
-import json
 import zipfile
 from pathlib import Path
 

--- a/vibe_code_apps_23/tests/test_energyplus_worker.py
+++ b/vibe_code_apps_23/tests/test_energyplus_worker.py
@@ -1,0 +1,60 @@
+"""Unit tests for the Render EnergyPlus worker HTTP client (mocked)."""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+from vibe23.energyplus_worker import (
+    extract_results_zip,
+    prefer_worker_backend,
+    worker_configured,
+)
+
+
+def test_worker_configured_requires_url_and_key(monkeypatch):
+    monkeypatch.delenv("EPLUS_WORKER_URL", raising=False)
+    monkeypatch.delenv("EPLUS_WORKER_API_KEY", raising=False)
+    assert worker_configured() is False
+    monkeypatch.setenv("EPLUS_WORKER_URL", "https://example.test")
+    assert worker_configured() is False
+    monkeypatch.setenv("EPLUS_WORKER_API_KEY", "secret")
+    assert worker_configured() is True
+
+
+def test_prefer_worker_backend_modes(monkeypatch):
+    monkeypatch.setenv("EPLUS_WORKER_URL", "https://example.test")
+    monkeypatch.setenv("EPLUS_WORKER_API_KEY", "secret")
+    monkeypatch.delenv("EPLUS_WORKER_FORCE", raising=False)
+
+    monkeypatch.setenv("EPLUS_BACKEND", "worker")
+    assert prefer_worker_backend() is True
+
+    monkeypatch.setenv("EPLUS_BACKEND", "local")
+    assert prefer_worker_backend() is False
+
+    monkeypatch.setenv("EPLUS_BACKEND", "auto")
+    monkeypatch.setenv("EPLUS_WORKER_FORCE", "1")
+    assert prefer_worker_backend() is True
+
+
+def test_extract_results_zip_flattens_output_prefix(tmp_path: Path):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("output/eplusout.csv", "Date/Time,x\n")
+        zf.writestr("output/eplusout.err", "ok\n")
+    dest = tmp_path / "run"
+    extract_results_zip(buf.getvalue(), dest)
+    assert (dest / "eplusout.csv").is_file()
+    assert (dest / "eplusout.err").is_file()
+    assert not (dest / "output").exists()
+
+
+def test_extract_results_zip_accepts_flat_archive(tmp_path: Path):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("eplusout.csv", "Date/Time,x\n")
+    dest = tmp_path / "run"
+    extract_results_zip(buf.getvalue(), dest)
+    assert (dest / "eplusout.csv").read_text(encoding="utf-8").startswith("Date/Time")


### PR DESCRIPTION
## Summary
- Add `vibe23.energyplus_worker` client (submit/poll/download/extract) and route `run_residential_day` through it when `EPLUS_BACKEND=worker` (or auto with no native exe).
- Studio sidebar: `auto` / `local` / `worker` backend switch; Streamlit secrets + `.env.local` for URL/API key.
- Docs/tests updated; client flattens nested worker ZIP layouts.

## Local validation
- Residential Jul-15 day via Render: `ok=true`, 288 intervals, ~27 kWh.
- 1-candidate summer grid via Render wrote `ranking.json`.
- Full `pytest` green locally.
- Worker repo: flat ZIP root fix pushed; CI green.

## Test plan
- [x] Unit tests for worker client + Streamlit AppTest
- [x] Live smoke against https://vibe23-energyplus-worker.onrender.com
- [ ] vibe23-ci on this PR
- [ ] Streamlit Cloud secrets paste (next: showcase deploy)