### PR TITLE
feat(vibe25): Open-FDD PID-HUNT-1 tutorial notebook

### DIFF
--- a/.github/workflows/vibe25-ci.yml
+++ b/.github/workflows/vibe25-ci.yml
@@ -1,0 +1,39 @@
+name: vibe25-ci
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - "vibe_code_apps_25/**"
+      - ".github/workflows/vibe25-ci.yml"
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - "vibe_code_apps_25/**"
+      - ".github/workflows/vibe25-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: vibe_code_apps_25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Vibe 25
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[dev]"
+      - name: Pytest
+        run: python -m pytest
+      - name: Ruff
+        run: python -m ruff check src tests
+      - name: Compile package
+        run: python -m compileall -q src/vibe25

--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,9 @@ __pycache__/
 !vibe_code_apps_23/utilities/**/*.csv
 !vibe_code_apps_23/scorecards/**/*.csv
 
-# Vibe 23 local EnergyPlus/Open-FDD campaign payloads. Commit only reviewed,
-# lightweight manifests/results outside these raw run directories.
+# Vibe 23 local EnergyPlus/Open-FDD campaign payloads (full trees + studio exports).
+vibe_code_apps_23/campaigns/
 vibe_code_apps_23/weather/**/*.epw
-vibe_code_apps_23/campaigns/runs/
 vibe_code_apps_23/openfdd/packages/
 vibe_code_apps_23/**/campaign_log_enriched.csv
 vibe_code_apps_23/data/raw/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Days **1–27** lead with Python + BACnet (BAC0 / BACpypes3) and a Rust companio
 | **Demand twin (app 21)** | Liberty cooling DR twin *(completed reference)* | [`vibe_code_apps_21/`](vibe_code_apps_21/) |
 | **Lakeside ES (app 22)** | Lakeside heating DSM / grid-search stack *(completed reference)* | [`vibe_code_apps_22/`](vibe_code_apps_22/) |
 | **Residential DSM lab (app 23)** | Heat-pump home DR + thermostat/battery grid search | [`vibe_code_apps_23/`](vibe_code_apps_23/) |
+| **Live BACnet twin (app 24)** | Priority-array RTU twin + BAS mimic (`SURROGATE_PLANT_V1`) | [`vibe_code_apps_24/`](vibe_code_apps_24/) |
+| **PID hunting tutorial (app 25)** | Open-FDD PID-HUNT-1 notebook + synthetic AO math | [`vibe_code_apps_25/`](vibe_code_apps_25/) |
 
 </details>
 
@@ -99,6 +101,8 @@ Hands-on milestones from BACnet scripting to cloud FDD. Checkpoints **1–10** a
 | **21** | **[Demand-management twin](vibe_code_apps_21/)** | Liberty Building cooling DR: G14 Twin → hourly E+ farm → sklearn `facility_kw`. | Done |
 | **22** | **[Lakeside ES (unified)](vibe_code_apps_22/)** | Lakeside Elementary heating DSM / grid-search stack. | Done |
 | **23** | **[Residential heat-pump DSM](vibe_code_apps_23/)** | Hypothetical heat-pump home: DR demo, TOU thermostat grid, battery co-optimization. | **Active** |
+| **24** | **[Live BACnet + physics twin](vibe_code_apps_24/)** | FastAPI BAS mimic + optional BACnet; priority-8 UI writes; `SURROGATE_PLANT_V1`. | **Active** |
+| **25** | **[Open-FDD PID hunting tutorial](vibe_code_apps_25/)** | Jupyter + PyPI `open-fdd`: synthetic AO hunting, PID-HUNT-1 math, AND-gate viz. | **Active** |
 
 </details>
 

--- a/vibe_code_apps_23/.gitignore
+++ b/vibe_code_apps_23/.gitignore
@@ -1,4 +1,4 @@
-﻿campaigns/runs/
+﻿campaigns/
 __pycache__/
 *.pyc
 .pytest_cache/

--- a/vibe_code_apps_25/AGENTS.md
+++ b/vibe_code_apps_25/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md — Vibe 25 Open-FDD PID hunting tutorial
+
+**Mission:** teach **PID-HUNT-1** (suspected control-output hunting) with synthetic AO data and the Open-FDD pandas detector.
+
+**Claim boundary:** educational screening demo. PID-HUNT-1 is **suspected loop hunting**, not proof of bad PID alone. Do not invent thresholds — use `PidHuntingParams` defaults from Open-FDD.
+
+## Install
+```powershell
+cd vibe_code_apps_25
+pip install -e ".[dev]"
+# tip-of-tree Open-FDD (optional):
+# pip install -e "C:\Users\ben\Documents\open-fdd[oracle]"
+```
+
+PyPI package is **`open-fdd`** (import `open_fdd`). Extra **`[oracle]`** pulls pandas rules.
+
+## Hard rules
+- Tutorial scope is **PID-HUNT-1** (AO TV / span / cycles / reversals) — **not** FC4 (AHU operating-state thrash)
+- Extreme low/high seen metrics are diagnostic only — they are **not** in the fault AND
+- Keep synth generators deterministic (`vibe25.synth`) so pytest stays green
+- Prefer column roles like `cooling-valve` with a `DatetimeIndex`
+
+## Resume
+```powershell
+python -m pytest
+python -m ruff check src tests
+jupyter notebook notebooks/01_pid_hunt_tutorial.ipynb
+```

--- a/vibe_code_apps_25/README.md
+++ b/vibe_code_apps_25/README.md
@@ -1,0 +1,38 @@
+# Vibe 25 — Open-FDD PID hunting tutorial
+
+Jupyter walkthrough of **PID-HUNT-1** from [`open-fdd`](https://pypi.org/project/open-fdd/) (pandas oracle): generate synthetic cooling-valve AO traces, learn the rolling TV / span / cycles / reversals math, run `hunting_fault_mask`, and plot how those metrics AND into a fault.
+
+This is a **screening** demo — suspected control-output hunting, not proof of a bad PID alone. Distinct from cookbook **FC4** (operating-state oscillation).
+
+## Quick start
+
+```powershell
+cd vibe_code_apps_25
+pip install -e ".[dev]"
+jupyter notebook notebooks/01_pid_hunt_tutorial.ipynb
+```
+
+Or execute headlessly:
+
+```powershell
+jupyter nbconvert --to notebook --execute notebooks/01_pid_hunt_tutorial.ipynb --inplace
+python -m pytest
+```
+
+Optional tip-of-tree Open-FDD:
+
+```powershell
+pip install -e "C:\Users\ben\Documents\open-fdd[oracle]"
+```
+
+## Layout
+
+| Path | Role |
+|------|------|
+| [`notebooks/01_pid_hunt_tutorial.ipynb`](notebooks/01_pid_hunt_tutorial.ipynb) | Tutorial |
+| [`src/vibe25/synth.py`](src/vibe25/synth.py) | Healthy vs hunting AO generators |
+| [`tests/`](tests/) | Detector smoke tests |
+
+## Defaults (Open-FDD `PidHuntingParams`)
+
+Rolling **1h** window; fault when coverage ≥ 80%, span ≥ 20%, TV ≥ 500 %-pts, equivalent cycles ≥ 2.5, and reversals ≥ 4.

--- a/vibe_code_apps_25/notebooks/01_pid_hunt_tutorial.ipynb
+++ b/vibe_code_apps_25/notebooks/01_pid_hunt_tutorial.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ab8d1850",
+   "metadata": {},
+   "source": [
+    "# Vibe 25 — Open-FDD PID-HUNT-1 tutorial\n",
+    "\n",
+    "Educational walkthrough of **suspected control-output hunting** using the pandas detector from PyPI package [`open-fdd`](https://pypi.org/project/open-fdd/).\n",
+    "\n",
+    "**Claim:** screening demo only. A trip means the AO *looks like* hunting over a rolling hour — not proof that PID gains alone are wrong.\n",
+    "\n",
+    "**Not in scope:** cookbook **FC4** (AHU operating-state / mode thrash). Same colloquial \"PID hunting\" name, different evidence.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e814fdc6",
+   "metadata": {},
+   "source": [
+    "## 0. Install Open-FDD (oracle / pandas rules)\n",
+    "\n",
+    "PyPI name is `open-fdd`; import path is `open_fdd`. Extra `[oracle]` installs the pandas rule stack.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a77bb92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"open-fdd[oracle]>=4.4.1\" matplotlib\n",
+    "# Optional tip-of-tree: %pip install -q -e \"C:/Users/ben/Documents/open-fdd[oracle]\" \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01e08225",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "from open_fdd.rules.pid_hunting import PidHuntingParams, hunting_fault_mask\n",
+    "\n",
+    "from vibe25.synth import COLUMN, POLL_SECONDS, healthy_cooling_valve, hunting_cooling_valve\n",
+    "\n",
+    "params = PidHuntingParams()\n",
+    "params\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4768bf9a",
+   "metadata": {},
+   "source": [
+    "## 1. Synthetic data — healthy vs hunting\n",
+    "\n",
+    "We synthesize a `cooling-valve` AO (%) on a 1-minute `DatetimeIndex` (>=3 h so rolling 1 h windows fill).\n",
+    "\n",
+    "- **Healthy:** slow ramp + sub-deadband noise (should stay clear)\n",
+    "- **Hunting:** 10 to 90 percent square chatter (should trip defaults)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38aa5dc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "healthy = healthy_cooling_valve()\n",
+    "hunting = hunting_cooling_valve()\n",
+    "healthy.head(), hunting[COLUMN].describe()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7eff0353",
+   "metadata": {},
+   "source": [
+    "## 2. How the math works (PID-HUNT-1)\n",
+    "\n",
+    "Open-FDD `hunting_fault_mask` (defaults from `PidHuntingParams`):\n",
+    "\n",
+    "1. **Normalize** the command to 0-100% (`to_percent_output`).\n",
+    "2. Take sample-to-sample delta; ignore moves smaller than **`change_deadband_pct = 1`**.\n",
+    "3. Over a rolling **`window = 1h`**, compute:\n",
+    "   - **TV** (total variation) = sum of abs(significant delta) -> trip if >= **500** percent-points\n",
+    "   - **span** = rolling max - min -> trip if >= **20** %\n",
+    "   - **equivalent cycles** = TV / (2 * span) -> trip if >= **2.5**\n",
+    "   - **reversals** = sign flips of significant delta -> trip if >= **4**\n",
+    "   - **coverage** >= **80%** of expected samples in the window\n",
+    "4. **Fault** = AND of coverage, span, TV, cycles, reversals (and optional `loop-enabled`).\n",
+    "\n",
+    "`low_extreme_seen` / `high_extreme_seen` are logged for diagnostics but are **not** part of the fault AND.\n",
+    "\n",
+    "```text\n",
+    "fault = coverage>=80% AND span>=20% AND TV>=500 AND cycles>=2.5 AND reversals>=4\n",
+    "```\n",
+    "\n",
+    "**FC4 != PID-HUNT-1:** FC4 counts AHU *operating-state* entry transitions per hour. PID-HUNT-1 watches analog AO travel.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfa95966",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_hunt(df: pd.DataFrame):\n",
+    "    fault, metrics = hunting_fault_mask(\n",
+    "        df[COLUMN],\n",
+    "        params=params,\n",
+    "        poll_seconds=POLL_SECONDS,\n",
+    "    )\n",
+    "    out = metrics.copy()\n",
+    "    out[\"fault\"] = fault.astype(bool)\n",
+    "    return out\n",
+    "\n",
+    "m_hunt = run_hunt(hunting)\n",
+    "m_ok = run_hunt(healthy)\n",
+    "print(\"hunting fault samples:\", int(m_hunt[\"fault\"].sum()))\n",
+    "print(\"healthy fault samples:\", int(m_ok[\"fault\"].sum()))\n",
+    "peak = m_hunt.loc[m_hunt[\"fault\"]].iloc[-1]\n",
+    "peak[\n",
+    "    [\n",
+    "        \"control-output-pct\",\n",
+    "        \"total_variation_1h\",\n",
+    "        \"output_span_1h\",\n",
+    "        \"equivalent_cycles_1h\",\n",
+    "        \"reversals_1h\",\n",
+    "        \"coverage_pct_1h\",\n",
+    "    ]\n",
+    "]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab382220",
+   "metadata": {},
+   "source": [
+    "## 3. Schematic viz — AO vs time, then TV vs span (the AND gates)\n",
+    "\n",
+    "Panel A shows the raw AO with fault shading. Panel B plots rolling **TV** against **span** (and marks thresholds) so you can see the quantities that combine into the fault.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4d0f15d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_hunt(metrics: pd.DataFrame, title: str):\n",
+    "    fig, axes = plt.subplots(2, 1, figsize=(11, 7), sharex=True, constrained_layout=True)\n",
+    "    ax0, ax1 = axes\n",
+    "    ao = metrics[\"control-output-pct\"]\n",
+    "    fault = metrics[\"fault\"].fillna(False)\n",
+    "    ax0.plot(ao.index, ao.values, color=\"#0d9b8c\", lw=1.2, label=\"cooling-valve %\")\n",
+    "    ax0.fill_between(ao.index, 0, 100, where=fault.values, color=\"#f87171\", alpha=0.25, label=\"fault\")\n",
+    "    ax0.set_ylabel(\"AO %\")\n",
+    "    ax0.set_ylim(0, 100)\n",
+    "    ax0.set_title(title)\n",
+    "    ax0.legend(loc=\"upper right\", fontsize=9)\n",
+    "    ax0.grid(True, alpha=0.3)\n",
+    "\n",
+    "    ax1.plot(metrics.index, metrics[\"total_variation_1h\"], color=\"#2563eb\", lw=1.2, label=\"TV 1h\")\n",
+    "    ax1.axhline(params.total_variation_fault_pct, color=\"#2563eb\", ls=\"--\", lw=1, label=\"TV>=500\")\n",
+    "    ax1b = ax1.twinx()\n",
+    "    ax1b.plot(metrics.index, metrics[\"output_span_1h\"], color=\"#c47b08\", lw=1.2, label=\"span 1h\")\n",
+    "    ax1b.axhline(params.minimum_span_pct, color=\"#c47b08\", ls=\"--\", lw=1, label=\"span>=20\")\n",
+    "    ax1.set_ylabel(\"TV (percent-points)\")\n",
+    "    ax1b.set_ylabel(\"span (%)\")\n",
+    "    ax1.set_xlabel(\"time\")\n",
+    "    lines, labels = ax1.get_legend_handles_labels()\n",
+    "    lines2, labels2 = ax1b.get_legend_handles_labels()\n",
+    "    ax1.legend(lines + lines2, labels + labels2, loc=\"upper left\", fontsize=8)\n",
+    "    ax1.grid(True, alpha=0.3)\n",
+    "    return fig\n",
+    "\n",
+    "fig = plot_hunt(m_hunt, \"Hunting AO — PID-HUNT-1 trip region\")\n",
+    "plt.show()\n",
+    "\n",
+    "gates = pd.DataFrame(\n",
+    "    {\n",
+    "        \"metric\": [\"coverage %\", \"span %\", \"TV percent-pts\", \"equiv cycles\", \"reversals\"],\n",
+    "        \"value\": [\n",
+    "            float(peak[\"coverage_pct_1h\"]),\n",
+    "            float(peak[\"output_span_1h\"]),\n",
+    "            float(peak[\"total_variation_1h\"]),\n",
+    "            float(peak[\"equivalent_cycles_1h\"]),\n",
+    "            float(peak[\"reversals_1h\"]),\n",
+    "        ],\n",
+    "        \"threshold\": [\n",
+    "            params.minimum_coverage_pct,\n",
+    "            params.minimum_span_pct,\n",
+    "            params.total_variation_fault_pct,\n",
+    "            params.minimum_equivalent_cycles,\n",
+    "            params.minimum_reversals,\n",
+    "        ],\n",
+    "    }\n",
+    ")\n",
+    "gates[\"passes\"] = gates[\"value\"] >= gates[\"threshold\"]\n",
+    "gates\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "809af0f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8, 3.5), constrained_layout=True)\n",
+    "colors = [\"#4ade80\" if p else \"#f87171\" for p in gates[\"passes\"]]\n",
+    "ax.barh(gates[\"metric\"], gates[\"value\"], color=colors, alpha=0.85)\n",
+    "for i, row in gates.iterrows():\n",
+    "    ax.axvline(row[\"threshold\"], color=\"#64748b\", ls=\":\", lw=1)\n",
+    "    ax.text(row[\"threshold\"], i, f\"  thr={row['threshold']:g}\", va=\"center\", fontsize=8, color=\"#334155\")\n",
+    "ax.set_xlabel(\"metric value at a peak fault sample\")\n",
+    "ax.set_title(\"AND-gate schematic — all green bars must clear their thresholds\")\n",
+    "ax.grid(True, axis=\"x\", alpha=0.3)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd8e401a",
+   "metadata": {},
+   "source": [
+    "## 4. Healthy contrast\n",
+    "\n",
+    "Same detector, slow ramp — TV stays near zero under the 1% deadband, so the AND never closes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3741b3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot_hunt(m_ok, \"Healthy AO — no PID-HUNT-1 trip\")\n",
+    "plt.show()\n",
+    "m_ok[\n",
+    "    [\n",
+    "        \"control-output-pct\",\n",
+    "        \"total_variation_1h\",\n",
+    "        \"output_span_1h\",\n",
+    "        \"equivalent_cycles_1h\",\n",
+    "        \"reversals_1h\",\n",
+    "        \"fault\",\n",
+    "    ]\n",
+    "].tail(3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8f7cb78",
+   "metadata": {},
+   "source": [
+    "## Takeaways\n",
+    "\n",
+    "- **TV** accumulates travel; **span** needs meaningful travel range; **cycles** = TV/(2*span); **reversals** need direction chatter.\n",
+    "- All must fire together with enough **coverage** — that is the fault.\n",
+    "- Use `open_fdd.rules.pid_hunting.hunting_fault_mask` (or cookbook `run_rule(\"PID-HUNT-1\", ...)`) on real historian AOs the same way.\n",
+    "- For mode thrashing, look at **FC4**, not PID-HUNT-1.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/vibe_code_apps_25/pyproject.toml
+++ b/vibe_code_apps_25/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=75", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vibe25-pid-hunt"
+version = "0.1.0"
+description = "Open-FDD PID-HUNT-1 tutorial: synthetic AO hunting + math walkthrough"
+requires-python = ">=3.12"
+dependencies = [
+    "open-fdd[oracle]>=4.4.1",
+    "matplotlib>=3.9",
+    "jupyter>=1.0",
+    "nbconvert>=7.16",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "ruff>=0.12"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q --tb=short"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]

--- a/vibe_code_apps_25/scripts/build_notebook.py
+++ b/vibe_code_apps_25/scripts/build_notebook.py
@@ -1,0 +1,230 @@
+"""Generate notebooks/01_pid_hunt_tutorial.ipynb (run once during scaffolding)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def md(src: str) -> dict:
+    lines = src.strip("\n").split("\n")
+    return {"cell_type": "markdown", "metadata": {}, "source": [ln + "\n" for ln in lines]}
+
+
+def code(src: str) -> dict:
+    lines = src.strip("\n").split("\n")
+    return {
+        "cell_type": "code",
+        "metadata": {},
+        "execution_count": None,
+        "outputs": [],
+        "source": [ln + "\n" for ln in lines],
+    }
+
+
+cells = [
+    md(
+        """# Vibe 25 — Open-FDD PID-HUNT-1 tutorial
+
+Educational walkthrough of **suspected control-output hunting** using the pandas detector from PyPI package [`open-fdd`](https://pypi.org/project/open-fdd/).
+
+**Claim:** screening demo only. A trip means the AO *looks like* hunting over a rolling hour — not proof that PID gains alone are wrong.
+
+**Not in scope:** cookbook **FC4** (AHU operating-state / mode thrash). Same colloquial "PID hunting" name, different evidence."""
+    ),
+    md(
+        """## 0. Install Open-FDD (oracle / pandas rules)
+
+PyPI name is `open-fdd`; import path is `open_fdd`. Extra `[oracle]` installs the pandas rule stack."""
+    ),
+    code(
+        """%pip install -q "open-fdd[oracle]>=4.4.1" matplotlib
+# Optional tip-of-tree: %pip install -q -e "C:/Users/ben/Documents/open-fdd[oracle]" """
+    ),
+    code(
+        """from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from open_fdd.rules.pid_hunting import PidHuntingParams, hunting_fault_mask
+
+from vibe25.synth import COLUMN, POLL_SECONDS, healthy_cooling_valve, hunting_cooling_valve
+
+params = PidHuntingParams()
+params"""
+    ),
+    md(
+        """## 1. Synthetic data — healthy vs hunting
+
+We synthesize a `cooling-valve` AO (%) on a 1-minute `DatetimeIndex` (>=3 h so rolling 1 h windows fill).
+
+- **Healthy:** slow ramp + sub-deadband noise (should stay clear)
+- **Hunting:** 10 to 90 percent square chatter (should trip defaults)"""
+    ),
+    code(
+        """healthy = healthy_cooling_valve()
+hunting = hunting_cooling_valve()
+healthy.head(), hunting[COLUMN].describe()"""
+    ),
+    md(
+        """## 2. How the math works (PID-HUNT-1)
+
+Open-FDD `hunting_fault_mask` (defaults from `PidHuntingParams`):
+
+1. **Normalize** the command to 0-100% (`to_percent_output`).
+2. Take sample-to-sample delta; ignore moves smaller than **`change_deadband_pct = 1`**.
+3. Over a rolling **`window = 1h`**, compute:
+   - **TV** (total variation) = sum of abs(significant delta) -> trip if >= **500** percent-points
+   - **span** = rolling max - min -> trip if >= **20** %
+   - **equivalent cycles** = TV / (2 * span) -> trip if >= **2.5**
+   - **reversals** = sign flips of significant delta -> trip if >= **4**
+   - **coverage** >= **80%** of expected samples in the window
+4. **Fault** = AND of coverage, span, TV, cycles, reversals (and optional `loop-enabled`).
+
+`low_extreme_seen` / `high_extreme_seen` are logged for diagnostics but are **not** part of the fault AND.
+
+```text
+fault = coverage>=80% AND span>=20% AND TV>=500 AND cycles>=2.5 AND reversals>=4
+```
+
+**FC4 != PID-HUNT-1:** FC4 counts AHU *operating-state* entry transitions per hour. PID-HUNT-1 watches analog AO travel."""
+    ),
+    code(
+        """def run_hunt(df: pd.DataFrame):
+    fault, metrics = hunting_fault_mask(
+        df[COLUMN],
+        params=params,
+        poll_seconds=POLL_SECONDS,
+    )
+    out = metrics.copy()
+    out["fault"] = fault.astype(bool)
+    return out
+
+m_hunt = run_hunt(hunting)
+m_ok = run_hunt(healthy)
+print("hunting fault samples:", int(m_hunt["fault"].sum()))
+print("healthy fault samples:", int(m_ok["fault"].sum()))
+peak = m_hunt.loc[m_hunt["fault"]].iloc[-1]
+peak[
+    [
+        "control-output-pct",
+        "total_variation_1h",
+        "output_span_1h",
+        "equivalent_cycles_1h",
+        "reversals_1h",
+        "coverage_pct_1h",
+    ]
+]"""
+    ),
+    md(
+        """## 3. Schematic viz — AO vs time, then TV vs span (the AND gates)
+
+Panel A shows the raw AO with fault shading. Panel B plots rolling **TV** against **span** (and marks thresholds) so you can see the quantities that combine into the fault."""
+    ),
+    code(
+        """def plot_hunt(metrics: pd.DataFrame, title: str):
+    fig, axes = plt.subplots(2, 1, figsize=(11, 7), sharex=True, constrained_layout=True)
+    ax0, ax1 = axes
+    ao = metrics["control-output-pct"]
+    fault = metrics["fault"].fillna(False)
+    ax0.plot(ao.index, ao.values, color="#0d9b8c", lw=1.2, label="cooling-valve %")
+    ax0.fill_between(ao.index, 0, 100, where=fault.values, color="#f87171", alpha=0.25, label="fault")
+    ax0.set_ylabel("AO %")
+    ax0.set_ylim(0, 100)
+    ax0.set_title(title)
+    ax0.legend(loc="upper right", fontsize=9)
+    ax0.grid(True, alpha=0.3)
+
+    ax1.plot(metrics.index, metrics["total_variation_1h"], color="#2563eb", lw=1.2, label="TV 1h")
+    ax1.axhline(params.total_variation_fault_pct, color="#2563eb", ls="--", lw=1, label="TV>=500")
+    ax1b = ax1.twinx()
+    ax1b.plot(metrics.index, metrics["output_span_1h"], color="#c47b08", lw=1.2, label="span 1h")
+    ax1b.axhline(params.minimum_span_pct, color="#c47b08", ls="--", lw=1, label="span>=20")
+    ax1.set_ylabel("TV (percent-points)")
+    ax1b.set_ylabel("span (%)")
+    ax1.set_xlabel("time")
+    lines, labels = ax1.get_legend_handles_labels()
+    lines2, labels2 = ax1b.get_legend_handles_labels()
+    ax1.legend(lines + lines2, labels + labels2, loc="upper left", fontsize=8)
+    ax1.grid(True, alpha=0.3)
+    return fig
+
+fig = plot_hunt(m_hunt, "Hunting AO — PID-HUNT-1 trip region")
+plt.show()
+
+gates = pd.DataFrame(
+    {
+        "metric": ["coverage %", "span %", "TV percent-pts", "equiv cycles", "reversals"],
+        "value": [
+            float(peak["coverage_pct_1h"]),
+            float(peak["output_span_1h"]),
+            float(peak["total_variation_1h"]),
+            float(peak["equivalent_cycles_1h"]),
+            float(peak["reversals_1h"]),
+        ],
+        "threshold": [
+            params.minimum_coverage_pct,
+            params.minimum_span_pct,
+            params.total_variation_fault_pct,
+            params.minimum_equivalent_cycles,
+            params.minimum_reversals,
+        ],
+    }
+)
+gates["passes"] = gates["value"] >= gates["threshold"]
+gates"""
+    ),
+    code(
+        """fig, ax = plt.subplots(figsize=(8, 3.5), constrained_layout=True)
+colors = ["#4ade80" if p else "#f87171" for p in gates["passes"]]
+ax.barh(gates["metric"], gates["value"], color=colors, alpha=0.85)
+for i, row in gates.iterrows():
+    ax.axvline(row["threshold"], color="#64748b", ls=":", lw=1)
+    ax.text(row["threshold"], i, f"  thr={row['threshold']:g}", va="center", fontsize=8, color="#334155")
+ax.set_xlabel("metric value at a peak fault sample")
+ax.set_title("AND-gate schematic — all green bars must clear their thresholds")
+ax.grid(True, axis="x", alpha=0.3)
+plt.show()"""
+    ),
+    md(
+        """## 4. Healthy contrast
+
+Same detector, slow ramp — TV stays near zero under the 1% deadband, so the AND never closes."""
+    ),
+    code(
+        """fig = plot_hunt(m_ok, "Healthy AO — no PID-HUNT-1 trip")
+plt.show()
+m_ok[
+    [
+        "control-output-pct",
+        "total_variation_1h",
+        "output_span_1h",
+        "equivalent_cycles_1h",
+        "reversals_1h",
+        "fault",
+    ]
+].tail(3)"""
+    ),
+    md(
+        """## Takeaways
+
+- **TV** accumulates travel; **span** needs meaningful travel range; **cycles** = TV/(2*span); **reversals** need direction chatter.
+- All must fire together with enough **coverage** — that is the fault.
+- Use `open_fdd.rules.pid_hunting.hunting_fault_mask` (or cookbook `run_rule("PID-HUNT-1", ...)`) on real historian AOs the same way.
+- For mode thrashing, look at **FC4**, not PID-HUNT-1."""
+    ),
+]
+
+nb = {
+    "nbformat": 4,
+    "nbformat_minor": 5,
+    "metadata": {
+        "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+        "language_info": {"name": "python", "pygments_lexer": "ipython3"},
+    },
+    "cells": cells,
+}
+
+path = Path(__file__).resolve().parents[1] / "notebooks" / "01_pid_hunt_tutorial.ipynb"
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(nb, indent=1) + "\n", encoding="utf-8")
+print("wrote", path, "cells", len(cells))

--- a/vibe_code_apps_25/src/vibe25/__init__.py
+++ b/vibe_code_apps_25/src/vibe25/__init__.py
@@ -1,0 +1,3 @@
+"""Vibe 25 — Open-FDD PID-HUNT-1 tutorial helpers."""
+
+__version__ = "0.1.0"

--- a/vibe_code_apps_25/src/vibe25/synth.py
+++ b/vibe_code_apps_25/src/vibe25/synth.py
@@ -1,0 +1,61 @@
+"""Deterministic synthetic control-output series for PID-HUNT-1 tutorials."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+POLL_SECONDS = 60.0
+COLUMN = "cooling-valve"
+
+
+def _index(hours: float = 3.0, *, start: str = "2024-07-15 08:00:00") -> pd.DatetimeIndex:
+    periods = int(hours * 3600 / POLL_SECONDS)
+    return pd.date_range(start, periods=periods, freq=f"{int(POLL_SECONDS)}s")
+
+
+def healthy_cooling_valve(
+    *,
+    hours: float = 3.0,
+    start_pct: float = 20.0,
+    end_pct: float = 55.0,
+    noise_std: float = 0.15,
+    seed: int = 7,
+) -> pd.DataFrame:
+    """Slow ramp with sub-deadband noise — should NOT trip PID-HUNT-1 defaults."""
+    idx = _index(hours)
+    rng = np.random.default_rng(seed)
+    ramp = np.linspace(start_pct, end_pct, len(idx))
+    noise = rng.normal(0.0, noise_std, len(idx))
+    series = np.clip(ramp + noise, 0.0, 100.0)
+    return pd.DataFrame({COLUMN: series}, index=idx)
+
+
+def hunting_cooling_valve(
+    *,
+    hours: float = 3.0,
+    low_pct: float = 10.0,
+    high_pct: float = 90.0,
+    half_period_samples: int = 5,
+) -> pd.DataFrame:
+    """Square-wave AO chatter — trips default PID-HUNT-1 (TV/span/cycles/reversals)."""
+    idx = _index(hours)
+    t = np.arange(len(idx))
+    period = max(2, int(half_period_samples) * 2)
+    series = np.where((t % period) < half_period_samples, high_pct, low_pct).astype(float)
+    return pd.DataFrame({COLUMN: series}, index=idx)
+
+
+def hunting_sine_cooling_valve(
+    *,
+    hours: float = 3.0,
+    center_pct: float = 50.0,
+    amplitude_pct: float = 40.0,
+    period_samples: int = 6,
+) -> pd.DataFrame:
+    """High-amplitude sine AO — also trips defaults; useful for continuous-travel viz."""
+    idx = _index(hours)
+    t = np.arange(len(idx), dtype=float)
+    series = center_pct + amplitude_pct * np.sin(2.0 * np.pi * t / max(period_samples, 2))
+    series = np.clip(series, 0.0, 100.0)
+    return pd.DataFrame({COLUMN: series}, index=idx)

--- a/vibe_code_apps_25/tests/test_synth_and_detector.py
+++ b/vibe_code_apps_25/tests/test_synth_and_detector.py
@@ -1,0 +1,30 @@
+"""Synthetic series vs Open-FDD hunting_fault_mask."""
+
+from open_fdd.rules.pid_hunting import PidHuntingParams, hunting_fault_mask
+
+from vibe25.synth import COLUMN, POLL_SECONDS, healthy_cooling_valve, hunting_cooling_valve
+
+
+def test_hunting_trips_default_pid_hunt_1():
+    df = hunting_cooling_valve()
+    fault, metrics = hunting_fault_mask(
+        df[COLUMN],
+        params=PidHuntingParams(),
+        poll_seconds=POLL_SECONDS,
+    )
+    assert bool(fault.any())
+    assert float(metrics.loc[fault, "total_variation_1h"].max()) >= 500.0
+    assert float(metrics.loc[fault, "output_span_1h"].max()) >= 20.0
+    assert float(metrics.loc[fault, "equivalent_cycles_1h"].max()) >= 2.5
+    assert float(metrics.loc[fault, "reversals_1h"].max()) >= 4.0
+
+
+def test_healthy_does_not_trip_default_pid_hunt_1():
+    df = healthy_cooling_valve()
+    fault, metrics = hunting_fault_mask(
+        df[COLUMN],
+        params=PidHuntingParams(),
+        poll_seconds=POLL_SECONDS,
+    )
+    assert not bool(fault.any())
+    assert float(metrics["total_variation_1h"].fillna(0).max()) < 500.0


### PR DESCRIPTION
## Summary
- New `vibe_code_apps_25`: PyPI `open-fdd[oracle]` PID-HUNT-1 tutorial with deterministic healthy vs hunting AO synth, math cells, AND-gate / TV-vs-span viz
- Root README lists vibe **24** (live twin) and **25**; CI workflow `vibe25-ci`
- Widen gitignore so `vibe_code_apps_23/campaigns/` (including studio fixture E+ dumps) is not trackable

## Test plan
- [x] `cd vibe_code_apps_25; pip install -e '.[dev]'; pytest; ruff`
- [x] `jupyter nbconvert --execute notebooks/01_pid_hunt_tutorial.ipynb`
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Vibe 25 Open-FDD PID-hunting tutorial with synthetic healthy and fault-condition cooling-valve data.
  * Added a Jupyter notebook demonstrating PID-HUNT-1 detection, metrics, visualizations, and healthy-behavior comparisons.
  * Added reusable generators for healthy, square-wave, and sine-wave control-output series.

* **Documentation**
  * Added setup, usage, project structure, and detector-threshold guidance.
  * Updated the main README with Live BACnet/physics twin and Open-FDD PID-hunting projects.

* **Chores**
  * Added automated testing, linting, and package validation for the new project.
  * Broadened campaign-data ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->