### PR TITLE
feat(vibe23): wake sleeping Render EnergyPlus worker

### DIFF
--- a/vibe_code_apps_23/README.md
+++ b/vibe_code_apps_23/README.md
@@ -90,6 +90,8 @@ EPLUS_BACKEND = "worker"
 
 On Community Cloud without a native exe, choose `worker` (or `auto` once URL+key are set). Keep candidate counts low on free Render tiers; a full 169-cell campaign is a paid-instance / overnight job.
 
+**Render free-tier sleep:** idle workers stop. Studio pings `GET /healthz` (sidebar **Wake / check Render worker**, and automatically before each live job) with retries so a cold start can take 30–90s instead of failing the first submit. Paid always-on instances skip this delay.
+
 `.env` / `.env.local` are for local native EnergyPlus and worker keys — never commit secrets.
 
 ### Fixture rankings are a proxy, not simulation output

--- a/vibe_code_apps_23/scripts/run_studio.ps1
+++ b/vibe_code_apps_23/scripts/run_studio.ps1
@@ -28,4 +28,4 @@ Get-NetTCPConnection -LocalPort 8501 -ErrorAction SilentlyContinue |
 Start-Sleep -Seconds 1
 
 $env:PYTHONPATH = "src"
-& $Py -m streamlit run streamlit_app.py --server.headless true --browser.gatherUsageStats false
+& $Py -m streamlit run streamlit_app.py --server.headless true --server.address 127.0.0.1 --server.port 8501 --browser.gatherUsageStats false

--- a/vibe_code_apps_23/src/vibe23/energyplus_worker.py
+++ b/vibe_code_apps_23/src/vibe23/energyplus_worker.py
@@ -63,11 +63,58 @@ def _request(
     except urllib.error.HTTPError as exc:
         body = exc.read()
         raise EnergyPlusWorkerError(f"{method} {url} -> HTTP {exc.code}: {body[:500]!r}") from exc
+    except urllib.error.URLError as exc:
+        raise EnergyPlusWorkerError(f"{method} {url} -> network error: {exc.reason}") from exc
+    except TimeoutError as exc:
+        raise EnergyPlusWorkerError(f"{method} {url} -> timed out after {timeout}s") from exc
 
 
 def healthz(*, timeout: float = 60.0) -> dict[str, Any]:
     _, body = _request("GET", f"{worker_base_url()}/healthz", timeout=timeout)
     return json.loads(body)
+
+
+def ensure_worker_awake(
+    *,
+    attempts: int = 4,
+    per_try_timeout: float = 90.0,
+    pause_seconds: float = 3.0,
+) -> dict[str, Any]:
+    """Ping ``/healthz`` until the Render free-tier worker answers (or fail).
+
+    Sleeping free instances often need 30–90s on the first request. A successful
+    health check both detects sleep and wakes the service before job submit.
+    """
+    if not worker_configured():
+        raise EnergyPlusWorkerError("EPLUS_WORKER_URL / EPLUS_WORKER_API_KEY not configured")
+    started = time.perf_counter()
+    last_error: Exception | None = None
+    for attempt in range(1, max(1, attempts) + 1):
+        try_started = time.perf_counter()
+        try:
+            payload = healthz(timeout=per_try_timeout)
+            wall = round(time.perf_counter() - started, 3)
+            try_wall = round(time.perf_counter() - try_started, 3)
+            # Heuristic: first response that took a long time was a cold start.
+            woke_from_sleep = attempt > 1 or try_wall >= 8.0
+            return {
+                "ok": bool(payload.get("ok")),
+                "awake": True,
+                "woke_from_sleep": woke_from_sleep,
+                "attempt": attempt,
+                "wall_seconds": wall,
+                "try_seconds": try_wall,
+                "health": payload,
+            }
+        except (EnergyPlusWorkerError, json.JSONDecodeError, OSError) as exc:
+            last_error = exc
+            if attempt < attempts:
+                time.sleep(pause_seconds)
+    wall = round(time.perf_counter() - started, 3)
+    raise EnergyPlusWorkerError(
+        f"Render worker did not wake after {attempts} health checks "
+        f"({wall}s). Last error: {last_error}"
+    )
 
 
 def _multipart(fields: dict[str, str], files: dict[str, tuple[str, bytes]]) -> tuple[bytes, str]:
@@ -180,6 +227,7 @@ def run_day_via_worker(
 ) -> dict[str, Any]:
     """Submit → poll → download → extract. Returns job metadata."""
     started = time.perf_counter()
+    wake = ensure_worker_awake()
     created = submit_job(idf_path=idf_path, epw_path=epw_path, expand_objects=expand_objects)
     job_id = str(created["job_id"])
     meta = wait_for_job(job_id, timeout_seconds=timeout_seconds)
@@ -188,12 +236,14 @@ def run_day_via_worker(
     meta = dict(meta)
     meta["worker_job_id"] = job_id
     meta["worker_wall_seconds"] = round(time.perf_counter() - started, 3)
+    meta["worker_wake"] = wake
     (output_dir / "worker_job.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
     return meta
 
 
 __all__ = [
     "EnergyPlusWorkerError",
+    "ensure_worker_awake",
     "extract_results_zip",
     "get_job",
     "healthz",

--- a/vibe_code_apps_23/streamlit_app.py
+++ b/vibe_code_apps_23/streamlit_app.py
@@ -817,7 +817,36 @@ def main() -> None:
             live_ready, live_label = _live_sim_ready()
             st.caption(f"Active: **{live_label}**")
             if os.environ.get("EPLUS_WORKER_URL"):
-                st.caption(f"Worker URL configured · API key {'set' if os.environ.get('EPLUS_WORKER_API_KEY') else 'MISSING'}")
+                st.caption(
+                    f"Worker URL configured · API key "
+                    f"{'set' if os.environ.get('EPLUS_WORKER_API_KEY') else 'MISSING'}"
+                )
+                st.caption(
+                    "Free Render tiers sleep after idle time. The first request can take "
+                    "30–90s; Studio pings `/healthz` before each live job to wake it."
+                )
+                if st.button("Wake / check Render worker", key="wake_eplus_worker"):
+                    from vibe23.energyplus_worker import EnergyPlusWorkerError, ensure_worker_awake
+
+                    with st.spinner("Pinging worker /healthz (cold start may take up to ~90s)…"):
+                        try:
+                            wake = ensure_worker_awake()
+                            health = wake.get("health") or {}
+                            if wake.get("woke_from_sleep"):
+                                st.success(
+                                    f"Worker woke in {wake['wall_seconds']}s "
+                                    f"(attempt {wake['attempt']}) · "
+                                    f"E+ {health.get('energyplus_version', '?')} · "
+                                    f"api_key_configured={health.get('api_key_configured')}"
+                                )
+                            else:
+                                st.success(
+                                    f"Worker already awake ({wake['try_seconds']}s) · "
+                                    f"E+ {health.get('energyplus_version', '?')} · "
+                                    f"api_key_configured={health.get('api_key_configured')}"
+                                )
+                        except EnergyPlusWorkerError as exc:
+                            st.error(f"Worker wake failed: {exc}")
         st.divider()
         st.header("Demo day")
         st.radio(

--- a/vibe_code_apps_23/tests/test_energyplus_worker.py
+++ b/vibe_code_apps_23/tests/test_energyplus_worker.py
@@ -6,6 +6,8 @@ import zipfile
 from pathlib import Path
 
 from vibe23.energyplus_worker import (
+    EnergyPlusWorkerError,
+    ensure_worker_awake,
     extract_results_zip,
     prefer_worker_backend,
     worker_configured,
@@ -36,6 +38,28 @@ def test_prefer_worker_backend_modes(monkeypatch):
     monkeypatch.setenv("EPLUS_BACKEND", "auto")
     monkeypatch.setenv("EPLUS_WORKER_FORCE", "1")
     assert prefer_worker_backend() is True
+
+
+def test_ensure_worker_awake_retries_then_succeeds(monkeypatch):
+    monkeypatch.setenv("EPLUS_WORKER_URL", "https://example.test")
+    monkeypatch.setenv("EPLUS_WORKER_API_KEY", "secret")
+    calls = {"n": 0}
+
+    def fake_healthz(*, timeout: float = 60.0):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise EnergyPlusWorkerError("sleeping")
+        return {"ok": True, "energyplus_version": "26.1.0", "api_key_configured": True}
+
+    from vibe23 import energyplus_worker as mod
+
+    monkeypatch.setattr(mod, "healthz", fake_healthz)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    result = ensure_worker_awake(attempts=4, per_try_timeout=1.0, pause_seconds=0.0)
+    assert result["ok"] is True
+    assert result["awake"] is True
+    assert result["attempt"] == 3
+    assert result["woke_from_sleep"] is True
 
 
 def test_extract_results_zip_flattens_output_prefix(tmp_path: Path):


### PR DESCRIPTION
## Summary
- `ensure_worker_awake()` retries `GET /healthz` (long timeout) before each remote day sim.
- Studio sidebar **Wake / check Render worker** button + cold-start caption.
- Docs note free-tier sleep behavior.

## Validation
- Streamlit running at http://127.0.0.1:8501 — `/_stcore/health` = ok, AppTest 0 exceptions.
- Live wake ping succeeded against Render worker.