### PR TITLE
fix(vibe23): Streamlit Cloud monorepo requirements path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Fallback if Streamlit Cloud resolves requirements from the GitHub repo root.
+-r vibe_code_apps_23/requirements-studio.txt
+-e ./vibe_code_apps_23

--- a/vibe_code_apps_23/README.md
+++ b/vibe_code_apps_23/README.md
@@ -77,7 +77,8 @@ Studio is **Render-worker only** for live sims (no native EnergyPlus on Cloud). 
 2. [share.streamlit.io](https://share.streamlit.io/) → **New app** → this repo → set:
    - **Main file path:** `vibe_code_apps_23/streamlit_app.py`
    - **Python version:** 3.12
-3. **App settings → Secrets** (TOML):
+   - Branch: **`develop`**
+3. **App settings → Secrets** (TOML) — paste into the editor, Save, then Reboot app:
 
 ```toml
 EPLUS_BACKEND = "worker"

--- a/vibe_code_apps_23/requirements.txt
+++ b/vibe_code_apps_23/requirements.txt
@@ -1,13 +1,10 @@
-# Studio dependencies under the filename Streamlit Community Cloud auto-detects.
+# Studio dependencies — Streamlit Community Cloud auto-detects this file next to
+# streamlit_app.py. Cloud's pip CWD is the *GitHub repo root*, so the editable
+# install must be `-e ./vibe_code_apps_23` (not `-e .`).
 #
-# Nested -r paths are resolved relative to this file, so the pinned studio set stays in
-# one place (requirements-studio.txt) and cannot drift from this file.
+# Nested -r paths are resolved relative to this file.
+# Local editable install from this directory:  pip install -e ".[studio]"
 #
-# EnergyPlus is NOT installable via this file (pip only). Live sims need a full native
-# EnergyPlus 26.1 tree — see README "Deployment note" and packages.txt.
+# EnergyPlus is NOT installable via pip. Live sims use the Render worker.
 -r requirements-studio.txt
-
-# The app imports `vibe23`, so the package itself must be installed. pip resolves this
-# relative path against the working directory, which must be this app directory
-# (vibe_code_apps_23). Locally: `py -3.12 -m pip install -r requirements.txt` from here.
--e .
+-e ./vibe_code_apps_23


### PR DESCRIPTION
## Summary
- Cloud pip CWD is the GitHub repo root, so `-e .` failed (no root pyproject.toml).
- Install with `-e ./vibe_code_apps_23` and add a root requirements fallback.

## Test plan
- [x] `pip install -r vibe_code_apps_23/requirements.txt` from repo root
- [x] AppTest + ruff
- [ ] Redeploy Streamlit Community Cloud from develop after merge