### PR TITLE
fix(vibe13): Part B integrity — raw-peer idle budget, orientation env, fail-closed

### DIFF
--- a/vibe_code_apps_13/ansible/pi-lab/playbooks/deploy.yml
+++ b/vibe_code_apps_13/ansible/pi-lab/playbooks/deploy.yml
@@ -7,7 +7,6 @@
   any_errors_fatal: true
   vars:
     lab_release_id: "{{ lab_revision | mandatory }}"
-  vars:
     lab_scripts: "{{ playbook_dir }}/../scripts"
   pre_tasks:
     - name: Refuse TX during deploy

--- a/vibe_code_apps_13/ansible/pi-lab/roles/run_orchestrate/tasks/main.yml
+++ b/vibe_code_apps_13/ansible/pi-lab/roles/run_orchestrate/tasks/main.yml
@@ -44,6 +44,15 @@
         )
       }}
 
+- name: Refresh host.env with orientation-derived lab_role
+  # Deploy-time host.env freezes inventory roles; orientation must rewrite before TX.
+  ansible.builtin.template:
+    src: "{{ playbook_dir }}/../roles/deploy_release/templates/host.env.j2"
+    dest: "{{ lab_etc_root }}/{{ inventory_hostname }}.env"
+    owner: root
+    group: "{{ lab_service_user }}"
+    mode: "0640"
+
 - name: Stop vibe13 units first (absent unit is OK)
   ansible.builtin.shell: |
     set -euo pipefail
@@ -228,9 +237,13 @@
   when: lab_enable_observer | default(true) | bool
 
 - name: Bounded profile wait (smoke / gate / soak)
+  # pause is controller-side; do NOT gate on lab_role — when the first play host is
+  # probe (workerpi2-server), a per-host when: skips the wait for everyone.
   ansible.builtin.pause:
     seconds: "{{ lab_runtime_secs | int }}"
-  when: lab_role == 'server'
+  run_once: true
+  delegate_to: localhost
+  become: false
 
 - name: Evaluate finite-profile evidence (never PASS on is-active alone)
   ansible.builtin.shell: |
@@ -321,6 +334,15 @@
     fail_msg: >-
       Profile {{ lab_profile }} host {{ inventory_hostname }} role {{ lab_role }}
       ended FAIL (detail in summary.json). Refuse soft-ok on Ansible success.
+
+- name: Fail closed when raw profile is not PASS
+  ansible.builtin.assert:
+    that:
+      - summary_eval.stdout == 'PASS'
+    fail_msg: >-
+      Raw profile {{ lab_profile }} host {{ inventory_hostname }} ended
+      {{ summary_eval.stdout }} (need PASS). Refuse PARTIAL/NOT_RUN soft-ok.
+  when: lab_is_raw | bool
 
 - name: Refresh observer status with terminal summary
   ansible.builtin.copy:

--- a/vibe_code_apps_13/ansible/pi-lab/roles/run_orchestrate/tasks/main.yml
+++ b/vibe_code_apps_13/ansible/pi-lab/roles/run_orchestrate/tasks/main.yml
@@ -314,6 +314,14 @@
   register: summary_eval
   changed_when: false
 
+- name: Fail closed when any host summary is FAIL
+  ansible.builtin.assert:
+    that:
+      - summary_eval.stdout != 'FAIL'
+    fail_msg: >-
+      Profile {{ lab_profile }} host {{ inventory_hostname }} role {{ lab_role }}
+      ended FAIL (detail in summary.json). Refuse soft-ok on Ansible success.
+
 - name: Refresh observer status with terminal summary
   ansible.builtin.copy:
     dest: "{{ lab_state_root }}/observer/status.json"

--- a/vibe_code_apps_13/ansible/pi-lab/roles/run_orchestrate/tasks/main.yml
+++ b/vibe_code_apps_13/ansible/pi-lab/roles/run_orchestrate/tasks/main.yml
@@ -327,23 +327,8 @@
   register: summary_eval
   changed_when: false
 
-- name: Fail closed when any host summary is FAIL
-  ansible.builtin.assert:
-    that:
-      - summary_eval.stdout != 'FAIL'
-    fail_msg: >-
-      Profile {{ lab_profile }} host {{ inventory_hostname }} role {{ lab_role }}
-      ended FAIL (detail in summary.json). Refuse soft-ok on Ansible success.
-
-- name: Fail closed when raw profile is not PASS
-  ansible.builtin.assert:
-    that:
-      - summary_eval.stdout == 'PASS'
-    fail_msg: >-
-      Raw profile {{ lab_profile }} host {{ inventory_hostname }} ended
-      {{ summary_eval.stdout }} (need PASS). Refuse PARTIAL/NOT_RUN soft-ok.
-  when: lab_is_raw | bool
-
+# Publish terminal observer status before fail-closed asserts so FAIL/PARTIAL/NOT_RUN
+# are not left looking like a live success when Ansible aborts.
 - name: Refresh observer status with terminal summary
   ansible.builtin.copy:
     dest: "{{ lab_state_root }}/observer/status.json"
@@ -362,3 +347,20 @@
     owner: "{{ lab_service_user }}"
     group: "{{ lab_service_user }}"
     mode: "0640"
+
+- name: Fail closed when any host summary is FAIL
+  ansible.builtin.assert:
+    that:
+      - summary_eval.stdout != 'FAIL'
+    fail_msg: >-
+      Profile {{ lab_profile }} host {{ inventory_hostname }} role {{ lab_role }}
+      ended FAIL (detail in summary.json). Refuse soft-ok on Ansible success.
+
+- name: Fail closed when raw profile is not PASS
+  ansible.builtin.assert:
+    that:
+      - summary_eval.stdout == 'PASS'
+    fail_msg: >-
+      Raw profile {{ lab_profile }} host {{ inventory_hostname }} ended
+      {{ summary_eval.stdout }} (need PASS). Refuse PARTIAL/NOT_RUN soft-ok.
+  when: lab_is_raw | bool

--- a/vibe_code_apps_13/apps/vibe13-raw-peer/src/main.rs
+++ b/vibe_code_apps_13/apps/vibe13-raw-peer/src/main.rs
@@ -165,13 +165,14 @@ async fn main() -> Result<()> {
     let deadline = Instant::now()
         + Duration::from_millis(args.timeout_ms.saturating_mul(args.exchanges as u64 + 5));
 
-    for seq in 1..=args.exchanges {
-        if Instant::now() > deadline {
-            fail += 1;
-            warn!(seq, "total deadline exceeded");
-            break;
-        }
-        if initiator {
+    if initiator {
+        // Probe: fixed exchange budget (one loop iteration == one ping).
+        for seq in 1..=args.exchanges {
+            if Instant::now() > deadline {
+                fail += 1;
+                warn!(seq, "total deadline exceeded");
+                break;
+            }
             let payload = format!("ping-{seq}").into_bytes();
             let frame = encode(seq, &payload);
             port.write_all(&frame).await?;
@@ -203,7 +204,16 @@ async fn main() -> Result<()> {
                 warn!(seq, "timeout waiting reply");
             }
             tokio::time::sleep(Duration::from_millis(args.interval_ms)).await;
-        } else {
+        }
+    } else {
+        // Server: idle pre-ping waits must NOT burn the exchange budget.
+        // (A `for 1..=N` loop + `continue` on idle caused consistent 99/100 PASS/FAIL.)
+        while ok + fail < args.exchanges {
+            if Instant::now() > deadline {
+                fail += 1;
+                warn!(ok, fail, "total deadline exceeded");
+                break;
+            }
             let wait_until =
                 Instant::now() + Duration::from_millis(args.timeout_ms.saturating_mul(5));
             let mut handled = false;
@@ -228,11 +238,8 @@ async fn main() -> Result<()> {
                 tokio::task::yield_now().await;
             }
             if !handled {
-                // idle; keep waiting for initiator exchanges
+                // Still waiting for initiator; do not count against exchanges.
                 continue;
-            }
-            if ok + fail >= args.exchanges {
-                break;
             }
         }
     }


### PR DESCRIPTION
## Summary
- **raw-peer**: server no longer burns exchange budget on pre-ping idle waits (fixed consistent 99/100 FAIL)
- **deploy.yml**: merge duplicate `vars:` so `lab_release_id` is defined
- **run**: rewrite `host.env` from orientation before TX; controller `pause` always runs once (workerpi2-server was skipping the wait); fail-closed on FAIL / raw non-PASS

## Lab evidence (in progress)
- raw-smoke workerpi1-server: PASS 100/100 (`20260907T190541Z`)
- raw-smoke workerpi2-server: PASS 100/100 (`20260907T191455Z`)
- raw-gate running during this PR

## Test plan
- [x] raw-smoke both orientations PASS
- [ ] raw-gate / mstp matrix + soak
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment now requires an explicit lab revision, ensuring releases use a defined version.
  - Deployment validation now publishes terminal observer status before stopping on failed checks.
  - Lab role information is refreshed before unit shutdown.
  - Profile wait handling runs consistently from the controller.
  - Server exchange counts now exclude idle pre-ping waits, ensuring the configured number of exchanges is completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->