### PR TITLE
fix(vibe13): discover works without orientation lab_role

### DIFF
--- a/vibe_code_apps_13/ansible/pi-lab/playbooks/discover.yml
+++ b/vibe_code_apps_13/ansible/pi-lab/playbooks/discover.yml
@@ -26,6 +26,15 @@
   roles:
     - role: discover_serial
   tasks:
+    - name: Ensure controller discovery report dir
+      ansible.builtin.file:
+        path: "{{ playbook_dir }}/../reports/pi-lab/{{ lab_run_id | default('discover') }}"
+        state: directory
+        mode: "0755"
+      delegate_to: localhost
+      become: false
+      run_once: true
+
     - name: Write per-host discovery JSON on controller
       ansible.builtin.copy:
         dest: "{{ playbook_dir }}/../reports/pi-lab/{{ lab_run_id | default('discover') }}/{{ inventory_hostname }}.json"

--- a/vibe_code_apps_13/ansible/pi-lab/roles/discover_serial/tasks/main.yml
+++ b/vibe_code_apps_13/ansible/pi-lab/roles/discover_serial/tasks/main.yml
@@ -41,7 +41,8 @@
     lab_discovery:
       host: "{{ inventory_hostname }}"
       ansible_host: "{{ ansible_host }}"
-      role: "{{ lab_role }}"
+      # Discover is orientation-free; roles are assigned at confirm-wiring / run time.
+      role: "{{ lab_role | default('unassigned') }}"
       expected_serial_by_id: "{{ lab_serial_by_id | default('') }}"
       expected_adapter_model: "{{ lab_adapter_model | default('unconfirmed') }}"
       os_lines: "{{ os_facts.stdout_lines }}"

--- a/vibe_code_apps_13/ansible/pi-lab/tests/test_inventory_safety.py
+++ b/vibe_code_apps_13/ansible/pi-lab/tests/test_inventory_safety.py
@@ -150,6 +150,11 @@ class WiringRunGateDocs(unittest.TestCase):
         self.assertIn("expected_recovery_exit_code", text)
         self.assertIn("--unit", text)
 
+    def test_discover_role_defaults_without_orientation(self) -> None:
+        text = (ROOT / "roles/discover_serial/tasks/main.yml").read_text()
+        self.assertIn("lab_role | default('unassigned')", text)
+        self.assertIn("Ensure controller discovery report dir", (ROOT / "playbooks/discover.yml").read_text())
+
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
## Summary
- Discover playbook no longer requires `lab_role` (defaults to `unassigned`) so read-only preflight works before confirm-wiring.
- Ensure controller discovery report directory exists.
- Offline test locks the default.

## Test plan
- [x] `python3 ansible/pi-lab/tests/test_inventory_safety.py`
- [x] Read-only `discover.yml` against workerpi1/2 (no serial open)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Discovery runs now create the report directory before writing per-device results.
  - Devices without an assigned role are labeled “unassigned” instead of causing discovery to fail.

- **Tests**
  - Added offline coverage to verify report-directory setup and default role handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->